### PR TITLE
keypair: validate payload length in ParseAddress to prevent panic

### DIFF
--- a/keypair/from_address.go
+++ b/keypair/from_address.go
@@ -24,7 +24,7 @@ func newFromAddress(address string) (*FromAddress, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(payload) != 32 {
+	if len(payload) != ed25519.PublicKeySize {
 		return nil, ErrInvalidKey
 	}
 	pub := ed25519.PublicKey(payload)

--- a/keypair/from_address.go
+++ b/keypair/from_address.go
@@ -24,6 +24,9 @@ func newFromAddress(address string) (*FromAddress, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(payload) != 32 {
+		return nil, ErrInvalidKey
+	}
 	pub := ed25519.PublicKey(payload)
 	return &FromAddress{
 		address:   address,

--- a/keypair/from_address_test.go
+++ b/keypair/from_address_test.go
@@ -1,6 +1,7 @@
 package keypair
 
 import (
+	"crypto/ed25519"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -36,7 +37,7 @@ func TestParseAddress_RejectsLongPayload(t *testing.T) {
 }
 
 func TestParseAddress_AcceptsValid32BytePayload(t *testing.T) {
-	validPayload := make([]byte, 32)
+	validPayload := make([]byte, ed25519.PublicKeySize)
 	validAddress, err := strkey.Encode(strkey.VersionByteAccountID, validPayload)
 	require.NoError(t, err)
 

--- a/keypair/from_address_test.go
+++ b/keypair/from_address_test.go
@@ -7,12 +7,42 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFromAddress_Hint(t *testing.T) {
 	kp := MustParseAddress("GAYUB4KATGTUZEGUMJEOZDPPWM4MQLHCIKC4T55YSXHN234WI6BJMIY2")
 	assert.Equal(t, [4]byte{0x96, 0x47, 0x82, 0x96}, kp.Hint())
+}
+
+func TestParseAddress_RejectsShortPayload(t *testing.T) {
+	shortPayload := make([]byte, 5)
+	shortAddress, err := strkey.Encode(strkey.VersionByteAccountID, shortPayload)
+	require.NoError(t, err)
+
+	_, err = ParseAddress(shortAddress)
+	assert.ErrorIs(t, err, ErrInvalidKey)
+}
+
+func TestParseAddress_RejectsLongPayload(t *testing.T) {
+	longPayload := make([]byte, 64)
+	longAddress, err := strkey.Encode(strkey.VersionByteAccountID, longPayload)
+	require.NoError(t, err)
+
+	_, err = ParseAddress(longAddress)
+	assert.ErrorIs(t, err, ErrInvalidKey)
+}
+
+func TestParseAddress_AcceptsValid32BytePayload(t *testing.T) {
+	validPayload := make([]byte, 32)
+	validAddress, err := strkey.Encode(strkey.VersionByteAccountID, validPayload)
+	require.NoError(t, err)
+
+	kp, err := ParseAddress(validAddress)
+	require.NoError(t, err)
+	assert.Equal(t, validAddress, kp.Address())
 }
 
 func TestFromAddress_Equal(t *testing.T) {


### PR DESCRIPTION
strkey.Decode() accepts payloads of any length with valid checksums. Without length validation, short G-addresses could pass ParseAddress() and later cause panics in Hint() or Verify() methods.

Add explicit 32-byte length check in newFromAddress() to reject malformed addresses early with ErrInvalidKey.

Fixes #5901 