### PR TITLE
Fix XDR stream DoS via memory exhaustion and decouple hash validation from Close

### DIFF
--- a/ingest/checkpoint_change_reader_test.go
+++ b/ingest/checkpoint_change_reader_test.go
@@ -718,10 +718,6 @@ func (s *ReadBucketEntryTestSuite) TestNewXDRStream() {
 	emptyHash := historyarchive.EmptyXdrArrayHash()
 	expectedStream := createXdrStream(metaEntry(1), metaEntry(2))
 
-	hash, ok := expectedStream.ExpectedHash()
-	s.Require().NotEqual(historyarchive.Hash(hash), emptyHash)
-	s.Require().False(ok)
-
 	s.mockArchive.
 		On("GetXdrStreamForHash", emptyHash).
 		Return(expectedStream, nil).Once()
@@ -729,10 +725,6 @@ func (s *ReadBucketEntryTestSuite) TestNewXDRStream() {
 	stream, err := s.reader.newXDRStream(emptyHash)
 	s.Require().NoError(err)
 	s.Require().True(stream == expectedStream)
-
-	hash, ok = stream.ExpectedHash()
-	s.Require().Equal(historyarchive.Hash(hash), emptyHash)
-	s.Require().True(ok)
 }
 
 func (s *ReadBucketEntryTestSuite) TestReadAllEntries() {
@@ -837,10 +829,6 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetryIgnoresProtocolCloseError()
 	s.Require().NoError(err)
 	s.Require().Equal(entry, expectedEntry)
 
-	hash, ok := stream.ExpectedHash()
-	s.Require().Equal(historyarchive.Hash(hash), emptyHash)
-	s.Require().True(ok)
-
 	err = s.reader.readBucketRecord(stream, emptyHash, &entry)
 	s.Require().Equal(err, io.EOF)
 }
@@ -919,10 +907,6 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceeds() {
 	s.Require().NoError(err)
 	s.Require().Equal(entry, expectedEntry)
 
-	hash, ok := stream.ExpectedHash()
-	s.Require().Equal(historyarchive.Hash(hash), emptyHash)
-	s.Require().True(ok)
-
 	err = s.reader.readBucketRecord(stream, emptyHash, &entry)
 	s.Require().Equal(err, io.EOF)
 }
@@ -956,10 +940,6 @@ func (s *ReadBucketEntryTestSuite) TestReadEntryRetrySucceedsWithDiscard() {
 	err = s.reader.readBucketRecord(stream, emptyHash, &entry)
 	s.Require().NoError(err)
 	s.Require().Equal(entry, secondEntry)
-
-	hash, ok := stream.ExpectedHash()
-	s.Require().Equal(historyarchive.Hash(hash), emptyHash)
-	s.Require().True(ok)
 
 	err = s.reader.readBucketRecord(stream, emptyHash, &entry)
 	s.Require().Equal(err, io.EOF)

--- a/xdr/xdrstream.go
+++ b/xdr/xdrstream.go
@@ -10,6 +10,7 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/binary"
+	stderrors "errors"
 	"fmt"
 	"hash"
 	"io"
@@ -20,15 +21,17 @@ import (
 	"github.com/stellar/go-stellar-sdk/support/errors"
 )
 
+const DefaultMaxXDRStreamRecordSize = 64 * 1024 * 1024 // 64 MB
+
+var ErrRecordTooLarge = stderrors.New("xdr record too large")
+
 type Stream struct {
 	buf              bytes.Buffer
 	compressedReader *countReader
 	reader           *countReader
 	sha256Hash       hash.Hash
-
-	validateHash bool
-	expectedHash [sha256.Size]byte
-	xdrDecoder   *BytesDecoder
+	maxRecordSize    uint32
+	xdrDecoder       *BytesDecoder
 }
 
 type countReader struct {
@@ -50,7 +53,7 @@ func newCountReader(r io.ReadCloser) *countReader {
 
 func NewStream(in io.ReadCloser) *Stream {
 	// We write all we read from in to sha256Hash that can be later
-	// compared with `expectedHash` using SetExpectedHash and Close.
+	// used with ValidateHash to verify stream integrity.
 	sha256Hash := sha256.New()
 	teeReader := io.TeeReader(in, sha256Hash)
 	return &Stream{
@@ -60,8 +63,9 @@ func NewStream(in io.ReadCloser) *Stream {
 				io.Closer
 			}{bufio.NewReader(teeReader), in},
 		),
-		sha256Hash: sha256Hash,
-		xdrDecoder: NewBytesDecoder(),
+		sha256Hash:    sha256Hash,
+		maxRecordSize: DefaultMaxXDRStreamRecordSize,
+		xdrDecoder:    NewBytesDecoder(),
 	}
 }
 
@@ -110,40 +114,34 @@ func HashXdr(x interface{}) (Hash, error) {
 	return sha256.Sum256(msg.Bytes()), nil
 }
 
-// SetExpectedHash sets expected hash that will be checked in Close().
-// This (obviously) needs to be set before Close() is called.
-func (x *Stream) SetExpectedHash(hash [sha256.Size]byte) {
-	x.validateHash = true
-	x.expectedHash = hash
-}
-
-// ExpectedHash returns the expected hash and a boolean indicating if the
-// expected hash was set
-func (x *Stream) ExpectedHash() ([sha256.Size]byte, bool) {
-	return x.expectedHash, x.validateHash
-}
-
-// Close closes all internal readers and checks if the expected hash
-// (if set by SetExpectedHash) matches the actual hash of the stream.
-func (x *Stream) Close() error {
-	if x.validateHash {
-		// Read all remaining data from reader
-		_, err := io.Copy(io.Discard, x.reader)
-		if err != nil {
-			// close the internal readers to avoid memory leaks
-			x.closeReaders()
-			return errors.Wrap(err, "Error reading remaining bytes from reader")
-		}
-
-		actualHash := x.sha256Hash.Sum([]byte{})
-
-		if !bytes.Equal(x.expectedHash[:], actualHash[:]) {
-			// close the internal readers to avoid memory leaks
-			x.closeReaders()
-			return errors.New("Stream hash does not match expected hash!")
-		}
+// SetMaxRecordSize sets the maximum allowed size for a single XDR record.
+// If size is 0, the default (DefaultMaxXDRStreamRecordSize) is used.
+func (x *Stream) SetMaxRecordSize(size uint32) {
+	if size == 0 {
+		x.maxRecordSize = DefaultMaxXDRStreamRecordSize
+	} else {
+		x.maxRecordSize = size
 	}
+}
 
+// ValidateHash drains any remaining bytes from the stream, then checks that the
+// stream's SHA-256 hash matches the given expected hash. Must be called before Close().
+// Call after reading all records to verify stream integrity.
+func (x *Stream) ValidateHash(expected [sha256.Size]byte) error {
+	// Drain remaining bytes so the hash covers the entire stream.
+	// After a full read (ReadOne returned EOF), this is near-zero bytes.
+	if _, err := io.Copy(io.Discard, x.reader); err != nil {
+		return fmt.Errorf("reading remaining stream bytes for hash validation: %w", err)
+	}
+	actualHash := x.sha256Hash.Sum(nil)
+	if !bytes.Equal(expected[:], actualHash) {
+		return fmt.Errorf("stream hash mismatch: expected %x, got %x", expected, actualHash)
+	}
+	return nil
+}
+
+// Close closes all internal readers and releases resources.
+func (x *Stream) Close() error {
 	return x.closeReaders()
 }
 
@@ -181,6 +179,10 @@ func (x *Stream) ReadOne(in DecoderFrom) error {
 	if nbytes == 0 {
 		x.reader.Close()
 		return io.EOF
+	}
+	if nbytes > x.maxRecordSize {
+		x.reader.Close()
+		return fmt.Errorf("%w: %d bytes (max %d)", ErrRecordTooLarge, nbytes, x.maxRecordSize)
 	}
 	x.buf.Grow(int(nbytes))
 	read, err := x.buf.ReadFrom(io.LimitReader(x.reader, int64(nbytes)))

--- a/xdr/xdrstream.go
+++ b/xdr/xdrstream.go
@@ -134,8 +134,12 @@ func (x *Stream) SetMaxRecordSize(size uint32) {
 }
 
 // ValidateHash drains any remaining bytes from the stream, then checks that the
-// stream's SHA-256 hash matches the given expected hash. Must be called before Close().
-// Call after reading all records to verify stream integrity.
+// stream's SHA-256 hash matches the given expected hash.
+//
+// It must be called after reading all records, and before Close(), to ensure that the
+// hash covers the complete stream. If called after Close(), the underlying reader will
+// already be closed and the internal io.Copy used to drain remaining bytes will fail
+// with an error from the closed reader rather than successfully validating the hash.
 func (x *Stream) ValidateHash(expected [sha256.Size]byte) error {
 	// Drain remaining bytes so the hash covers the entire stream.
 	// After a full read (ReadOne returned EOF), this is near-zero bytes.

--- a/xdr/xdrstream.go
+++ b/xdr/xdrstream.go
@@ -115,7 +115,16 @@ func HashXdr(x interface{}) (Hash, error) {
 }
 
 // SetMaxRecordSize sets the maximum allowed size for a single XDR record.
+//
+// This method may be called before reading begins or between calls to
+// ReadOne. The new limit only applies to records read after the call; it
+// does not retroactively affect or re-validate records that have already
+// been read from the stream.
+//
 // If size is 0, the default (DefaultMaxXDRStreamRecordSize) is used.
+// This method is not safe for concurrent use with other operations on the
+// same Stream; if a Stream is accessed from multiple goroutines, configure
+// the maximum record size once before starting to read.
 func (x *Stream) SetMaxRecordSize(size uint32) {
 	if size == 0 {
 		x.maxRecordSize = DefaultMaxXDRStreamRecordSize

--- a/xdr/xdrstream_test.go
+++ b/xdr/xdrstream_test.go
@@ -143,6 +143,52 @@ func TestValidateHashMismatch(t *testing.T) {
 	assert.Contains(t, err.Error(), "stream hash mismatch")
 }
 
+// closedReader is a ReadCloser that returns an error on Read after Close.
+type closedReader struct {
+	*bytes.Reader
+	closed bool
+}
+
+func (c *closedReader) Read(p []byte) (int, error) {
+	if c.closed {
+		return 0, errors.New("read after close")
+	}
+	return c.Reader.Read(p)
+}
+
+func (c *closedReader) Close() error {
+	c.closed = true
+	return nil
+}
+
+func TestValidateHashAfterClose(t *testing.T) {
+	bucketEntry := BucketEntry{
+		Type: BucketEntryTypeLiveentry,
+		LiveEntry: &LedgerEntry{
+			Data: LedgerEntryData{
+				Type: LedgerEntryTypeAccount,
+				Account: &AccountEntry{
+					AccountId: MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+					Balance:   Int64(200000000),
+				},
+			},
+		},
+	}
+
+	b := &bytes.Buffer{}
+	require.NoError(t, MarshalFramed(b, bucketEntry))
+	expectedHash := sha256.Sum256(b.Bytes())
+
+	stream := NewStream(&closedReader{Reader: bytes.NewReader(b.Bytes())})
+	var readBucketEntry BucketEntry
+	require.NoError(t, stream.ReadOne(&readBucketEntry))
+
+	// Close first, then try ValidateHash — should fail because reader is closed.
+	require.NoError(t, stream.Close())
+	err := stream.ValidateHash(expectedHash)
+	require.Error(t, err)
+}
+
 func TestValidateHashDrainsUnreadBytes(t *testing.T) {
 	firstEntry := BucketEntry{
 		Type: BucketEntryTypeLiveentry,

--- a/xdr/xdrstream_test.go
+++ b/xdr/xdrstream_test.go
@@ -7,6 +7,8 @@ package xdr
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
+	"errors"
 	"io"
 	"testing"
 
@@ -37,7 +39,6 @@ func TestXdrStreamHash(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedHash := sha256.Sum256(b.Bytes())
-	stream.SetExpectedHash(expectedHash)
 
 	var readBucketEntry BucketEntry
 	err = stream.ReadOne(&readBucketEntry)
@@ -49,6 +50,7 @@ func TestXdrStreamHash(t *testing.T) {
 	assert.Equal(t, io.EOF, stream.ReadOne(&readBucketEntry))
 	assert.Equal(t, int(stream.BytesRead()), b.Len())
 
+	assert.NoError(t, stream.ValidateHash(expectedHash))
 	assert.NoError(t, stream.Close())
 }
 
@@ -83,10 +85,8 @@ func TestXdrStreamDiscard(t *testing.T) {
 	require.NoError(t, MarshalFramed(b, firstEntry))
 	require.NoError(t, MarshalFramed(b, secondEntry))
 	expectedHash := sha256.Sum256(b.Bytes())
-	fullStream.SetExpectedHash(expectedHash)
 
 	discardStream := CreateXdrStream(firstEntry, secondEntry)
-	discardStream.SetExpectedHash(expectedHash)
 
 	var readBucketEntry BucketEntry
 	require.NoError(t, fullStream.ReadOne(&readBucketEntry))
@@ -112,6 +112,135 @@ func TestXdrStreamDiscard(t *testing.T) {
 	assert.Equal(t, int(fullStream.BytesRead()), b.Len())
 	assert.Equal(t, fullStream.BytesRead(), discardStream.BytesRead())
 
+	assert.NoError(t, discardStream.ValidateHash(expectedHash))
 	assert.NoError(t, discardStream.Close())
+	assert.NoError(t, fullStream.ValidateHash(expectedHash))
 	assert.NoError(t, fullStream.Close())
+}
+
+func TestValidateHashMismatch(t *testing.T) {
+	bucketEntry := BucketEntry{
+		Type: BucketEntryTypeLiveentry,
+		LiveEntry: &LedgerEntry{
+			Data: LedgerEntryData{
+				Type: LedgerEntryTypeAccount,
+				Account: &AccountEntry{
+					AccountId: MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+					Balance:   Int64(200000000),
+				},
+			},
+		},
+	}
+	stream := CreateXdrStream(bucketEntry)
+
+	var readBucketEntry BucketEntry
+	require.NoError(t, stream.ReadOne(&readBucketEntry))
+	assert.Equal(t, io.EOF, stream.ReadOne(&readBucketEntry))
+
+	var wrongHash [32]byte // zero hash, won't match
+	err := stream.ValidateHash(wrongHash)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stream hash mismatch")
+}
+
+func TestValidateHashDrainsUnreadBytes(t *testing.T) {
+	firstEntry := BucketEntry{
+		Type: BucketEntryTypeLiveentry,
+		LiveEntry: &LedgerEntry{
+			Data: LedgerEntryData{
+				Type: LedgerEntryTypeAccount,
+				Account: &AccountEntry{
+					AccountId: MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+					Balance:   Int64(200000000),
+				},
+			},
+		},
+	}
+	secondEntry := BucketEntry{
+		Type: BucketEntryTypeLiveentry,
+		LiveEntry: &LedgerEntry{
+			Data: LedgerEntryData{
+				Type: LedgerEntryTypeAccount,
+				Account: &AccountEntry{
+					AccountId: MustAddress("GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"),
+					Balance:   Int64(100000000),
+				},
+			},
+		},
+	}
+
+	// Compute expected hash over the full stream (both entries).
+	b := &bytes.Buffer{}
+	require.NoError(t, MarshalFramed(b, firstEntry))
+	require.NoError(t, MarshalFramed(b, secondEntry))
+	expectedHash := sha256.Sum256(b.Bytes())
+
+	// Only read the first entry, leaving the second unread.
+	stream := CreateXdrStream(firstEntry, secondEntry)
+	var readBucketEntry BucketEntry
+	require.NoError(t, stream.ReadOne(&readBucketEntry))
+	assert.Equal(t, firstEntry, readBucketEntry)
+
+	// ValidateHash should drain the remaining bytes and still match.
+	assert.NoError(t, stream.ValidateHash(expectedHash))
+	assert.NoError(t, stream.Close())
+}
+
+func TestReadOneRecordTooLarge(t *testing.T) {
+	// Write a 4-byte header claiming 256 MB, with no actual payload.
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], 256*1024*1024)
+	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
+
+	var entry BucketEntry
+	err := stream.ReadOne(&entry)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRecordTooLarge))
+}
+
+func TestReadOneCustomMaxRecordSize(t *testing.T) {
+	// Write a 4-byte header claiming 2048 bytes.
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], 2048)
+	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
+	stream.SetMaxRecordSize(1024)
+
+	var entry BucketEntry
+	err := stream.ReadOne(&entry)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRecordTooLarge))
+}
+
+func TestReadOneMaxBoundary(t *testing.T) {
+	// Header at exactly DefaultMaxXDRStreamRecordSize + 1 -> rejected.
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], DefaultMaxXDRStreamRecordSize+1)
+	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
+
+	var entry BucketEntry
+	err := stream.ReadOne(&entry)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRecordTooLarge))
+
+	// Header at exactly DefaultMaxXDRStreamRecordSize -> accepted (will fail reading data, not size check).
+	binary.BigEndian.PutUint32(header[:], DefaultMaxXDRStreamRecordSize)
+	stream = NewStream(io.NopCloser(bytes.NewReader(header[:])))
+
+	err = stream.ReadOne(&entry)
+	require.Error(t, err)
+	// Should NOT be ErrRecordTooLarge — the size is accepted, but reading the payload fails.
+	assert.False(t, errors.Is(err, ErrRecordTooLarge))
+}
+
+func TestSetMaxRecordSizeZero(t *testing.T) {
+	// SetMaxRecordSize(0) should use the default.
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], DefaultMaxXDRStreamRecordSize+1)
+	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
+	stream.SetMaxRecordSize(0) // should reset to default
+
+	var entry BucketEntry
+	err := stream.ReadOne(&entry)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRecordTooLarge))
 }


### PR DESCRIPTION

Add a record size limit (default 64MB) to ReadOne to prevent an attacker from triggering massive allocations with a small 4-byte header claiming up to 2GB. Replace SetExpectedHash/Close hash validation with an explicit ValidateHash method so Close only releases resources and early close never triggers unnecessary stream draining.

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go-stellar-sdk/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

                                                                                                                                           
  - Fix DoS via memory exhaustion: ReadOne now validates the 4-byte length prefix against a configurable max (default 64MB) before calling Grow, preventing an attacker from triggering up to 2GB
  allocations with just 4 bytes of input
  - Decouple hash validation from Close: Replace SetExpectedHash/Close pattern with explicit ValidateHash(hash) method so Close only releases resources — early close via defer no longer drains the entire
   decompressed stream
  - Callers updated: streamBucket now calls ValidateHash after the read loop completes, before closing the stream