### PR TITLE
exp/orderbook: reject negative inputs in exp/orderbook/pools.go

### DIFF
--- a/exp/orderbook/pools.go
+++ b/exp/orderbook/pools.go
@@ -93,6 +93,9 @@ func makeTrade(
 //
 // It returns false if the calculation overflows.
 func CalculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int32, calculateRoundingSlippage bool) (xdr.Int64, xdr.Int64, bool) {
+	if reserveA < 0 || reserveB < 0 || received < 0 {
+		return 0, 0, false
+	}
 	if feeBips < 0 || feeBips >= maxBasisPoints {
 		return 0, 0, false
 	}
@@ -171,6 +174,9 @@ func CalculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 func CalculatePoolExpectation(
 	reserveA, reserveB, disbursed xdr.Int64, feeBips xdr.Int32, calculateRoundingSlippage bool,
 ) (xdr.Int64, xdr.Int64, bool) {
+	if reserveA < 0 || reserveB < 0 || disbursed < 0 {
+		return 0, 0, false
+	}
 	if feeBips < 0 || feeBips >= maxBasisPoints {
 		return 0, 0, false
 	}

--- a/exp/orderbook/pools.go
+++ b/exp/orderbook/pools.go
@@ -91,7 +91,7 @@ func makeTrade(
 //
 //	y = floor[(1 - F) Yx / (X + x - Fx)]
 //
-// It returns false if the calculation overflows.
+// It returns false if the calculation overflows or invalid inputs (e.g. negative values).
 func CalculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int32, calculateRoundingSlippage bool) (xdr.Int64, xdr.Int64, bool) {
 	if reserveA < 0 || reserveB < 0 || received < 0 {
 		return 0, 0, false
@@ -170,7 +170,7 @@ func CalculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 //
 //	x = ceil[Xy / ((Y - y)(1 - F))]
 //
-// It returns false if the calculation overflows.
+// It returns false if the calculation overflows or invalid inputs (e.g. negative values).
 func CalculatePoolExpectation(
 	reserveA, reserveB, disbursed xdr.Int64, feeBips xdr.Int32, calculateRoundingSlippage bool,
 ) (xdr.Int64, xdr.Int64, bool) {

--- a/exp/orderbook/pools_test.go
+++ b/exp/orderbook/pools_test.go
@@ -338,6 +338,54 @@ func TestCalculatePoolPayoutRoundingSlippage(t *testing.T) {
 	})
 }
 
+func TestCalculatePoolPayoutNegativeInputs(t *testing.T) {
+	// Negative values must be rejected before the uint64 cast to prevent
+	// wraparound (e.g. int64(-1) becomes uint64(18446744073709551615)).
+	t.Run("negative reserveA", func(t *testing.T) {
+		_, _, ok := CalculatePoolPayout(-1, 1000, 100, 30, false)
+		assert.False(t, ok)
+	})
+	t.Run("negative reserveB", func(t *testing.T) {
+		_, _, ok := CalculatePoolPayout(1000, -1, 100, 30, false)
+		assert.False(t, ok)
+	})
+	t.Run("negative received", func(t *testing.T) {
+		_, _, ok := CalculatePoolPayout(1000, 2000, -100, 30, false)
+		assert.False(t, ok)
+	})
+	t.Run("all negative", func(t *testing.T) {
+		_, _, ok := CalculatePoolPayout(-1000, -2000, -100, 30, false)
+		assert.False(t, ok)
+	})
+	t.Run("MinInt64 reserveB", func(t *testing.T) {
+		_, _, ok := CalculatePoolPayout(1000, math.MinInt64, 100, 30, false)
+		assert.False(t, ok)
+	})
+}
+
+func TestCalculatePoolExpectationNegativeInputs(t *testing.T) {
+	t.Run("negative reserveA", func(t *testing.T) {
+		_, _, ok := CalculatePoolExpectation(-1, 1000, 100, 30, false)
+		assert.False(t, ok)
+	})
+	t.Run("negative reserveB", func(t *testing.T) {
+		_, _, ok := CalculatePoolExpectation(1000, -1, 100, 30, false)
+		assert.False(t, ok)
+	})
+	t.Run("negative disbursed", func(t *testing.T) {
+		_, _, ok := CalculatePoolExpectation(1000, 2000, -100, 30, false)
+		assert.False(t, ok)
+	})
+	t.Run("all negative", func(t *testing.T) {
+		_, _, ok := CalculatePoolExpectation(-1000, -2000, -100, 30, false)
+		assert.False(t, ok)
+	})
+	t.Run("MinInt64 reserveA", func(t *testing.T) {
+		_, _, ok := CalculatePoolExpectation(math.MinInt64, 1000, 100, 30, false)
+		assert.False(t, ok)
+	})
+}
+
 // CalculatePoolPayout calculates the amount of `reserveB` disbursed from the
 // pool for a `received` amount of `reserveA` . From CAP-38:
 //


### PR DESCRIPTION


<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go-stellar-sdk/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Negative xdr.Int64 values wrap to large uint64 values when cast, which would distort liquidity pool payout calculations. Add explicit checks to reject negative reserveA, reserveB, and received/disbursed before the uint64 conversion, consistent with the existing feeBips validation.

### Why

This is just a defense in depth validation because the function can never be called with negative inputs (pool reserves are always >= 0 ) and path finding will always call the functions with valid inputs.


### Known limitations

[N/A]
