### PR TITLE
strkey: validate payload length in DecodeSignedPayload to prevent panic

### DIFF
--- a/strkey/signed_payload.go
+++ b/strkey/signed_payload.go
@@ -60,6 +60,9 @@ func DecodeSignedPayload(address string) (*SignedPayload, error) {
 	}
 
 	const signerLen = 32
+	if len(raw) < signerLen {
+		return nil, errors.Errorf("signed payload too short: %d bytes", len(raw))
+	}
 	rawSigner, raw := raw[:signerLen], raw[signerLen:]
 	signer, err := Encode(VersionByteAccountID, rawSigner)
 	if err != nil {

--- a/strkey/signed_payload_test.go
+++ b/strkey/signed_payload_test.go
@@ -90,6 +90,30 @@ func TestSignedPayloadErrors(t *testing.T) {
 	}
 }
 
+func TestDecodeSignedPayload_RejectsShortRawPayload(t *testing.T) {
+	testCases := []struct {
+		name       string
+		payloadLen int
+	}{
+		{"0 bytes", 0},
+		{"10 bytes", 10},
+		{"31 bytes", 31},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			shortPayload := make([]byte, tc.payloadLen)
+			shortAddress, err := Encode(VersionByteSignedPayload, shortPayload)
+			assert.NoError(t, err)
+
+			sp, err := DecodeSignedPayload(shortAddress)
+			assert.Nil(t, sp)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "signed payload too short")
+		})
+	}
+}
+
 // TestSignedPayloadSizes ensures all valid payload lengths work
 func TestSignedPayloadSizes(t *testing.T) {
 	signer := "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"


### PR DESCRIPTION
strkey.Decode() accepts payloads of any length with valid checksums. Without length validation, short P-addresses could pass DecodeSignedPayload() and later cause panics when slicing for the 32-byte signer key.

Add explicit length check before slicing to reject malformed signed payloads early with a descriptive error.

This fixes issue #5902 
