### PR TITLE
Migrate to actions/create-github-app-token

### DIFF
--- a/.github/workflows/update-completed-sprint-on-issue-closed.yml
+++ b/.github/workflows/update-completed-sprint-on-issue-closed.yml
@@ -14,8 +14,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_ID }}
-          private_key: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_PEM }}
+          app-id: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_ID }}
+          private-key: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_PEM }}
       - name: Update CompletedSprint on Issue Closed
         id: update_completedsprint_on_issue_closed
         uses: stellar/actions/update-completed-sprint-on-issue-closed@main

--- a/.github/workflows/update-completed-sprint-on-issue-closed.yml
+++ b/.github/workflows/update-completed-sprint-on-issue-closed.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_ID }}
           private_key: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_PEM }}


### PR DESCRIPTION
### What
Replace `tibdex/github-app-token@v1` with `actions/create-github-app-token@v1` in the CompletedSprint workflow.

### Why
The tibdex action is archived and its README directs users to migrate to the official GitHub action.

Close stellar/actions#93