### PR TITLE
support/datastore: Fix ListFilePath for datastore bucket with no prefix

### DIFF
--- a/support/datastore/gcs.go
+++ b/support/datastore/gcs.go
@@ -209,16 +209,11 @@ func (b GCSDataStore) putFile(ctx context.Context, filePath string, in io.Writer
 func (b GCSDataStore) ListFilePaths(ctx context.Context, options ListFileOptions) ([]string, error) {
 	var fullPrefix string
 
-	// When 'prefix' is empty, ensure the base prefix ends with a slash (e.g., "a/b/")
-	// so the query returns only objects within that directory, not similarly named paths like "a/b-1".
-	if options.Prefix == "" {
-		fullPrefix = b.prefix
-		if fullPrefix != "" && !strings.HasSuffix(fullPrefix, "/") {
-			fullPrefix += "/"
-		}
-	} else {
-		// Join the caller-provided prefix with the datastore prefix
-		fullPrefix = path.Join(b.prefix, options.Prefix)
+	// Ensure the prefix ends with a slash so the query returns only objects
+	// within that directory, not similarly named paths like "a/b-1".
+	fullPrefix = path.Join(b.prefix, options.Prefix)
+	if fullPrefix != "" {
+		fullPrefix += "/"
 	}
 
 	var StartAfter string

--- a/support/datastore/gcs.go
+++ b/support/datastore/gcs.go
@@ -213,7 +213,7 @@ func (b GCSDataStore) ListFilePaths(ctx context.Context, options ListFileOptions
 	// so the query returns only objects within that directory, not similarly named paths like "a/b-1".
 	if options.Prefix == "" {
 		fullPrefix = b.prefix
-		if !strings.HasSuffix(fullPrefix, "/") {
+		if fullPrefix != "" && !strings.HasSuffix(fullPrefix, "/") {
 			fullPrefix += "/"
 		}
 	} else {

--- a/support/datastore/gcs_test.go
+++ b/support/datastore/gcs_test.go
@@ -437,6 +437,40 @@ func TestGCSListFilePaths(t *testing.T) {
 	require.Equal(t, []string{"a", "b"}, paths)
 }
 
+func TestGCSListFilePaths_NoPrefix(t *testing.T) {
+	server := fakestorage.NewServer([]fakestorage.Object{
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "a"},
+			Content:     []byte("1"),
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "b"},
+			Content:     []byte("1"),
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "c"},
+			Content:     []byte("1"),
+		},
+	})
+	defer server.Stop()
+
+	store, err := FromGCSClient(context.Background(), server.Client(), "test-bucket")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	paths, err := store.ListFilePaths(context.Background(), ListFileOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b", "c"}, paths)
+
+	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{Limit: 2})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, paths)
+
+	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{StartAfter: "a"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"b", "c"}, paths)
+}
+
 func TestGCSListFilePaths_WithPrefix(t *testing.T) {
 	server := fakestorage.NewServer([]fakestorage.Object{
 		{

--- a/support/datastore/s3.go
+++ b/support/datastore/s3.go
@@ -288,16 +288,11 @@ func (b S3DataStore) putFile(ctx context.Context, filePath string, in io.WriterT
 func (b S3DataStore) ListFilePaths(ctx context.Context, options ListFileOptions) ([]string, error) {
 	var fullPrefix string
 
-	// When 'prefix' is empty, ensure the base prefix ends with a slash (e.g., "a/b/")
-	// so the query returns only objects within that directory, not similarly named paths like "a/b-1".
-	if options.Prefix == "" {
-		fullPrefix = b.prefix
-		if fullPrefix != "" && !strings.HasSuffix(fullPrefix, "/") {
-			fullPrefix += "/"
-		}
-	} else {
-		// Join the caller-provided prefix with the datastore prefix
-		fullPrefix = path.Join(b.prefix, options.Prefix)
+	// Ensure the prefix ends with a slash so the query returns only objects
+	// within that directory, not similarly named paths like "a/b-1".
+	fullPrefix = path.Join(b.prefix, options.Prefix)
+	if fullPrefix != "" {
+		fullPrefix += "/"
 	}
 
 	var StartAfter string

--- a/support/datastore/s3.go
+++ b/support/datastore/s3.go
@@ -292,7 +292,7 @@ func (b S3DataStore) ListFilePaths(ctx context.Context, options ListFileOptions)
 	// so the query returns only objects within that directory, not similarly named paths like "a/b-1".
 	if options.Prefix == "" {
 		fullPrefix = b.prefix
-		if !strings.HasSuffix(fullPrefix, "/") {
+		if fullPrefix != "" && !strings.HasSuffix(fullPrefix, "/") {
 			fullPrefix += "/"
 		}
 	} else {

--- a/support/datastore/s3_test.go
+++ b/support/datastore/s3_test.go
@@ -256,6 +256,28 @@ func TestS3ListFilePaths(t *testing.T) {
 	require.Equal(t, []string{"a", "b"}, paths)
 }
 
+func TestS3ListFilePaths_NoPrefix(t *testing.T) {
+	ctx := context.Background()
+	store, teardown := setupTestS3DataStore(t, ctx, "test-bucket", map[string]mockS3Object{
+		"a": {body: []byte("1")},
+		"b": {body: []byte("1")},
+		"c": {body: []byte("1")},
+	})
+	defer teardown()
+
+	paths, err := store.ListFilePaths(context.Background(), ListFileOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b", "c"}, paths)
+
+	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{Limit: 2})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, paths)
+
+	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{StartAfter: "a"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"b", "c"}, paths)
+}
+
 func TestS3ListFilePaths_WithPrefix(t *testing.T) {
 	ctx := context.Background()
 	store, teardown := setupTestS3DataStore(t, ctx, "test-bucket/objects/testnet", map[string]mockS3Object{


### PR DESCRIPTION


<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go-stellar-sdk/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
The fix corrects ListFilePath to handle datastore configurations where `destination_bucket_path` contains only a bucket name with no prefix. 

### Known limitations
N/A