### PR TITLE
historyarchive: add size bound to GetPathHAS to prevent resource exhaustion

### DIFF
--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -140,11 +140,11 @@ func (a *Archive) GetPathHAS(path string) (HistoryArchiveState, error) {
 		return has, err
 	}
 	defer rdr.Close()
-	lr := io.LimitReader(rdr, maxHASSize)
+	lr := &io.LimitedReader{R: rdr, N: maxHASSize + 1}
 	dec := json.NewDecoder(lr)
 	err = dec.Decode(&has)
 	if err != nil {
-		if lr.(*io.LimitedReader).N == 0 {
+		if lr.N == 0 && (err == io.EOF || err == io.ErrUnexpectedEOF) {
 			return has, errors.Errorf("history archive state response exceeds %d bytes limit", maxHASSize)
 		}
 		return has, err

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -30,6 +30,7 @@ import (
 
 const hexPrefixPat = "/[0-9a-f]{2}/[0-9a-f]{2}/[0-9a-f]{2}/"
 const rootHASPath = ".well-known/stellar-history.json"
+const maxHASSize = 10 * 1024 * 1024 // 10 MB
 
 type CommandOptions struct {
 	Concurrency  int
@@ -139,9 +140,13 @@ func (a *Archive) GetPathHAS(path string) (HistoryArchiveState, error) {
 		return has, err
 	}
 	defer rdr.Close()
-	dec := json.NewDecoder(rdr)
+	lr := io.LimitReader(rdr, maxHASSize)
+	dec := json.NewDecoder(lr)
 	err = dec.Decode(&has)
 	if err != nil {
+		if lr.(*io.LimitedReader).N == 0 {
+			return has, errors.Errorf("history archive state response exceeds %d bytes limit", maxHASSize)
+		}
 		return has, err
 	}
 


### PR DESCRIPTION
## Summary
- Wraps the reader in `GetPathHAS()` with `io.LimitReader` (10 MB cap) before JSON decoding to prevent unbounded memory allocation from malicious/oversized history archive responses
- Returns a clear error message when the size limit is exceeded
- Follows the existing pattern from `clients/stellartoml/client.go`


🤖 Generated with [Claude Code](https://claude.com/claude-code)