### PR TITLE
Fix negative amount encoding in NewPaymentToContract

### DIFF
--- a/txnbuild/invoke_host_function.go
+++ b/txnbuild/invoke_host_function.go
@@ -80,7 +80,7 @@ func NewPaymentToContract(params PaymentToContractParams) (InvokeHostFunction, e
 		return InvokeHostFunction{}, err
 	}
 	if parsedAmount < 0 {
-		return InvokeHostFunction{}, errors.New("amount must be positive")
+		return InvokeHostFunction{}, errors.New("amount can not be negative")
 	}
 
 	transferArgs := xdr.ScVec{

--- a/txnbuild/invoke_host_function.go
+++ b/txnbuild/invoke_host_function.go
@@ -79,6 +79,9 @@ func NewPaymentToContract(params PaymentToContractParams) (InvokeHostFunction, e
 	if err != nil {
 		return InvokeHostFunction{}, err
 	}
+	if parsedAmount < 0 {
+		return InvokeHostFunction{}, errors.New("amount must be positive")
+	}
 
 	transferArgs := xdr.ScVec{
 		xdr.ScVal{

--- a/txnbuild/invoke_host_function_test.go
+++ b/txnbuild/invoke_host_function_test.go
@@ -57,6 +57,10 @@ func TestPaymentToContract(t *testing.T) {
 	require.Equal(t, uint32(op.Ext.SorobanData.Resources.WriteBytes), uint32(3))
 	require.Equal(t, uint32(op.Ext.SorobanData.Resources.DiskReadBytes), uint32(2))
 	require.Equal(t, uint32(op.Ext.SorobanData.Resources.Instructions), uint32(1))
+
+	params.Amount = "-1"
+	op, err = NewPaymentToContract(params)
+	require.EqualError(t, err, "amount must be positive")
 }
 
 func TestCreateInvokeHostFunctionValid(t *testing.T) {

--- a/txnbuild/invoke_host_function_test.go
+++ b/txnbuild/invoke_host_function_test.go
@@ -60,7 +60,7 @@ func TestPaymentToContract(t *testing.T) {
 
 	params.Amount = "-1"
 	op, err = NewPaymentToContract(params)
-	require.EqualError(t, err, "amount must be positive")
+	require.EqualError(t, err, "amount can not be negative")
 }
 
 func TestCreateInvokeHostFunctionValid(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go-stellar-sdk/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add explicit validation to ensure the parsed amount is non-negative before encoding it into the i128 transfer argument.

### Why

Previously, negative amounts were cast to uint64 when constructing the i128 value, causing them to wrap into very large positive numbers.  While SAC reject this, other contracts that accept i128 values could process the large positive amount.
 
### Known limitations
N/A