### PR TITLE
Fix SetOpSourceAccount silently ignoring invalid source account errors

### DIFF
--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -5,6 +5,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Breaking changes
+
+* `SetOpSourceAccount` now returns an `error` instead of silently ignoring invalid source account addresses. All `BuildXDR()` methods propagate this error. ([#5912](https://github.com/stellar/go-stellar-sdk/pull/5912))
+
 ## [11.0.0](https://github.com/stellar/go-stellar-sdk/releases/tag/horizonclient-v11.0.0) - 2023-03-29
 
 ### Breaking changes

--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -26,7 +26,9 @@ func (am *AccountMerge) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, am.SourceAccount)
+	if err = SetOpSourceAccount(&op, am.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -56,7 +56,9 @@ func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, at.SourceAccount)
+	if err = SetOpSourceAccount(&op, at.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/begin_sponsoring_future_reserves.go
+++ b/txnbuild/begin_sponsoring_future_reserves.go
@@ -27,7 +27,9 @@ func (bs *BeginSponsoringFutureReserves) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, bs.SourceAccount)
+	if err = SetOpSourceAccount(&op, bs.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/bump_sequence.go
+++ b/txnbuild/bump_sequence.go
@@ -21,7 +21,9 @@ func (bs *BumpSequence) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, bs.SourceAccount)
+	if err = SetOpSourceAccount(&op, bs.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -58,7 +58,9 @@ func (ct *ChangeTrust) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, ct.SourceAccount)
+	if err = SetOpSourceAccount(&op, ct.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/claim_claimable_balance.go
+++ b/txnbuild/claim_claimable_balance.go
@@ -31,7 +31,9 @@ func (cb *ClaimClaimableBalance) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, cb.SourceAccount)
+	if err = SetOpSourceAccount(&op, cb.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 
 	return op, nil
 }

--- a/txnbuild/clawback.go
+++ b/txnbuild/clawback.go
@@ -54,7 +54,9 @@ func (cb *Clawback) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR Operation")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, cb.SourceAccount)
+	if err = SetOpSourceAccount(&op, cb.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/clawback_claimable_balance.go
+++ b/txnbuild/clawback_claimable_balance.go
@@ -30,7 +30,9 @@ func (cb *ClawbackClaimableBalance) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, cb.SourceAccount)
+	if err = SetOpSourceAccount(&op, cb.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 
 	return op, nil
 }

--- a/txnbuild/create_account.go
+++ b/txnbuild/create_account.go
@@ -34,7 +34,9 @@ func (ca *CreateAccount) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, ca.SourceAccount)
+	if err = SetOpSourceAccount(&op, ca.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 
 	return op, nil
 }

--- a/txnbuild/create_claimable_balance.go
+++ b/txnbuild/create_claimable_balance.go
@@ -134,7 +134,9 @@ func (cb *CreateClaimableBalance) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, cb.SourceAccount)
+	if err = SetOpSourceAccount(&op, cb.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/create_passive_offer.go
+++ b/txnbuild/create_passive_offer.go
@@ -46,7 +46,9 @@ func (cpo *CreatePassiveSellOffer) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, cpo.SourceAccount)
+	if err = SetOpSourceAccount(&op, cpo.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 
 	return op, nil
 }

--- a/txnbuild/end_sponsoring_future_reserves.go
+++ b/txnbuild/end_sponsoring_future_reserves.go
@@ -21,7 +21,9 @@ func (es *EndSponsoringFutureReserves) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, es.SourceAccount)
+	if err = SetOpSourceAccount(&op, es.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 
 	return op, nil
 }

--- a/txnbuild/extend_footprint_ttl.go
+++ b/txnbuild/extend_footprint_ttl.go
@@ -26,7 +26,9 @@ func (f *ExtendFootprintTtl) BuildXDR() (xdr.Operation, error) {
 
 	op := xdr.Operation{Body: body}
 
-	SetOpSourceAccount(&op, f.SourceAccount)
+	if err = SetOpSourceAccount(&op, f.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/inflation.go
+++ b/txnbuild/inflation.go
@@ -19,7 +19,9 @@ func (inf *Inflation) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, inf.SourceAccount)
+	if err = SetOpSourceAccount(&op, inf.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/invoke_host_function.go
+++ b/txnbuild/invoke_host_function.go
@@ -237,7 +237,9 @@ func (f *InvokeHostFunction) BuildXDR() (xdr.Operation, error) {
 
 	op := xdr.Operation{Body: body}
 
-	SetOpSourceAccount(&op, f.SourceAccount)
+	if err = SetOpSourceAccount(&op, f.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/liquidity_pool_deposit.go
+++ b/txnbuild/liquidity_pool_deposit.go
@@ -78,7 +78,9 @@ func (lpd *LiquidityPoolDeposit) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, lpd.SourceAccount)
+	if err = SetOpSourceAccount(&op, lpd.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/liquidity_pool_withdraw.go
+++ b/txnbuild/liquidity_pool_withdraw.go
@@ -79,7 +79,9 @@ func (lpd *LiquidityPoolWithdraw) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, lpd.SourceAccount)
+	if err = SetOpSourceAccount(&op, lpd.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/manage_buy_offer.go
+++ b/txnbuild/manage_buy_offer.go
@@ -48,7 +48,9 @@ func (mo *ManageBuyOffer) BuildXDR() (xdr.Operation, error) {
 	}
 
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, mo.SourceAccount)
+	if err = SetOpSourceAccount(&op, mo.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/manage_data.go
+++ b/txnbuild/manage_data.go
@@ -31,7 +31,9 @@ func (md *ManageData) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, md.SourceAccount)
+	if err = SetOpSourceAccount(&op, md.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/manage_offer.go
+++ b/txnbuild/manage_offer.go
@@ -115,7 +115,9 @@ func (mo *ManageSellOffer) BuildXDR() (xdr.Operation, error) {
 	}
 
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, mo.SourceAccount)
+	if err = SetOpSourceAccount(&op, mo.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -3,6 +3,7 @@ package txnbuild
 import (
 	"fmt"
 
+	"github.com/stellar/go-stellar-sdk/support/errors"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
@@ -15,13 +16,19 @@ type Operation interface {
 }
 
 // SetOpSourceAccount sets the source account ID on an Operation, allowing M-strkeys (as defined in SEP23).
-func SetOpSourceAccount(op *xdr.Operation, sourceAccount string) {
+// It returns an error if sourceAccount is not a valid Stellar address. If an error is returned,
+// op.SourceAccount is left unset. If sourceAccount is empty, this is a no-op.
+func SetOpSourceAccount(op *xdr.Operation, sourceAccount string) error {
 	if sourceAccount == "" {
-		return
+		return nil
 	}
 	var opSourceAccountID xdr.MuxedAccount
-	opSourceAccountID.SetAddress(sourceAccount)
+	err := opSourceAccountID.SetAddress(sourceAccount)
+	if err != nil {
+		return errors.Wrap(err, "failed to set op source account")
+	}
 	op.SourceAccount = &opSourceAccountID
+	return nil
 }
 
 // operationFromXDR returns a txnbuild Operation from its corresponding XDR operation

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -88,7 +88,9 @@ func (pp *PathPaymentStrictReceive) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, pp.SourceAccount)
+	if err = SetOpSourceAccount(&op, pp.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/path_payment_strict_send.go
+++ b/txnbuild/path_payment_strict_send.go
@@ -82,7 +82,9 @@ func (pp *PathPaymentStrictSend) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, pp.SourceAccount)
+	if err = SetOpSourceAccount(&op, pp.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/payment.go
+++ b/txnbuild/payment.go
@@ -49,7 +49,9 @@ func (p *Payment) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR Operation")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, p.SourceAccount)
+	if err = SetOpSourceAccount(&op, p.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/restore_footprint.go
+++ b/txnbuild/restore_footprint.go
@@ -97,7 +97,9 @@ func (f *RestoreFootprint) BuildXDR() (xdr.Operation, error) {
 
 	op := xdr.Operation{Body: body}
 
-	SetOpSourceAccount(&op, f.SourceAccount)
+	if err = SetOpSourceAccount(&op, f.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/revoke_sponsorship.go
+++ b/txnbuild/revoke_sponsorship.go
@@ -153,7 +153,9 @@ func (r *RevokeSponsorship) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, r.SourceAccount)
+	if err = SetOpSourceAccount(&op, r.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 
 	return op, nil
 }

--- a/txnbuild/set_options.go
+++ b/txnbuild/set_options.go
@@ -95,7 +95,9 @@ func (so *SetOptions) BuildXDR() (xdr.Operation, error) {
 	}
 
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, so.SourceAccount)
+	if err = SetOpSourceAccount(&op, so.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 

--- a/txnbuild/set_trust_line_flags.go
+++ b/txnbuild/set_trust_line_flags.go
@@ -57,7 +57,9 @@ func (stf *SetTrustLineFlags) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceAccount(&op, stf.SourceAccount)
+	if err = SetOpSourceAccount(&op, stf.SourceAccount); err != nil {
+		return xdr.Operation{}, err
+	}
 	return op, nil
 }
 


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go-stellar-sdk/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

SetOpSourceAccount was discarding the error returned by MuxedAccount.SetAddress, which could produce a partially initialized MuxedAccount that panics on subsequent Address() calls. Return the error instead and check it in all 27 BuildXDR callers.


### Known limitations

[N/A]
