### PR TITLE
strkey: bound decode input length to avoid unnecessary allocation

### DIFF
--- a/strkey/decode_test.go
+++ b/strkey/decode_test.go
@@ -1,6 +1,7 @@
 package strkey
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -246,5 +247,26 @@ func TestMalformed(t *testing.T) {
 				assert.Error(t, err)
 			})
 		})
+	}
+}
+
+func TestDecodeRejectsOversizedInput(t *testing.T) {
+	oversized := strings.Repeat("A", maxEncodedSize+1)
+
+	_, err := Decode(VersionByteAccountID, oversized)
+	assert.ErrorContains(t, err, "maximum valid length")
+
+	_, _, err = DecodeAny(oversized)
+	assert.ErrorContains(t, err, "maximum valid length")
+
+	_, err = Version(oversized)
+	assert.ErrorContains(t, err, "maximum valid length")
+
+	// Exactly-maxEncodedSize input must pass the length guard and reach
+	// downstream validation (which will reject it for other reasons).
+	boundary := strings.Repeat("A", maxEncodedSize)
+	_, err = Decode(VersionByteAccountID, boundary)
+	if assert.Error(t, err) {
+		assert.NotContains(t, err.Error(), "maximum valid length")
 	}
 }

--- a/strkey/main.go
+++ b/strkey/main.go
@@ -223,6 +223,11 @@ func initDecodingTable() [256]byte {
 // potentially be strkey encoded (i.e. it has both a version byte and a
 // checksum, neither of which are explicitly checked by this func)
 func decodeString(src string) ([]byte, error) {
+	// Reject inputs larger than the longest possible valid strkey before
+	// allocating a byte copy, so oversized inputs can't force large allocations.
+	if len(src) > maxEncodedSize {
+		return nil, errors.Errorf("strkey is %d bytes long; maximum valid length is %d", len(src), maxEncodedSize)
+	}
 	// operations on strings are expensive since it involves unicode parsing
 	// so, we use bytes from the beginning
 	srcBytes := []byte(src)


### PR DESCRIPTION
## Summary

- Add an early length check to `strkey.decodeString` so oversized inputs are rejected before the `[]byte(src)` copy.
- Add a test covering `Decode`, `DecodeAny`, and `Version` for oversized input, plus a boundary test at exactly `maxEncodedSize` to guard against off-by-one regressions.
