### PR TITLE
Fix InputLen() guard bypass in streaming XDR decoders

### DIFF
--- a/ingest/ledgerbackend/buffered_meta_pipe_reader_test.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader_test.go
@@ -39,7 +39,7 @@ func TestReadLedgerMetaFromPipe(t *testing.T) {
 func TestReadLedgerMetaFromPipeFrameTooLarge(t *testing.T) {
 	var buf bytes.Buffer
 	// Write a frame header with length exceeding maxLedgerMetaFrameSize.
-	// Frame header has the high bit set (0x80000000) plus a large length.
+	// The high bit marks the last fragment per RFC 5531 record marking.
 	frameHeader := uint32(0x80000000) | (maxLedgerMetaFrameSize + 1)
 	require.NoError(t, binary.Write(&buf, binary.BigEndian, frameHeader))
 

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader_test.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader_test.go
@@ -1,0 +1,69 @@
+package ledgerbackend
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+func createTestLedgerCloseMeta(seq uint32) xdr.LedgerCloseMeta {
+	return xdr.LedgerCloseMeta{
+		V: int32(0),
+		V0: &xdr.LedgerCloseMetaV0{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					LedgerSeq: xdr.Uint32(seq),
+				},
+			},
+		},
+	}
+}
+
+func TestReadLedgerMetaFromPipe(t *testing.T) {
+	lcm := createTestLedgerCloseMeta(1234)
+
+	var buf bytes.Buffer
+	require.NoError(t, xdr.MarshalFramed(&buf, lcm))
+
+	reader := newBufferedLedgerMetaReader(&buf)
+	result, err := reader.readLedgerMetaFromPipe()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1234), uint32(result.LedgerHeaderHistoryEntry().Header.LedgerSeq))
+}
+
+func TestReadLedgerMetaFromPipeFrameTooLarge(t *testing.T) {
+	var buf bytes.Buffer
+	// Write a frame header with length exceeding maxLedgerMetaFrameSize.
+	// Frame header has the high bit set (0x80000000) plus a large length.
+	frameHeader := uint32(0x80000000) | (maxLedgerMetaFrameSize + 1)
+	require.NoError(t, binary.Write(&buf, binary.BigEndian, frameHeader))
+
+	reader := newBufferedLedgerMetaReader(&buf)
+	_, err := reader.readLedgerMetaFromPipe()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "frame too large")
+}
+
+func TestReadLedgerMetaFromPipeMultipleFrames(t *testing.T) {
+	lcm1 := createTestLedgerCloseMeta(100)
+	lcm2 := createTestLedgerCloseMeta(200)
+
+	var buf bytes.Buffer
+	require.NoError(t, xdr.MarshalFramed(&buf, lcm1))
+	require.NoError(t, xdr.MarshalFramed(&buf, lcm2))
+
+	reader := newBufferedLedgerMetaReader(&buf)
+
+	result1, err := reader.readLedgerMetaFromPipe()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(100), uint32(result1.LedgerHeaderHistoryEntry().Header.LedgerSeq))
+
+	result2, err := reader.readLedgerMetaFromPipe()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(200), uint32(result2.LedgerHeaderHistoryEntry().Header.LedgerSeq))
+}

--- a/support/compressxdr/compress_xdr.go
+++ b/support/compressxdr/compress_xdr.go
@@ -47,6 +47,13 @@ func (d XDRDecoder) ReadFrom(r io.Reader) (int64, error) {
 	}
 	defer zr.Close()
 
-	n, err := xdr.Unmarshal(zr, d.XdrPayload)
-	return int64(n), err
+	data, err := io.ReadAll(zr)
+	if err != nil {
+		return 0, err
+	}
+
+	if err = xdr.SafeUnmarshal(data, d.XdrPayload); err != nil {
+		return 0, err
+	}
+	return int64(len(data)), nil
 }

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -8,13 +8,12 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 
 	xdr "github.com/stellar/go-xdr/xdr3"
-
-	"github.com/stellar/go-stellar-sdk/support/errors"
 )
 
 // CommitHash is the commit hash that was used to generate the xdr in this folder.
@@ -284,7 +283,7 @@ func MarshalFramed(w io.Writer, v interface{}) error {
 	un = un | 0x80000000
 	err = binary.Write(w, binary.BigEndian, &un)
 	if err != nil {
-		return errors.Wrap(err, "error in binary.Write")
+		return fmt.Errorf("error in binary.Write: %w", err)
 	}
 	k, err := tmp.WriteTo(w)
 	if int64(n) != k {
@@ -293,20 +292,20 @@ func MarshalFramed(w io.Writer, v interface{}) error {
 	return err
 }
 
-// ReadFrameLength returns a length of a framed XDR object.
-func ReadFrameLength(d *xdr.Decoder) (uint32, error) {
-	frameLen, n, e := d.DecodeUint()
-	if e != nil {
-		return 0, errors.Wrap(e, "unmarshaling XDR frame header")
+// ReadFrameLength reads and returns the payload length from a framed XDR
+// stream.
+func ReadFrameLength(r io.Reader) (uint32, error) {
+	var frameHeader uint32
+	if err := binary.Read(r, binary.BigEndian, &frameHeader); err != nil {
+		if errors.Is(err, io.EOF) {
+			return 0, io.EOF
+		}
+		return 0, fmt.Errorf("reading XDR frame header: %w", err)
 	}
-	if n != 4 {
-		return 0, errors.New("bad length of XDR frame header")
-	}
-	if (frameLen & 0x80000000) != 0x80000000 {
+	if (frameHeader & 0x80000000) != 0x80000000 {
 		return 0, errors.New("malformed XDR frame header")
 	}
-	frameLen &= 0x7fffffff
-	return frameLen, nil
+	return frameHeader & 0x7fffffff, nil
 }
 
 type countWriter struct {

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -269,6 +269,15 @@ func (e *EncodingBuffer) MarshalHex(encodable EncoderTo) (string, error) {
 	return string(b), nil
 }
 
+// XDR record marking constants from RFC 5531 (section 11).
+// Each record fragment is preceded by a 4-byte header: the high bit
+// indicates the last (or only) fragment, and the lower 31 bits
+// contain the fragment length in bytes.
+const (
+	xdrFrameLastFragment = 0x80000000
+	xdrFrameLengthMask   = 0x7fffffff
+)
+
 func MarshalFramed(w io.Writer, v interface{}) error {
 	var tmp bytes.Buffer
 	n, err := Marshal(&tmp, v)
@@ -276,11 +285,11 @@ func MarshalFramed(w io.Writer, v interface{}) error {
 		return err
 	}
 	un := uint32(n)
-	if un > 0x7fffffff {
+	if un > xdrFrameLengthMask {
 		return fmt.Errorf("Overlong write: %d bytes", n)
 	}
 
-	un = un | 0x80000000
+	un = un | xdrFrameLastFragment
 	err = binary.Write(w, binary.BigEndian, &un)
 	if err != nil {
 		return fmt.Errorf("error in binary.Write: %w", err)
@@ -302,10 +311,10 @@ func ReadFrameLength(r io.Reader) (uint32, error) {
 		}
 		return 0, fmt.Errorf("reading XDR frame header: %w", err)
 	}
-	if (frameHeader & 0x80000000) != 0x80000000 {
+	if (frameHeader & xdrFrameLastFragment) != xdrFrameLastFragment {
 		return 0, errors.New("malformed XDR frame header")
 	}
-	return frameHeader & 0x7fffffff, nil
+	return frameHeader & xdrFrameLengthMask, nil
 }
 
 type countWriter struct {

--- a/xdr/xdrstream_test.go
+++ b/xdr/xdrstream_test.go
@@ -235,7 +235,7 @@ func TestValidateHashDrainsUnreadBytes(t *testing.T) {
 func TestReadOneRecordTooLarge(t *testing.T) {
 	// Write a 4-byte header claiming 256 MB, with no actual payload.
 	var header [4]byte
-	binary.BigEndian.PutUint32(header[:], 256*1024*1024)
+	binary.BigEndian.PutUint32(header[:], 256*1024*1024|0x80000000)
 	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
 
 	var entry BucketEntry
@@ -247,7 +247,7 @@ func TestReadOneRecordTooLarge(t *testing.T) {
 func TestReadOneCustomMaxRecordSize(t *testing.T) {
 	// Write a 4-byte header claiming 2048 bytes.
 	var header [4]byte
-	binary.BigEndian.PutUint32(header[:], 2048)
+	binary.BigEndian.PutUint32(header[:], 2048|0x80000000)
 	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
 	stream.SetMaxRecordSize(1024)
 
@@ -260,7 +260,7 @@ func TestReadOneCustomMaxRecordSize(t *testing.T) {
 func TestReadOneMaxBoundary(t *testing.T) {
 	// Header at exactly DefaultMaxXDRStreamRecordSize + 1 -> rejected.
 	var header [4]byte
-	binary.BigEndian.PutUint32(header[:], DefaultMaxXDRStreamRecordSize+1)
+	binary.BigEndian.PutUint32(header[:], (DefaultMaxXDRStreamRecordSize+1)|0x80000000)
 	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
 
 	var entry BucketEntry
@@ -269,7 +269,7 @@ func TestReadOneMaxBoundary(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrRecordTooLarge))
 
 	// Header at exactly DefaultMaxXDRStreamRecordSize -> accepted (will fail reading data, not size check).
-	binary.BigEndian.PutUint32(header[:], DefaultMaxXDRStreamRecordSize)
+	binary.BigEndian.PutUint32(header[:], DefaultMaxXDRStreamRecordSize|0x80000000)
 	stream = NewStream(io.NopCloser(bytes.NewReader(header[:])))
 
 	err = stream.ReadOne(&entry)
@@ -281,7 +281,7 @@ func TestReadOneMaxBoundary(t *testing.T) {
 func TestSetMaxRecordSizeZero(t *testing.T) {
 	// SetMaxRecordSize(0) should use the default.
 	var header [4]byte
-	binary.BigEndian.PutUint32(header[:], DefaultMaxXDRStreamRecordSize+1)
+	binary.BigEndian.PutUint32(header[:], (DefaultMaxXDRStreamRecordSize+1)|0x80000000)
 	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
 	stream.SetMaxRecordSize(0) // should reset to default
 

--- a/xdr/xdrstream_test.go
+++ b/xdr/xdrstream_test.go
@@ -235,7 +235,7 @@ func TestValidateHashDrainsUnreadBytes(t *testing.T) {
 func TestReadOneRecordTooLarge(t *testing.T) {
 	// Write a 4-byte header claiming 256 MB, with no actual payload.
 	var header [4]byte
-	binary.BigEndian.PutUint32(header[:], 256*1024*1024|0x80000000)
+	binary.BigEndian.PutUint32(header[:], 256*1024*1024|xdrFrameLastFragment)
 	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
 
 	var entry BucketEntry
@@ -247,7 +247,7 @@ func TestReadOneRecordTooLarge(t *testing.T) {
 func TestReadOneCustomMaxRecordSize(t *testing.T) {
 	// Write a 4-byte header claiming 2048 bytes.
 	var header [4]byte
-	binary.BigEndian.PutUint32(header[:], 2048|0x80000000)
+	binary.BigEndian.PutUint32(header[:], 2048|xdrFrameLastFragment)
 	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
 	stream.SetMaxRecordSize(1024)
 
@@ -260,7 +260,7 @@ func TestReadOneCustomMaxRecordSize(t *testing.T) {
 func TestReadOneMaxBoundary(t *testing.T) {
 	// Header at exactly DefaultMaxXDRStreamRecordSize + 1 -> rejected.
 	var header [4]byte
-	binary.BigEndian.PutUint32(header[:], (DefaultMaxXDRStreamRecordSize+1)|0x80000000)
+	binary.BigEndian.PutUint32(header[:], (DefaultMaxXDRStreamRecordSize+1)|xdrFrameLastFragment)
 	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
 
 	var entry BucketEntry
@@ -269,7 +269,7 @@ func TestReadOneMaxBoundary(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrRecordTooLarge))
 
 	// Header at exactly DefaultMaxXDRStreamRecordSize -> accepted (will fail reading data, not size check).
-	binary.BigEndian.PutUint32(header[:], DefaultMaxXDRStreamRecordSize|0x80000000)
+	binary.BigEndian.PutUint32(header[:], DefaultMaxXDRStreamRecordSize|xdrFrameLastFragment)
 	stream = NewStream(io.NopCloser(bytes.NewReader(header[:])))
 
 	err = stream.ReadOne(&entry)
@@ -281,7 +281,7 @@ func TestReadOneMaxBoundary(t *testing.T) {
 func TestSetMaxRecordSizeZero(t *testing.T) {
 	// SetMaxRecordSize(0) should use the default.
 	var header [4]byte
-	binary.BigEndian.PutUint32(header[:], (DefaultMaxXDRStreamRecordSize+1)|0x80000000)
+	binary.BigEndian.PutUint32(header[:], (DefaultMaxXDRStreamRecordSize+1)|xdrFrameLastFragment)
 	stream := NewStream(io.NopCloser(bytes.NewReader(header[:])))
 	stream.SetMaxRecordSize(0) // should reset to default
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go-stellar-sdk/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

 Every xdr type generated by xdrgen has a DecodeFrom() function which contains a guards like:

```go
  if il, ok := d.InputLen(); ok && uint(il) < uint(l) {
      return n, fmt.Errorf("length (%d) exceeds remaining input length (%d)", l, il)
  }
```

  These fire before every variable-length allocation (slices, strings, opaque data), preventing attacker-controlled length fields from triggering unbounded memory allocations.

  InputLen() delegates to the decoder's internal lenLeft interface:

```go
  type lenLeft interface {
      Len() int
  }
```

  When creating a decoder, go-xdr checks if the reader implements Len():

```go
  func NewDecoder(r io.Reader) *Decoder {
      if l, ok := r.(lenLeft); ok {
          return &Decoder{r: r, l: l, ...}
      }
      return &Decoder{r: r, l: nil, ...}  // InputLen() returns (0, false)
  }
```

  bytes.NewReader implements Len(), so guards are active. Streaming readers like bufio.Reader and zstd readers do not, so l is nil and all guards are silently skipped.

  Problem

  Two production decode paths create decoders wrapping streaming readers:

  1. bufferedLedgerMetaReader — xdr3.NewDecoder(bufio.Reader) over the captive core pipe
  2. compressxdr.XDRDecoder.ReadFrom — xdr.Unmarshal over a zstd streaming reader

  In both cases, InputLen() returns (0, false) which means the allocation checks are bypassed.

These two cases are fixed by using bytes.NewReader. 

### Known limitations

[N/A]
