### PR TITLE
ingest/loadtest: add stellar-core apply-load tooling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/mod v0.29.0 // indirect
+	golang.org/x/mod v0.29.0
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240701130421-f6361c86f094 // indirect

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -53,7 +53,7 @@ func NewApplyLoad(
 	}
 	coreVersion, err := ledgerbackend.CoreBuildVersion(coreBinaryPath)
 	if err != nil {
-		return nil, fmt.Errorf("error getting stellar-core version: %w", err)
+		return nil, fmt.Errorf("couldn't get stellar-core version: %w", err)
 	}
 
 	if logger == nil {
@@ -112,7 +112,7 @@ func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
 	// as setup ledgers would conflict with the fixtures.
 	if a.outputPath != "" {
 		if count, err := a.streamLedgersToFile(); err != nil {
-			return fmt.Errorf("error streaming ledgers to file: %w", err)
+			return fmt.Errorf("failed to stream ledgers to file: %w", err)
 		} else if count == 0 {
 			return fmt.Errorf("no benchmark ledgers found to write to file")
 		}
@@ -121,7 +121,7 @@ func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
 	// Stream fixtures to output file
 	if a.fixturesPath != "" {
 		if _, err := a.streamFixturesToFile(ctx); err != nil {
-			return fmt.Errorf("error streaming fixtures to file: %w", err)
+			return fmt.Errorf("failed to stream fixtures to file: %w", err)
 		}
 	}
 	return nil
@@ -132,7 +132,7 @@ func (a *ApplyLoad) run(ctx context.Context) error {
 	// Copy config to work dir (apply-load writes files relative to config location)
 	destConfigPath := filepath.Join(a.workDir, "apply-load.cfg")
 	if err := copyFile(a.configPath, destConfigPath); err != nil {
-		return fmt.Errorf("failed to copy config file: %w", err)
+		return err
 	}
 
 	// Step 1: Initialize database
@@ -140,7 +140,7 @@ func (a *ApplyLoad) run(ctx context.Context) error {
 	newDBCmd.Dir = a.workDir
 	output, err := newDBCmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("new-db failed:\noutput: %s\nerror: %w", string(output), err)
+		return err
 	}
 
 	// Step 2: Initialize history archive
@@ -148,7 +148,7 @@ func (a *ApplyLoad) run(ctx context.Context) error {
 	newHistCmd.Dir = a.workDir
 	output, err = newHistCmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("new-hist failed:\noutput: %s\nerror: %w", string(output), err)
+		return err
 	}
 	a.logger.Infof("Initialized history archive: %s\n", a.cfg.HistoryArchiveName)
 
@@ -157,13 +157,13 @@ func (a *ApplyLoad) run(ctx context.Context) error {
 	applyLoadCmd.Dir = a.workDir
 	output, err = applyLoadCmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("apply-load failed:\noutput: %s\nerror: %w", string(output), err)
+		return err
 	}
 
 	// Parse pre-benchmark checkpoint from stellar-core output.
 	// The config sets LOG_FILE_PATH="" so logs go to stdout.
 	if a.preBenchmarkCheckpoint, err = parsePreBenchmarkCheckpoint(string(output)); err != nil {
-		return fmt.Errorf("failed to parse pre-benchmark checkpoint: %w", err)
+		return err
 	}
 	a.logger.Infof("Pre-benchmark checkpoint: ledger %d", a.preBenchmarkCheckpoint)
 
@@ -345,7 +345,7 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 		// Extract changes from this ledger
 		changeReader, err := ingest.NewLedgerChangeReaderFromLedgerCloseMeta(a.cfg.NetworkPassphrase, ledger)
 		if err != nil {
-			return fmt.Errorf("error creating change reader: %w", err)
+			return err
 		}
 
 		for {
@@ -354,21 +354,21 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 				break
 			}
 			if err != nil {
-				return fmt.Errorf("error reading change: %w", err)
+				return err
 			}
 
 			// If the change has a Pre state, the entry must already exist in our known set
 			if change.Pre != nil {
 				key, err := change.Pre.LedgerKey()
 				if err != nil {
-					return fmt.Errorf("error getting ledger key: %w", err)
+					return err
 				}
 				keyB64, err := key.MarshalBinaryBase64()
 				if err != nil {
-					return fmt.Errorf("error marshalling ledger key: %w", err)
+					return err
 				}
 				if !knownKeys[keyB64] {
-					return fmt.Errorf("ledger key not found in known set: %s", keyB64)
+					return err
 				}
 			}
 
@@ -377,28 +377,28 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 				// Entry exists after this change - add/keep in set
 				key, err := change.Post.LedgerKey()
 				if err != nil {
-					return fmt.Errorf("error getting ledger key: %w", err)
+					return err
 				}
 				keyB64, err := key.MarshalBinaryBase64()
 				if err != nil {
-					return fmt.Errorf("error marshalling ledger key: %w", err)
+					return err
 				}
 				knownKeys[keyB64] = true
 			} else if change.Pre != nil {
 				// Entry was deleted - remove from set
 				key, err := change.Pre.LedgerKey()
 				if err != nil {
-					return fmt.Errorf("error getting ledger key: %w", err)
+					return err
 				}
 				keyB64, err := key.MarshalBinaryBase64()
 				if err != nil {
-					return fmt.Errorf("error marshalling ledger key: %w", err)
+					return err
 				}
 				delete(knownKeys, keyB64)
 			}
 		}
 		if err := changeReader.Close(); err != nil {
-			return fmt.Errorf("error closing change reader: %w", err)
+			return err
 		}
 	}
 	return nil
@@ -415,7 +415,7 @@ func parsePreBenchmarkCheckpoint(output string) (uint32, error) {
 
 	ledger, err := strconv.ParseUint(matches[1], 10, 32)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse ledger number: %w", err)
+		return 0, err
 	}
 
 	return uint32(ledger), nil

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -188,6 +188,7 @@ func streamLedgersToFile(
 
 	// Note: xdr.Stream closes the underlying reader when ReadOne hits EOF or error
 	stream := xdr.NewStream(inFile)
+	defer stream.Close()
 
 	outFile, err := os.Create(opts.OutputPath)
 	if err != nil {
@@ -374,6 +375,7 @@ func replayAndVerify(
 		return err
 	}
 	stream := xdr.NewStream(file)
+	defer stream.Close()
 
 	for {
 		select {

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -176,7 +176,6 @@ func (a *ApplyLoad) streamLedgersToFile() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer inFile.Close()
 
 	// Note: xdr.Stream closes the underlying reader when ReadOne hits EOF or error
 	stream := xdr.NewStream(inFile)
@@ -323,7 +322,6 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 	stream := xdr.NewStream(file)
 
 	for {

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -70,7 +70,7 @@ func ApplyLoad(ctx context.Context, opts Options) (Results, error) {
 	}
 
 	// Verify fixtures completeness before writing anything
-	if err := verifyFixturesCompleteness(ctx, cfg, opts, results.PreBenchmarkCheckpoint); err != nil {
+	if err = verifyFixturesCompleteness(ctx, cfg, opts, results.PreBenchmarkCheckpoint); err != nil {
 		return Results{}, fmt.Errorf("fixture completeness verification failed: %w", err)
 	}
 

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -46,7 +46,6 @@ func NewApplyLoad(
 	}
 
 	if coreBinaryPath == "" {
-		var err error
 		if coreBinaryPath, err = exec.LookPath("stellar-core"); err != nil {
 			return nil, fmt.Errorf("stellar-core binary unspecified and not found in PATH: %w", err)
 		}
@@ -362,7 +361,6 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 	fixtureCount := 0
 	for {
 		var change ingest.Change
-		var err error
 		if change, err = checkpointReader.Read(); err == io.EOF {
 			break
 		} else if err != nil {

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -399,6 +399,11 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 			return err
 		}
 
+		// Skip setup ledgers
+		if ledger.LedgerSequence() <= a.preBenchmarkCheckpoint {
+			continue
+		}
+
 		// Extract changes from this ledger
 		changeReader, err := ingest.NewLedgerChangeReaderFromLedgerCloseMeta(a.cfg.NetworkPassphrase, ledger)
 		if err != nil {

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/klauspost/compress/zstd"
@@ -170,8 +171,22 @@ func (a *ApplyLoad) runCore(ctx context.Context, destConfigPath string, args ...
 	return cmd.CombinedOutput()
 }
 
+// metadataPath resolves cfg.MetadataOutputStream against the work dir, rejecting
+// absolute paths or `..` traversals that would escape it.
+func (a *ApplyLoad) metadataPath() (string, error) {
+	cleanWorkDir := filepath.Clean(a.workDir)
+	p := filepath.Join(cleanWorkDir, a.cfg.MetadataOutputStream)
+	if p != cleanWorkDir && !strings.HasPrefix(p, cleanWorkDir+string(filepath.Separator)) {
+		return "", fmt.Errorf("METADATA_OUTPUT_STREAM %q escapes work dir", a.cfg.MetadataOutputStream)
+	}
+	return p, nil
+}
+
 func (a *ApplyLoad) streamLedgersToFile() (int, error) {
-	metadataPath := filepath.Join(a.workDir, a.cfg.MetadataOutputStream)
+	metadataPath, err := a.metadataPath()
+	if err != nil {
+		return 0, err
+	}
 	inFile, err := os.Open(metadataPath)
 	if err != nil {
 		return 0, err
@@ -282,7 +297,10 @@ func (a *ApplyLoad) streamFixturesToFile(ctx context.Context) (int, error) {
 }
 
 func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
-	metadataPath := filepath.Join(a.workDir, a.cfg.MetadataOutputStream)
+	metadataPath, err := a.metadataPath()
+	if err != nil {
+		return err
+	}
 
 	// Step 1: Load all ledger entry keys from fixtures into a set
 	knownKeys := make(map[string]bool)

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -367,11 +367,13 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 			return err
 		}
 		if change.Post != nil {
-			key, err := change.Post.LedgerKey()
+			var key xdr.LedgerKey
+			key, err = change.Post.LedgerKey()
 			if err != nil {
 				return err
 			}
-			keyB64, err := key.MarshalBinaryBase64()
+			var keyB64 string
+			keyB64, err = key.MarshalBinaryBase64()
 			if err != nil {
 				return err
 			}

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -53,7 +53,12 @@ func NewApplyLoad(
 		}
 	}
 
+	if logger == nil {
+		logger = log.New()
+	}
+
 	return &ApplyLoad{
+		logger:         logger,
 		coreBinaryPath: coreBinaryPath,
 		configPath:     configPath,
 		cfg:            cfg,
@@ -123,7 +128,7 @@ func (a *ApplyLoad) run() error {
 	if err != nil {
 		return fmt.Errorf("new-hist failed:\noutput: %s\nerror: %w", string(output), err)
 	}
-	// fmt.Printf("Initialized history archive: %s\n", cfg.HistoryArchiveName)
+	a.logger.Infof("Initialized history archive: %s\n", a.cfg.HistoryArchiveName)
 
 	// Step 3: Execute stellar-core apply-load
 	applyLoadCmd := exec.Command(a.coreBinaryPath, "apply-load", "--conf", destConfigPath)
@@ -138,6 +143,7 @@ func (a *ApplyLoad) run() error {
 	if a.preBenchmarkCheckpoint, err = parsePreBenchmarkCheckpoint(string(output)); err != nil {
 		return fmt.Errorf("failed to parse pre-benchmark checkpoint: %w", err)
 	}
+	a.logger.Infof("Pre-benchmark checkpoint: ledger %d", a.preBenchmarkCheckpoint)
 
 	return nil
 }
@@ -254,7 +260,7 @@ func (a *ApplyLoad) streamLedgersToFile() (int, error) {
 		count++
 	}
 
-	// t.Logf("Wrote %d benchmark ledgers, skipped %d setup ledgers", count, skipped)
+	a.logger.Infof("Wrote %d benchmark ledgers, skipped %d setup ledgers", count, skipped)
 	return count, nil
 }
 
@@ -315,7 +321,7 @@ func (a *ApplyLoad) streamFixturesToFile(ctx context.Context) (int, error) {
 		}
 	}
 
-	// t.Logf("Wrote %d entries, skipped %d protocol entries", count, skipped)
+	a.logger.Infof("Wrote %d entries, skipped %d protocol entries", count, skipped)
 	return count, nil
 }
 
@@ -333,6 +339,7 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 	}
 	defer checkpointReader.Close()
 
+	fixtureCount := 0
 	for {
 		var change ingest.Change
 		var err error
@@ -351,8 +358,10 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 				return err
 			}
 			knownKeys[keyB64] = true
+			fixtureCount++
 		}
 	}
+	a.logger.Infof("Loaded %d fixture keys into verification set", fixtureCount)
 
 	// Step 2: Stream through generated ledgers and verify each change
 	file, err := os.Open(metadataPath)

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -14,6 +14,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/stellar/go-stellar-sdk/historyarchive"
 	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -32,6 +33,9 @@ type ApplyLoad struct {
 	preBenchmarkCheckpoint uint32
 }
 
+// NewApplyLoad creates a new ApplyLoad instance with the given parameters.
+// If outputPath and fixturesPath are both set, ledgers and fixtures are written there after running apply-load.
+// If workDirPath is not set, a temporary directory will be created for stellar-core's working directory.
 func NewApplyLoad(
 	logger *log.Entry,
 	coreBinaryPath, configPath, outputPath, fixturesPath, workDirPath string,
@@ -40,6 +44,19 @@ func NewApplyLoad(
 	if err != nil {
 		return nil, err
 	}
+
+	if coreBinaryPath == "" {
+		var err error
+		if coreBinaryPath, err = exec.LookPath("stellar-core"); err != nil {
+			return nil, fmt.Errorf("stellar-core binary unspecified and not found in PATH: %w", err)
+		}
+	}
+	coreVersion, err := ledgerbackend.CoreBuildVersion(coreBinaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("error getting stellar-core version: %w", err)
+	}
+	logger.Infof("Using stellar-core: %s %s", coreBinaryPath, coreVersion)
+	logger.Infof("Using config: %s", configPath)
 
 	if (outputPath != "") != (fixturesPath != "") {
 		return nil, fmt.Errorf("outputPath and fixturesPath must both be set or both be empty")
@@ -68,6 +85,7 @@ func NewApplyLoad(
 	}, nil
 }
 
+// Cleanup removes the working directory and all its contents. Should be called after RunApplyLoadAndWrite.
 func (a *ApplyLoad) Cleanup() error {
 	if a.workDir == "" {
 		return nil
@@ -75,6 +93,7 @@ func (a *ApplyLoad) Cleanup() error {
 	return os.RemoveAll(a.workDir)
 }
 
+// RunApplyLoadAndWrite runs the apply-load process and writes outputs to files if paths are set.
 func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
 	// Run apply-load
 	if err := a.run(); err != nil {
@@ -106,6 +125,7 @@ func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
 	return nil
 }
 
+// run executes the stellar-core apply-load command and captures the pre-benchmark checkpoint from its output.
 func (a *ApplyLoad) run() error {
 	// Copy config to work dir (apply-load writes files relative to config location)
 	destConfigPath := filepath.Join(a.workDir, "apply-load.cfg")

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -29,6 +29,7 @@ type ApplyLoad struct {
 	outputPath     string
 	fixturesPath   string
 	workDir        string
+	cleanupWorkDir bool
 
 	preBenchmarkCheckpoint uint32
 }
@@ -67,8 +68,10 @@ func NewApplyLoad(
 		return nil, fmt.Errorf("both outputPath and fixturesPath are required")
 	}
 
+	var createdWorkDir bool
 	if workDirPath == "" {
 		var err error
+		createdWorkDir = true // Only cleanup if we created the work dir
 		workDirPath, err = os.MkdirTemp("", "apply-load-workdir-*")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temporary work directory: %w", err)
@@ -83,13 +86,14 @@ func NewApplyLoad(
 		outputPath:     outputPath,
 		fixturesPath:   fixturesPath,
 		workDir:        workDirPath,
+		cleanupWorkDir: createdWorkDir,
 	}, nil
 }
 
 // Cleanup removes the working directory and all its contents.
-// Should be called after RunApplyLoadAndWrite if no separately managed work dir is used.
+// Should be called after RunApplyLoadAndWrite if no separately managed work dir is used, no-ops otherwise.
 func (a *ApplyLoad) Cleanup() error {
-	if a.workDir == "" {
+	if a.workDir == "" || !a.cleanupWorkDir {
 		return nil
 	}
 	return os.RemoveAll(a.workDir)

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -26,15 +26,15 @@ type ApplyLoad struct {
 	coreBinaryPath string
 	configPath     string
 	cfg            applyLoadConfig
-	outputPath     string // optional
-	fixturesPath   string // optional
+	outputPath     string
+	fixturesPath   string
 	workDir        string
 
 	preBenchmarkCheckpoint uint32
 }
 
 // NewApplyLoad creates a new ApplyLoad instance with the given parameters.
-// If outputPath and fixturesPath are both set, ledgers and fixtures are written there after running apply-load.
+// outputPath and fixturesPath are required: ledgers and fixtures are written there after running apply-load.
 // If workDirPath is not set, a temporary directory will be created for stellar-core's working directory.
 // The supplied config's [HISTORY] commands must publish to a history/ subdirectory of the work dir.
 func NewApplyLoad(
@@ -63,8 +63,8 @@ func NewApplyLoad(
 	logger.Infof("Using stellar-core: %s %s", coreBinaryPath, coreVersion)
 	logger.Infof("Using config: %s", configPath)
 
-	if (outputPath != "") != (fixturesPath != "") {
-		return nil, fmt.Errorf("outputPath and fixturesPath must both be set or both be empty")
+	if outputPath == "" || fixturesPath == "" {
+		return nil, fmt.Errorf("both outputPath and fixturesPath are required")
 	}
 
 	if workDirPath == "" {
@@ -95,9 +95,8 @@ func (a *ApplyLoad) Cleanup() error {
 	return os.RemoveAll(a.workDir)
 }
 
-// RunApplyLoadAndWrite runs the apply-load process and writes outputs to files if paths are set.
+// RunApplyLoadAndWrite runs the apply-load process and writes outputs to outputPath and fixturesPath.
 func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
-	// Run apply-load
 	if err := a.run(ctx); err != nil {
 		return err
 	}
@@ -107,22 +106,24 @@ func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
 		return fmt.Errorf("fixture completeness verification failed: %w", err)
 	}
 
-	// Stream ledgers to output file or just count them for verification
-	// Only include benchmark ledgers (after the pre-benchmark checkpoint),
-	// as setup ledgers would conflict with the fixtures.
-	if a.outputPath != "" {
-		if count, err := a.streamLedgersToFile(); err != nil {
-			return fmt.Errorf("failed to stream ledgers to file: %w", err)
-		} else if count == 0 {
-			return fmt.Errorf("no benchmark ledgers found to write to file")
-		}
+	// Stream benchmark ledgers (after the pre-benchmark checkpoint) to output file.
+	// Setup ledgers are excluded because they would conflict with the fixtures.
+	var countLedgers, countFixtures int
+	var err error
+	countLedgers, err = a.streamLedgersToFile()
+	if err != nil {
+		return fmt.Errorf("failed to stream ledgers to file: %w", err)
+	}
+	if countLedgers == 0 {
+		return fmt.Errorf("no benchmark ledgers found to write to file")
 	}
 
-	// Stream fixtures to output file
-	if a.fixturesPath != "" {
-		if _, err := a.streamFixturesToFile(ctx); err != nil {
-			return fmt.Errorf("failed to stream fixtures to file: %w", err)
-		}
+	countFixtures, err = a.streamFixturesToFile(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to stream fixtures to file: %w", err)
+	}
+	if countFixtures == 0 {
+		return fmt.Errorf("no benchmark fixtures found to write to file")
 	}
 	return nil
 }
@@ -283,9 +284,6 @@ func (a *ApplyLoad) streamFixturesToFile(ctx context.Context) (int, error) {
 }
 
 func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
-	if a.fixturesPath == "" {
-		return nil // no fixtures to verify
-	}
 	metadataPath := filepath.Join(a.workDir, a.cfg.MetadataOutputStream)
 
 	// Step 1: Load all ledger entry keys from fixtures into a set

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -296,46 +296,57 @@ func (a *ApplyLoad) streamFixturesToFile(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+func encodeKey(e *xdr.LedgerEntry) (string, error) {
+	k, err := e.LedgerKey()
+	if err != nil {
+		return "", fmt.Errorf("couldn't get ledger key: %w", err)
+	}
+	return k.MarshalBinaryBase64()
+}
+
 func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
-	metadataPath, err := a.metadataPath()
+	knownKeys, err := a.loadFixtureKeys(ctx)
 	if err != nil {
 		return err
 	}
+	a.logger.Infof("Loaded %d fixture keys into verification set", len(knownKeys))
+	return a.replayAndVerify(knownKeys)
+}
 
-	// Step 1: Load all ledger entry keys from fixtures into a set
+// loadFixtureKeys returns the set of ledger entry keys present at preBenchmarkCheckpoint.
+func (a *ApplyLoad) loadFixtureKeys(ctx context.Context) (map[string]bool, error) {
 	knownKeys := make(map[string]bool)
 	checkpointReader, err := openCheckpointReader(ctx, a.workDir, a.cfg.NetworkPassphrase, a.preBenchmarkCheckpoint)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer checkpointReader.Close()
 
-	fixtureCount := 0
 	for {
 		var change ingest.Change
 		if change, err = checkpointReader.Read(); err == io.EOF {
 			break
 		} else if err != nil {
-			return err
+			return nil, err
 		}
 		if change.Post != nil {
-			var key xdr.LedgerKey
-			key, err = change.Post.LedgerKey()
+			keyB64, err := encodeKey(change.Post)
 			if err != nil {
-				return err
-			}
-			var keyB64 string
-			keyB64, err = key.MarshalBinaryBase64()
-			if err != nil {
-				return err
+				return nil, err
 			}
 			knownKeys[keyB64] = true
-			fixtureCount++
 		}
 	}
-	a.logger.Infof("Loaded %d fixture keys into verification set", fixtureCount)
+	return knownKeys, nil
+}
 
-	// Step 2: Stream through generated ledgers and verify each change
+// replayAndVerify streams the benchmark ledgers and asserts every Pre referenced
+// exists in knownKeys, mutating knownKeys to track Post adds and deletes.
+func (a *ApplyLoad) replayAndVerify(knownKeys map[string]bool) error {
+	metadataPath, err := a.metadataPath()
+	if err != nil {
+		return err
+	}
 	file, err := os.Open(metadataPath)
 	if err != nil {
 		return err
@@ -355,7 +366,6 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 			continue
 		}
 
-		// Extract changes from this ledger
 		changeReader, err := ingest.NewLedgerChangeReaderFromLedgerCloseMeta(a.cfg.NetworkPassphrase, ledger)
 		if err != nil {
 			return err
@@ -372,38 +382,26 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 
 			// If the change has a Pre state, the entry must already exist in our known set
 			if change.Pre != nil {
-				key, err := change.Pre.LedgerKey()
-				if err != nil {
-					return err
-				}
-				keyB64, err := key.MarshalBinaryBase64()
+				keyB64, err := encodeKey(change.Pre)
 				if err != nil {
 					return err
 				}
 				if !knownKeys[keyB64] {
-					return err
+					return fmt.Errorf("ledger key not found in known set: %s", keyB64)
 				}
 			}
 
 			// Update our known set based on the Post state
 			if change.Post != nil {
 				// Entry exists after this change - add/keep in set
-				key, err := change.Post.LedgerKey()
-				if err != nil {
-					return err
-				}
-				keyB64, err := key.MarshalBinaryBase64()
+				keyB64, err := encodeKey(change.Post)
 				if err != nil {
 					return err
 				}
 				knownKeys[keyB64] = true
 			} else if change.Pre != nil {
 				// Entry was deleted - remove from set
-				key, err := change.Pre.LedgerKey()
-				if err != nil {
-					return err
-				}
-				keyB64, err := key.MarshalBinaryBase64()
+				keyB64, err := encodeKey(change.Pre)
 				if err != nil {
 					return err
 				}

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/klauspost/compress/zstd"
+	"golang.org/x/mod/semver"
+
 	"github.com/stellar/go-stellar-sdk/historyarchive"
 	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
@@ -56,6 +58,9 @@ func NewApplyLoad(
 	coreVersion, err := ledgerbackend.CoreBuildVersion(coreBinaryPath)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get stellar-core version: %w", err)
+	}
+	if semver.Compare(semver.Major(coreVersion), "v22") < 0 {
+		return nil, fmt.Errorf("stellar-core %s does not support apply-load, need v22 or higher", coreVersion)
 	}
 
 	if logger == nil {

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -15,23 +15,27 @@ import (
 	"github.com/stellar/go-stellar-sdk/historyarchive"
 	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
 type ApplyLoad struct {
 	// Inputs (set in New)
+	logger         *log.Entry
 	coreBinaryPath string
 	configPath     string
 	cfg            applyLoadConfig
 	outputPath     string // optional
 	fixturesPath   string // optional
+	workDir        string
 
-	// Populated by Run()
-	workDir                string
 	preBenchmarkCheckpoint uint32
 }
 
-func NewApplyLoad(coreBinaryPath, configPath, outputPath, fixturesPath, workDirPath string) (*ApplyLoad, error) {
+func NewApplyLoad(
+	logger *log.Entry,
+	coreBinaryPath, configPath, outputPath, fixturesPath, workDirPath string,
+) (*ApplyLoad, error) {
 	cfg, err := parseConfig(configPath)
 	if err != nil {
 		return nil, err
@@ -66,14 +70,14 @@ func (a *ApplyLoad) Cleanup() error {
 	return os.RemoveAll(a.workDir)
 }
 
-func (a *ApplyLoad) RunApplyLoadAndWrite() error {
+func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
 	// Run apply-load
 	if err := a.run(); err != nil {
 		return err
 	}
 
 	// Verify fixtures completeness before writing anything
-	if err := a.verifyFixturesCompleteness(); err != nil {
+	if err := a.verifyFixturesCompleteness(ctx); err != nil {
 		return fmt.Errorf("fixture completeness verification failed: %w", err)
 	}
 
@@ -90,7 +94,7 @@ func (a *ApplyLoad) RunApplyLoadAndWrite() error {
 
 	// Stream fixtures to output file
 	if a.fixturesPath != "" {
-		if _, err := a.streamFixturesToFile(); err != nil {
+		if _, err := a.streamFixturesToFile(ctx); err != nil {
 			return fmt.Errorf("error streaming fixtures to file: %w", err)
 		}
 	}
@@ -254,8 +258,8 @@ func (a *ApplyLoad) streamLedgersToFile() (int, error) {
 	return count, nil
 }
 
-func (a *ApplyLoad) streamFixturesToFile() (int, error) {
-	checkpointReader, err := openCheckpointReader(a.workDir, a.cfg.NetworkPassphrase, a.preBenchmarkCheckpoint)
+func (a *ApplyLoad) streamFixturesToFile(ctx context.Context) (int, error) {
+	checkpointReader, err := openCheckpointReader(ctx, a.workDir, a.cfg.NetworkPassphrase, a.preBenchmarkCheckpoint)
 	if err != nil {
 		return 0, err
 	}
@@ -315,7 +319,7 @@ func (a *ApplyLoad) streamFixturesToFile() (int, error) {
 	return count, nil
 }
 
-func (a *ApplyLoad) verifyFixturesCompleteness() error {
+func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 	if a.fixturesPath == "" {
 		return nil // no fixtures to verify
 	}
@@ -323,7 +327,7 @@ func (a *ApplyLoad) verifyFixturesCompleteness() error {
 
 	// Step 1: Load all ledger entry keys from fixtures into a set
 	knownKeys := make(map[string]bool)
-	checkpointReader, err := openCheckpointReader(a.workDir, a.cfg.NetworkPassphrase, a.preBenchmarkCheckpoint)
+	checkpointReader, err := openCheckpointReader(ctx, a.workDir, a.cfg.NetworkPassphrase, a.preBenchmarkCheckpoint)
 	if err != nil {
 		return err
 	}
@@ -428,7 +432,7 @@ func (a *ApplyLoad) verifyFixturesCompleteness() error {
 	return nil
 }
 
-func openCheckpointReader(workDir, networkPassphrase string, checkpointLedger uint32) (ingest.ChangeReader, error) {
+func openCheckpointReader(ctx context.Context, workDir, networkPassphrase string, checkpointLedger uint32) (ingest.ChangeReader, error) {
 	archivePath := filepath.Join(workDir, "history")
 	archive, err := historyarchive.Connect(
 		"file://"+archivePath,
@@ -440,7 +444,7 @@ func openCheckpointReader(workDir, networkPassphrase string, checkpointLedger ui
 		return nil, err
 	}
 
-	checkpointReader, err := ingest.NewCheckpointChangeReader(context.TODO(), archive, checkpointLedger)
+	checkpointReader, err := ingest.NewCheckpointChangeReader(ctx, archive, checkpointLedger)
 	if err != nil {
 		return nil, err
 	}

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -140,32 +140,20 @@ func (a *ApplyLoad) run(ctx context.Context) error {
 		return err
 	}
 
-	// Step 1: Initialize database
-	newDBCmd := exec.CommandContext(ctx, a.coreBinaryPath, "new-db", "--conf", destConfigPath)
-	newDBCmd.Dir = a.workDir
-	output, err := newDBCmd.CombinedOutput()
-	if err != nil {
+	if _, err := a.runCore(ctx, destConfigPath, "new-db"); err != nil {
 		return err
 	}
-
-	// Step 2: Initialize history archive
-	newHistCmd := exec.CommandContext(ctx, a.coreBinaryPath, "new-hist", a.cfg.HistoryArchiveName, "--conf", destConfigPath)
-	newHistCmd.Dir = a.workDir
-	output, err = newHistCmd.CombinedOutput()
-	if err != nil {
+	if _, err := a.runCore(ctx, destConfigPath, "new-hist", a.cfg.HistoryArchiveName); err != nil {
 		return err
 	}
 	a.logger.Infof("Initialized history archive: %s\n", a.cfg.HistoryArchiveName)
 
-	// Step 3: Execute stellar-core apply-load
-	applyLoadCmd := exec.CommandContext(ctx, a.coreBinaryPath, "apply-load", "--conf", destConfigPath)
-	applyLoadCmd.Dir = a.workDir
-	output, err = applyLoadCmd.CombinedOutput()
+	output, err := a.runCore(ctx, destConfigPath, "apply-load")
 	if err != nil {
 		return err
 	}
 
-	// Parse pre-benchmark checkpoint from stellar-core output.
+	// Parse pre-benchmark checkpoint from stellar-core's stdout.
 	// The config sets LOG_FILE_PATH="" so logs go to stdout.
 	if a.preBenchmarkCheckpoint, err = parsePreBenchmarkCheckpoint(string(output)); err != nil {
 		return err
@@ -173,6 +161,13 @@ func (a *ApplyLoad) run(ctx context.Context) error {
 	a.logger.Infof("Pre-benchmark checkpoint: ledger %d", a.preBenchmarkCheckpoint)
 
 	return nil
+}
+
+// runCore invokes a stellar-core subcommand against the copy of the config in the work dir.
+func (a *ApplyLoad) runCore(ctx context.Context, destConfigPath string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, a.coreBinaryPath, append(args, "--conf", destConfigPath)...)
+	cmd.Dir = a.workDir
+	return cmd.CombinedOutput()
 }
 
 func (a *ApplyLoad) streamLedgersToFile() (int, error) {

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -387,7 +387,8 @@ func (a *ApplyLoad) replayAndVerify(knownKeys map[string]bool) error {
 					return err
 				}
 				if !knownKeys[keyB64] {
-					return fmt.Errorf("ledger key not found in known set: %s", keyB64)
+					return fmt.Errorf("ledger key (ledger: %d, type: %v) not found in known set: %s",
+						ledger.LedgerSequence(), change.Pre.Data.Type, keyB64)
 				}
 			}
 

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -33,16 +33,10 @@ type ApplyLoad struct {
 	preBenchmarkCheckpoint uint32
 }
 
-type applyLoadConfig struct {
-	NetworkPassphrase    string
-	MetadataOutputStream string
-	HistoryArchiveName   string
-}
-
 // NewApplyLoad creates a new ApplyLoad instance with the given parameters.
 // If outputPath and fixturesPath are both set, ledgers and fixtures are written there after running apply-load.
 // If workDirPath is not set, a temporary directory will be created for stellar-core's working directory.
-// The supplied config's [HISTORY] commands must publish to ./history/ relative to the work dir
+// The supplied config's [HISTORY] commands must publish to a history/ subdirectory of the work dir.
 func NewApplyLoad(
 	logger *log.Entry,
 	coreBinaryPath, configPath, outputPath, fixturesPath, workDirPath string,
@@ -424,6 +418,12 @@ func parsePreBenchmarkCheckpoint(output string) (uint32, error) {
 	}
 
 	return uint32(ledger), nil
+}
+
+type applyLoadConfig struct {
+	NetworkPassphrase    string
+	MetadataOutputStream string
+	HistoryArchiveName   string
 }
 
 func parseConfig(configPath string) (applyLoadConfig, error) {

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -168,7 +168,11 @@ func run(ctx context.Context, opts Options, cfg applyLoadConfig) (uint32, error)
 func runCore(ctx context.Context, opts Options, configPath string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, opts.CoreBinaryPath, append(args, "--conf", configPath)...)
 	cmd.Dir = opts.WorkDirPath
-	return cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("stellar-core %s failed:\n%s\n%w", strings.Join(args, " "), out, err)
+	}
+	return out, nil
 }
 
 func streamLedgersToFile(

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -33,9 +33,16 @@ type ApplyLoad struct {
 	preBenchmarkCheckpoint uint32
 }
 
+type applyLoadConfig struct {
+	NetworkPassphrase    string
+	MetadataOutputStream string
+	HistoryArchiveName   string
+}
+
 // NewApplyLoad creates a new ApplyLoad instance with the given parameters.
 // If outputPath and fixturesPath are both set, ledgers and fixtures are written there after running apply-load.
 // If workDirPath is not set, a temporary directory will be created for stellar-core's working directory.
+// The supplied config's [HISTORY] commands must publish to ./history/ relative to the work dir
 func NewApplyLoad(
 	logger *log.Entry,
 	coreBinaryPath, configPath, outputPath, fixturesPath, workDirPath string,
@@ -166,71 +173,6 @@ func (a *ApplyLoad) run(ctx context.Context) error {
 	a.logger.Infof("Pre-benchmark checkpoint: ledger %d", a.preBenchmarkCheckpoint)
 
 	return nil
-}
-
-func parsePreBenchmarkCheckpoint(output string) (uint32, error) {
-	// This parses a purpose-built log message from stellar-core's apply-load command.
-	// It is the intended interface for communicating the pre-benchmark checkpoint boundary.
-	re := regexp.MustCompile(`Published final checkpoint before benchmark: ledger (\d+)`)
-	matches := re.FindStringSubmatch(output)
-	if matches == nil {
-		return 0, fmt.Errorf("could not find 'Published final checkpoint before benchmark' in stellar-core output")
-	}
-
-	ledger, err := strconv.ParseUint(matches[1], 10, 32)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse ledger number: %w", err)
-	}
-
-	return uint32(ledger), nil
-}
-
-type applyLoadConfig struct {
-	NetworkPassphrase    string
-	MetadataOutputStream string
-	HistoryArchiveName   string
-}
-
-func parseConfig(configPath string) (applyLoadConfig, error) {
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return applyLoadConfig{}, err
-	}
-
-	var raw map[string]any
-	err = toml.Unmarshal(data, &raw)
-	if err != nil {
-		return applyLoadConfig{}, err
-	}
-
-	passphrase, ok := raw["NETWORK_PASSPHRASE"].(string)
-	if !ok {
-		return applyLoadConfig{}, fmt.Errorf("NETWORK_PASSPHRASE not found in config")
-	}
-
-	metadataStream, ok := raw["METADATA_OUTPUT_STREAM"].(string)
-	if !ok {
-		return applyLoadConfig{}, fmt.Errorf("METADATA_OUTPUT_STREAM not found in config")
-	}
-
-	history, ok := raw["HISTORY"].(map[string]any)
-	if !ok {
-		return applyLoadConfig{}, fmt.Errorf("HISTORY section not found in config")
-	}
-	if len(history) != 1 {
-		return applyLoadConfig{}, fmt.Errorf("expected exactly one history archive in config")
-	}
-
-	var archiveName string
-	for name := range history {
-		archiveName = name
-	}
-
-	return applyLoadConfig{
-		NetworkPassphrase:    passphrase,
-		MetadataOutputStream: metadataStream,
-		HistoryArchiveName:   archiveName,
-	}, nil
 }
 
 func (a *ApplyLoad) streamLedgersToFile() (int, error) {
@@ -465,6 +407,65 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func parsePreBenchmarkCheckpoint(output string) (uint32, error) {
+	// This parses a purpose-built log message from stellar-core's apply-load command.
+	// It is the intended interface for communicating the pre-benchmark checkpoint boundary.
+	re := regexp.MustCompile(`Published final checkpoint before benchmark: ledger (\d+)`)
+	matches := re.FindStringSubmatch(output)
+	if matches == nil {
+		return 0, fmt.Errorf("could not find 'Published final checkpoint before benchmark' in stellar-core output")
+	}
+
+	ledger, err := strconv.ParseUint(matches[1], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse ledger number: %w", err)
+	}
+
+	return uint32(ledger), nil
+}
+
+func parseConfig(configPath string) (applyLoadConfig, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return applyLoadConfig{}, err
+	}
+
+	var raw map[string]any
+	err = toml.Unmarshal(data, &raw)
+	if err != nil {
+		return applyLoadConfig{}, err
+	}
+
+	passphrase, ok := raw["NETWORK_PASSPHRASE"].(string)
+	if !ok {
+		return applyLoadConfig{}, fmt.Errorf("NETWORK_PASSPHRASE not found in config")
+	}
+
+	metadataStream, ok := raw["METADATA_OUTPUT_STREAM"].(string)
+	if !ok {
+		return applyLoadConfig{}, fmt.Errorf("METADATA_OUTPUT_STREAM not found in config")
+	}
+
+	history, ok := raw["HISTORY"].(map[string]any)
+	if !ok {
+		return applyLoadConfig{}, fmt.Errorf("HISTORY section not found in config")
+	}
+	if len(history) != 1 {
+		return applyLoadConfig{}, fmt.Errorf("expected exactly one history archive in config")
+	}
+
+	var archiveName string
+	for name := range history {
+		archiveName = name
+	}
+
+	return applyLoadConfig{
+		NetworkPassphrase:    passphrase,
+		MetadataOutputStream: metadataStream,
+		HistoryArchiveName:   archiveName,
+	}, nil
 }
 
 func openCheckpointReader(ctx context.Context, workDir, networkPassphrase string, checkpointLedger uint32) (ingest.ChangeReader, error) {

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -23,172 +23,161 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
-type ApplyLoad struct {
-	// Inputs (set in New)
-	logger         *log.Entry
-	coreBinaryPath string
-	configPath     string
-	cfg            applyLoadConfig
-	outputPath     string
-	fixturesPath   string
-	workDir        string
-	cleanupWorkDir bool
-
-	preBenchmarkCheckpoint uint32
+type Options struct {
+	// inputs
+	ConfigPath     string
+	OutputPath     string
+	FixturesPath   string
+	CoreBinaryPath string     // optional, will be looked up in PATH if not set
+	WorkDirPath    string     // optional
+	Logger         *log.Entry // optional
 }
 
-// NewApplyLoad creates a new ApplyLoad instance with the given parameters.
-// outputPath and fixturesPath are required: ledgers and fixtures are written there after running apply-load.
-// If workDirPath is not set, a temporary directory will be created for stellar-core's working directory.
-// The supplied config's [HISTORY] commands must publish to a history/ subdirectory of the work dir.
-func NewApplyLoad(
-	logger *log.Entry,
-	coreBinaryPath, configPath, outputPath, fixturesPath, workDirPath string,
-) (*ApplyLoad, error) {
-	cfg, err := parseConfig(configPath)
+type Results struct {
+	PreBenchmarkCheckpoint uint32
+	CountLedgers           int
+	CountFixtures          int
+}
+
+// ApplyLoad runs stellar-core's apply-load against the supplied config and writes
+// benchmark ledgers + fixture entries to OutputPath / FixturesPath.
+//
+// Required: ConfigPath, OutputPath, FixturesPath. Optional: CoreBinaryPath
+// (looked up in PATH), Logger, WorkDirPath (temp dir if unspecified).
+// The supplied config's [HISTORY] commands must publish to a `history/`
+// subdirectory of the work dir.
+func ApplyLoad(ctx context.Context, opts Options) (Results, error) {
+	var results Results
+	createdWorkDir := (opts.WorkDirPath == "")
+
+	if err := resolveOptions(&opts); err != nil {
+		return Results{}, fmt.Errorf("invalid options: %w", err)
+	}
+	if createdWorkDir {
+		defer func() {
+			if err := os.RemoveAll(opts.WorkDirPath); err != nil {
+				opts.Logger.Warnf("failed to cleanup temporary work directory: %v", err)
+			}
+		}()
+	}
+	cfg, err := parseConfig(opts.ConfigPath)
 	if err != nil {
-		return nil, err
+		return Results{}, fmt.Errorf("failed to parse config: %w", err)
 	}
 
-	if coreBinaryPath == "" {
-		if coreBinaryPath, err = exec.LookPath("stellar-core"); err != nil {
-			return nil, fmt.Errorf("stellar-core binary unspecified and not found in PATH: %w", err)
-		}
-	}
-	coreVersion, err := ledgerbackend.CoreBuildVersion(coreBinaryPath)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't get stellar-core version: %w", err)
-	}
-	if semver.Compare(semver.Major(coreVersion), "v22") < 0 {
-		return nil, fmt.Errorf("stellar-core %s does not support apply-load, need v22 or higher", coreVersion)
-	}
-
-	if logger == nil {
-		logger = log.New()
-	}
-
-	logger.Infof("Using stellar-core: %s %s", coreBinaryPath, coreVersion)
-	logger.Infof("Using config: %s", configPath)
-
-	if outputPath == "" || fixturesPath == "" {
-		return nil, fmt.Errorf("both outputPath and fixturesPath are required")
-	}
-
-	var createdWorkDir bool
-	if workDirPath == "" {
-		var err error
-		createdWorkDir = true // Only cleanup if we created the work dir
-		workDirPath, err = os.MkdirTemp("", "apply-load-workdir-*")
-		if err != nil {
-			return nil, fmt.Errorf("failed to create temporary work directory: %w", err)
-		}
-	}
-
-	return &ApplyLoad{
-		logger:         logger,
-		coreBinaryPath: coreBinaryPath,
-		configPath:     configPath,
-		cfg:            cfg,
-		outputPath:     outputPath,
-		fixturesPath:   fixturesPath,
-		workDir:        workDirPath,
-		cleanupWorkDir: createdWorkDir,
-	}, nil
-}
-
-// Cleanup removes the working directory and all its contents.
-// Should be called after RunApplyLoadAndWrite if no separately managed work dir is used, no-ops otherwise.
-func (a *ApplyLoad) Cleanup() error {
-	if a.workDir == "" || !a.cleanupWorkDir {
-		return nil
-	}
-	return os.RemoveAll(a.workDir)
-}
-
-// RunApplyLoadAndWrite runs the apply-load process and writes outputs to outputPath and fixturesPath.
-func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
-	if err := a.run(ctx); err != nil {
-		return err
+	if results.PreBenchmarkCheckpoint, err = run(ctx, opts, cfg); err != nil {
+		return Results{}, fmt.Errorf("failed to run stellar-core commands: %w", err)
 	}
 
 	// Verify fixtures completeness before writing anything
-	if err := a.verifyFixturesCompleteness(ctx); err != nil {
-		return fmt.Errorf("fixture completeness verification failed: %w", err)
+	if err := verifyFixturesCompleteness(ctx, cfg, opts, results.PreBenchmarkCheckpoint); err != nil {
+		return Results{}, fmt.Errorf("fixture completeness verification failed: %w", err)
 	}
 
 	// Stream benchmark ledgers (after the pre-benchmark checkpoint) to output file.
 	// Setup ledgers are excluded because they would conflict with the fixtures.
-	var countLedgers, countFixtures int
-	var err error
-	countLedgers, err = a.streamLedgersToFile(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to stream ledgers to file: %w", err)
-	}
-	if countLedgers == 0 {
-		return fmt.Errorf("no benchmark ledgers found to write to file")
+	if results.CountLedgers, err = streamLedgersToFile(ctx, cfg, opts, results.PreBenchmarkCheckpoint); err != nil {
+		return Results{}, fmt.Errorf("failed to stream ledgers to file: %w", err)
+	} else if results.CountLedgers == 0 {
+		return Results{}, fmt.Errorf("no benchmark ledgers found to write to file")
 	}
 
-	countFixtures, err = a.streamFixturesToFile(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to stream fixtures to file: %w", err)
+	if results.CountFixtures, err = streamFixturesToFile(ctx, cfg, opts, results.PreBenchmarkCheckpoint); err != nil {
+		return Results{}, fmt.Errorf("failed to stream fixtures to file: %w", err)
+	} else if results.CountFixtures == 0 {
+		return Results{}, fmt.Errorf("no benchmark fixtures found to write to file")
 	}
-	if countFixtures == 0 {
-		return fmt.Errorf("no benchmark fixtures found to write to file")
+
+	return results, nil
+}
+
+// resolveOptions checks that required options are set and valid, and fills in defaults for optional ones.
+func resolveOptions(opts *Options) error {
+	if opts.ConfigPath == "" {
+		return fmt.Errorf("configPath is required")
+	}
+	if opts.OutputPath == "" || opts.FixturesPath == "" {
+		return fmt.Errorf("both outputPath and fixturesPath are required")
+	}
+
+	if opts.CoreBinaryPath == "" {
+		var err error
+		opts.CoreBinaryPath, err = exec.LookPath("stellar-core")
+		if err != nil {
+			return err
+		}
+	}
+	coreVersion, err := ledgerbackend.CoreBuildVersion(opts.CoreBinaryPath)
+	if err != nil {
+		return err
+	}
+	if semver.Compare(semver.Major(coreVersion), "v22") < 0 {
+		return fmt.Errorf("stellar-core %s does not support apply-load, need v22 or higher", coreVersion)
+	}
+
+	if opts.Logger == nil {
+		opts.Logger = log.New()
+	}
+
+	opts.Logger.Infof("Using stellar-core: %s %s", opts.CoreBinaryPath, coreVersion)
+	opts.Logger.Infof("Using config: %s", opts.ConfigPath)
+
+	if opts.WorkDirPath == "" {
+		var err error
+		opts.WorkDirPath, err = os.MkdirTemp("", "apply-load-workdir-*")
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 // run executes the stellar-core apply-load command and captures the pre-benchmark checkpoint from its output.
-func (a *ApplyLoad) run(ctx context.Context) error {
+func run(ctx context.Context, opts Options, cfg applyLoadConfig) (uint32, error) {
 	// Copy config to work dir (apply-load writes files relative to config location)
-	destConfigPath := filepath.Join(a.workDir, "apply-load.cfg")
-	if err := copyFile(a.configPath, destConfigPath); err != nil {
-		return err
+	destConfigPath := filepath.Join(opts.WorkDirPath, "apply-load.cfg")
+	if err := copyFile(opts.ConfigPath, destConfigPath); err != nil {
+		return 0, err
 	}
 
-	if _, err := a.runCore(ctx, destConfigPath, "new-db"); err != nil {
-		return err
+	if _, err := runCore(ctx, opts, destConfigPath, "new-db"); err != nil {
+		return 0, err
 	}
-	if _, err := a.runCore(ctx, destConfigPath, "new-hist", a.cfg.HistoryArchiveName); err != nil {
-		return err
+	if _, err := runCore(ctx, opts, destConfigPath, "new-hist", cfg.HistoryArchiveName); err != nil {
+		return 0, err
 	}
-	a.logger.Infof("Initialized history archive: %s\n", a.cfg.HistoryArchiveName)
+	opts.Logger.Infof("Initialized history archive: %s", cfg.HistoryArchiveName)
 
-	output, err := a.runCore(ctx, destConfigPath, "apply-load")
+	output, err := runCore(ctx, opts, destConfigPath, "apply-load")
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	// Parse pre-benchmark checkpoint from stellar-core's stdout.
 	// The config sets LOG_FILE_PATH="" so logs go to stdout.
-	if a.preBenchmarkCheckpoint, err = parsePreBenchmarkCheckpoint(string(output)); err != nil {
-		return err
+	preBenchmarkCheckpoint, err := parsePreBenchmarkCheckpoint(string(output))
+	if err != nil {
+		return 0, err
 	}
-	a.logger.Infof("Pre-benchmark checkpoint: ledger %d", a.preBenchmarkCheckpoint)
+	opts.Logger.Infof("Pre-benchmark checkpoint: ledger %d", preBenchmarkCheckpoint)
 
-	return nil
+	return preBenchmarkCheckpoint, nil
 }
 
 // runCore invokes a stellar-core subcommand against the copy of the config in the work dir.
-func (a *ApplyLoad) runCore(ctx context.Context, destConfigPath string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, a.coreBinaryPath, append(args, "--conf", destConfigPath)...)
-	cmd.Dir = a.workDir
+func runCore(ctx context.Context, opts Options, configPath string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, opts.CoreBinaryPath, append(args, "--conf", configPath)...)
+	cmd.Dir = opts.WorkDirPath
 	return cmd.CombinedOutput()
 }
 
-// metadataPath resolves cfg.MetadataOutputStream against the work dir, rejecting
-// absolute paths or `..` traversals that would escape it.
-func (a *ApplyLoad) metadataPath() (string, error) {
-	cleanWorkDir := filepath.Clean(a.workDir)
-	p := filepath.Join(cleanWorkDir, a.cfg.MetadataOutputStream)
-	if p != cleanWorkDir && !strings.HasPrefix(p, cleanWorkDir+string(filepath.Separator)) {
-		return "", fmt.Errorf("METADATA_OUTPUT_STREAM %q escapes work dir", a.cfg.MetadataOutputStream)
-	}
-	return p, nil
-}
-
-func (a *ApplyLoad) streamLedgersToFile(ctx context.Context) (int, error) {
-	metadataPath, err := a.metadataPath()
+func streamLedgersToFile(
+	ctx context.Context,
+	cfg applyLoadConfig,
+	opts Options,
+	preBenchmarkCheckpoint uint32,
+) (int, error) {
+	metadataPath, err := resolveMetadataPath(opts.WorkDirPath, cfg.MetadataOutputStream)
 	if err != nil {
 		return 0, err
 	}
@@ -200,7 +189,7 @@ func (a *ApplyLoad) streamLedgersToFile(ctx context.Context) (int, error) {
 	// Note: xdr.Stream closes the underlying reader when ReadOne hits EOF or error
 	stream := xdr.NewStream(inFile)
 
-	outFile, err := os.Create(a.outputPath)
+	outFile, err := os.Create(opts.OutputPath)
 	if err != nil {
 		return 0, err
 	}
@@ -231,7 +220,7 @@ func (a *ApplyLoad) streamLedgersToFile(ctx context.Context) (int, error) {
 
 		// Skip setup ledgers (ledgers up to and including the pre-benchmark checkpoint).
 		// Only include benchmark ledgers which operate on the fixture state.
-		if ledger.LedgerSequence() <= a.preBenchmarkCheckpoint {
+		if ledger.LedgerSequence() <= preBenchmarkCheckpoint {
 			skipped++
 			continue
 		}
@@ -242,21 +231,26 @@ func (a *ApplyLoad) streamLedgersToFile(ctx context.Context) (int, error) {
 		count++
 	}
 
-	a.logger.Infof("Wrote %d benchmark ledgers, skipped %d setup ledgers", count, skipped)
+	opts.Logger.Infof("Wrote %d benchmark ledgers, skipped %d setup ledgers", count, skipped)
 	return count, nil
 }
 
-func (a *ApplyLoad) streamFixturesToFile(ctx context.Context) (int, error) {
-	checkpointReader, err := openCheckpointReader(ctx, a.workDir, a.cfg.NetworkPassphrase, a.preBenchmarkCheckpoint)
+func streamFixturesToFile(
+	ctx context.Context,
+	cfg applyLoadConfig,
+	opts Options,
+	preBenchmarkCheckpoint uint32,
+) (int, error) {
+	checkpointReader, err := openCheckpointReader(ctx, opts.WorkDirPath, cfg.NetworkPassphrase, preBenchmarkCheckpoint)
 	if err != nil {
 		return 0, err
 	}
 	defer checkpointReader.Close()
 
 	// Compute root account to filter it out (exists in any network with this passphrase)
-	rootAccountID := keypair.Root(a.cfg.NetworkPassphrase).Address()
+	rootAccountID := keypair.Root(cfg.NetworkPassphrase).Address()
 
-	outFile, err := os.Create(a.fixturesPath)
+	outFile, err := os.Create(opts.FixturesPath)
 	if err != nil {
 		return 0, err
 	}
@@ -309,31 +303,36 @@ func (a *ApplyLoad) streamFixturesToFile(ctx context.Context) (int, error) {
 		}
 	}
 
-	a.logger.Infof("Wrote %d entries, skipped %d protocol entries", count, skipped)
+	opts.Logger.Infof("Wrote %d entries, skipped %d protocol entries", count, skipped)
 	return count, nil
 }
 
 func encodeKey(e *xdr.LedgerEntry) (string, error) {
 	k, err := e.LedgerKey()
 	if err != nil {
-		return "", fmt.Errorf("couldn't get ledger key: %w", err)
+		return "", err
 	}
 	return k.MarshalBinaryBase64()
 }
 
-func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
-	knownKeys, err := a.loadFixtureKeys(ctx)
+func verifyFixturesCompleteness(ctx context.Context, cfg applyLoadConfig, opts Options, preBenchmarkCheckpoint uint32) error {
+	knownKeys, err := loadFixtureKeys(ctx, cfg, opts.WorkDirPath, preBenchmarkCheckpoint)
 	if err != nil {
 		return err
 	}
-	a.logger.Infof("Loaded %d fixture keys into verification set", len(knownKeys))
-	return a.replayAndVerify(ctx, knownKeys)
+	opts.Logger.Infof("Loaded %d fixture keys into verification set", len(knownKeys))
+	return replayAndVerify(ctx, cfg, opts, preBenchmarkCheckpoint, knownKeys)
 }
 
 // loadFixtureKeys returns the set of ledger entry keys present at preBenchmarkCheckpoint.
-func (a *ApplyLoad) loadFixtureKeys(ctx context.Context) (map[string]bool, error) {
+func loadFixtureKeys(
+	ctx context.Context,
+	cfg applyLoadConfig,
+	workDir string,
+	preBenchmarkCheckpoint uint32,
+) (map[string]bool, error) {
 	knownKeys := make(map[string]bool)
-	checkpointReader, err := openCheckpointReader(ctx, a.workDir, a.cfg.NetworkPassphrase, a.preBenchmarkCheckpoint)
+	checkpointReader, err := openCheckpointReader(ctx, workDir, cfg.NetworkPassphrase, preBenchmarkCheckpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -359,8 +358,14 @@ func (a *ApplyLoad) loadFixtureKeys(ctx context.Context) (map[string]bool, error
 
 // replayAndVerify streams the benchmark ledgers and asserts every Pre referenced
 // exists in knownKeys, mutating knownKeys to track Post adds and deletes.
-func (a *ApplyLoad) replayAndVerify(ctx context.Context, knownKeys map[string]bool) error {
-	metadataPath, err := a.metadataPath()
+func replayAndVerify(
+	ctx context.Context,
+	cfg applyLoadConfig,
+	opts Options,
+	preBenchmarkCheckpoint uint32,
+	knownKeys map[string]bool,
+) error {
+	metadataPath, err := resolveMetadataPath(opts.WorkDirPath, cfg.MetadataOutputStream)
 	if err != nil {
 		return err
 	}
@@ -385,11 +390,11 @@ func (a *ApplyLoad) replayAndVerify(ctx context.Context, knownKeys map[string]bo
 		}
 
 		// Skip setup ledgers
-		if ledger.LedgerSequence() <= a.preBenchmarkCheckpoint {
+		if ledger.LedgerSequence() <= preBenchmarkCheckpoint {
 			continue
 		}
 
-		changeReader, err := ingest.NewLedgerChangeReaderFromLedgerCloseMeta(a.cfg.NetworkPassphrase, ledger)
+		changeReader, err := ingest.NewLedgerChangeReaderFromLedgerCloseMeta(cfg.NetworkPassphrase, ledger)
 		if err != nil {
 			return err
 		}
@@ -437,6 +442,17 @@ func (a *ApplyLoad) replayAndVerify(ctx context.Context, knownKeys map[string]bo
 		}
 	}
 	return nil
+}
+
+// resolveMetadataPath resolves cfg.MetadataOutputStream against the work dir, rejecting
+// absolute paths or `..` traversals that would escape it.
+func resolveMetadataPath(workDir, metadataOutputStream string) (string, error) {
+	cleanWorkDir := filepath.Clean(workDir)
+	p := filepath.Join(cleanWorkDir, metadataOutputStream)
+	if p != cleanWorkDir && !strings.HasPrefix(p, cleanWorkDir+string(filepath.Separator)) {
+		return "", fmt.Errorf("METADATA_OUTPUT_STREAM %q escapes work dir", metadataOutputStream)
+	}
+	return p, nil
 }
 
 func parsePreBenchmarkCheckpoint(output string) (uint32, error) {
@@ -504,7 +520,11 @@ func parseConfig(configPath string) (applyLoadConfig, error) {
 	}, nil
 }
 
-func openCheckpointReader(ctx context.Context, workDir, networkPassphrase string, checkpointLedger uint32) (ingest.ChangeReader, error) {
+func openCheckpointReader(
+	ctx context.Context,
+	workDir, networkPassphrase string,
+	checkpointLedger uint32,
+) (ingest.ChangeReader, error) {
 	archivePath := filepath.Join(workDir, "history")
 	archive, err := historyarchive.Connect(
 		"file://"+archivePath,

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -115,7 +115,7 @@ func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
 	// Setup ledgers are excluded because they would conflict with the fixtures.
 	var countLedgers, countFixtures int
 	var err error
-	countLedgers, err = a.streamLedgersToFile()
+	countLedgers, err = a.streamLedgersToFile(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to stream ledgers to file: %w", err)
 	}
@@ -182,7 +182,7 @@ func (a *ApplyLoad) metadataPath() (string, error) {
 	return p, nil
 }
 
-func (a *ApplyLoad) streamLedgersToFile() (int, error) {
+func (a *ApplyLoad) streamLedgersToFile(ctx context.Context) (int, error) {
 	metadataPath, err := a.metadataPath()
 	if err != nil {
 		return 0, err
@@ -211,6 +211,12 @@ func (a *ApplyLoad) streamLedgersToFile() (int, error) {
 	skipped := 0
 
 	for {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+		}
+
 		var ledger xdr.LedgerCloseMeta
 		if err := stream.ReadOne(&ledger); err == io.EOF {
 			break
@@ -260,6 +266,12 @@ func (a *ApplyLoad) streamFixturesToFile(ctx context.Context) (int, error) {
 	count := 0
 	skipped := 0
 	for {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+		}
+
 		change, err := checkpointReader.Read()
 		if err == io.EOF {
 			break
@@ -310,7 +322,7 @@ func (a *ApplyLoad) verifyFixturesCompleteness(ctx context.Context) error {
 		return err
 	}
 	a.logger.Infof("Loaded %d fixture keys into verification set", len(knownKeys))
-	return a.replayAndVerify(knownKeys)
+	return a.replayAndVerify(ctx, knownKeys)
 }
 
 // loadFixtureKeys returns the set of ledger entry keys present at preBenchmarkCheckpoint.
@@ -342,7 +354,7 @@ func (a *ApplyLoad) loadFixtureKeys(ctx context.Context) (map[string]bool, error
 
 // replayAndVerify streams the benchmark ledgers and asserts every Pre referenced
 // exists in knownKeys, mutating knownKeys to track Post adds and deletes.
-func (a *ApplyLoad) replayAndVerify(knownKeys map[string]bool) error {
+func (a *ApplyLoad) replayAndVerify(ctx context.Context, knownKeys map[string]bool) error {
 	metadataPath, err := a.metadataPath()
 	if err != nil {
 		return err
@@ -354,6 +366,12 @@ func (a *ApplyLoad) replayAndVerify(knownKeys map[string]bool) error {
 	stream := xdr.NewStream(file)
 
 	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
 		var ledger xdr.LedgerCloseMeta
 		if err := stream.ReadOne(&ledger); err == io.EOF {
 			break

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -1,0 +1,460 @@
+package loadtest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"github.com/BurntSushi/toml"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stellar/go-stellar-sdk/historyarchive"
+	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+type ApplyLoad struct {
+	// Inputs (set in New)
+	coreBinaryPath string
+	configPath     string
+	cfg            applyLoadConfig
+	outputPath     string // optional
+	fixturesPath   string // optional
+
+	// Populated by Run()
+	workDir                string
+	preBenchmarkCheckpoint uint32
+}
+
+func NewApplyLoad(coreBinaryPath, configPath, outputPath, fixturesPath, workDirPath string) (*ApplyLoad, error) {
+	cfg, err := parseConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if (outputPath != "") != (fixturesPath != "") {
+		return nil, fmt.Errorf("outputPath and fixturesPath must both be set or both be empty")
+	}
+
+	if workDirPath == "" {
+		var err error
+		workDirPath, err = os.MkdirTemp("", "apply-load-workdir-*")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temporary work directory: %w", err)
+		}
+	}
+
+	return &ApplyLoad{
+		coreBinaryPath: coreBinaryPath,
+		configPath:     configPath,
+		cfg:            cfg,
+		outputPath:     outputPath,
+		fixturesPath:   fixturesPath,
+		workDir:        workDirPath,
+	}, nil
+}
+
+func (a *ApplyLoad) Cleanup() error {
+	if a.workDir == "" {
+		return nil
+	}
+	return os.RemoveAll(a.workDir)
+}
+
+func (a *ApplyLoad) RunApplyLoadAndWrite() error {
+	// Run apply-load
+	if err := a.run(); err != nil {
+		return err
+	}
+
+	// Verify fixtures completeness before writing anything
+	if err := a.verifyFixturesCompleteness(); err != nil {
+		return fmt.Errorf("fixture completeness verification failed: %w", err)
+	}
+
+	// Stream ledgers to output file or just count them for verification
+	// Only include benchmark ledgers (after the pre-benchmark checkpoint),
+	// as setup ledgers would conflict with the fixtures.
+	if a.outputPath != "" {
+		if count, err := a.streamLedgersToFile(); err != nil {
+			return fmt.Errorf("error streaming ledgers to file: %w", err)
+		} else if count == 0 {
+			return fmt.Errorf("no benchmark ledgers found to write to file")
+		}
+	}
+
+	// Stream fixtures to output file
+	if a.fixturesPath != "" {
+		if _, err := a.streamFixturesToFile(); err != nil {
+			return fmt.Errorf("error streaming fixtures to file: %w", err)
+		}
+	}
+	return nil
+}
+
+func (a *ApplyLoad) run() error {
+	// Copy config to work dir (apply-load writes files relative to config location)
+	destConfigPath := filepath.Join(a.workDir, "apply-load.cfg")
+	if err := copyFile(a.configPath, destConfigPath); err != nil {
+		return fmt.Errorf("failed to copy config file: %w", err)
+	}
+
+	// Step 1: Initialize database
+	newDBCmd := exec.Command(a.coreBinaryPath, "new-db", "--conf", destConfigPath)
+	newDBCmd.Dir = a.workDir
+	output, err := newDBCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("new-db failed:\noutput: %s\nerror: %w", string(output), err)
+	}
+
+	// Step 2: Initialize history archive
+	newHistCmd := exec.Command(a.coreBinaryPath, "new-hist", a.cfg.HistoryArchiveName, "--conf", destConfigPath)
+	newHistCmd.Dir = a.workDir
+	output, err = newHistCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("new-hist failed:\noutput: %s\nerror: %w", string(output), err)
+	}
+	// fmt.Printf("Initialized history archive: %s\n", cfg.HistoryArchiveName)
+
+	// Step 3: Execute stellar-core apply-load
+	applyLoadCmd := exec.Command(a.coreBinaryPath, "apply-load", "--conf", destConfigPath)
+	applyLoadCmd.Dir = a.workDir
+	output, err = applyLoadCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("apply-load failed:\noutput: %s\nerror: %w", string(output), err)
+	}
+
+	// Parse pre-benchmark checkpoint from stellar-core output.
+	// The config sets LOG_FILE_PATH="" so logs go to stdout.
+	if a.preBenchmarkCheckpoint, err = parsePreBenchmarkCheckpoint(string(output)); err != nil {
+		return fmt.Errorf("failed to parse pre-benchmark checkpoint: %w", err)
+	}
+
+	return nil
+}
+
+func parsePreBenchmarkCheckpoint(output string) (uint32, error) {
+	// This parses a purpose-built log message from stellar-core's apply-load command.
+	// It is the intended interface for communicating the pre-benchmark checkpoint boundary.
+	re := regexp.MustCompile(`Published final checkpoint before benchmark: ledger (\d+)`)
+	matches := re.FindStringSubmatch(output)
+	if matches == nil {
+		return 0, fmt.Errorf("could not find 'Published final checkpoint before benchmark' in stellar-core output")
+	}
+
+	ledger, err := strconv.ParseUint(matches[1], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse ledger number: %w", err)
+	}
+
+	return uint32(ledger), nil
+}
+
+type applyLoadConfig struct {
+	NetworkPassphrase    string
+	MetadataOutputStream string
+	HistoryArchiveName   string
+}
+
+func parseConfig(configPath string) (applyLoadConfig, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return applyLoadConfig{}, err
+	}
+
+	var raw map[string]any
+	err = toml.Unmarshal(data, &raw)
+	if err != nil {
+		return applyLoadConfig{}, err
+	}
+
+	passphrase, ok := raw["NETWORK_PASSPHRASE"].(string)
+	if !ok {
+		return applyLoadConfig{}, fmt.Errorf("NETWORK_PASSPHRASE not found in config")
+	}
+
+	metadataStream, ok := raw["METADATA_OUTPUT_STREAM"].(string)
+	if !ok {
+		return applyLoadConfig{}, fmt.Errorf("METADATA_OUTPUT_STREAM not found in config")
+	}
+
+	history, ok := raw["HISTORY"].(map[string]any)
+	if !ok {
+		return applyLoadConfig{}, fmt.Errorf("HISTORY section not found in config")
+	}
+	if len(history) != 1 {
+		return applyLoadConfig{}, fmt.Errorf("expected exactly one history archive in config")
+	}
+
+	var archiveName string
+	for name := range history {
+		archiveName = name
+	}
+
+	return applyLoadConfig{
+		NetworkPassphrase:    passphrase,
+		MetadataOutputStream: metadataStream,
+		HistoryArchiveName:   archiveName,
+	}, nil
+}
+
+func (a *ApplyLoad) streamLedgersToFile() (int, error) {
+	metadataPath := filepath.Join(a.workDir, a.cfg.MetadataOutputStream)
+	inFile, err := os.Open(metadataPath)
+	if err != nil {
+		return 0, err
+	}
+	defer inFile.Close()
+
+	// Note: xdr.Stream closes the underlying reader when ReadOne hits EOF or error
+	stream := xdr.NewStream(inFile)
+
+	outFile, err := os.Create(a.outputPath)
+	if err != nil {
+		return 0, err
+	}
+	defer outFile.Close()
+
+	writer, err := zstd.NewWriter(outFile)
+	if err != nil {
+		return 0, err
+	}
+	defer writer.Close()
+
+	count := 0
+	skipped := 0
+
+	for {
+		var ledger xdr.LedgerCloseMeta
+		if err := stream.ReadOne(&ledger); err == io.EOF {
+			break
+		} else if err != nil {
+			return 0, err
+		}
+
+		// Skip setup ledgers (ledgers up to and including the pre-benchmark checkpoint).
+		// Only include benchmark ledgers which operate on the fixture state.
+		if ledger.LedgerSequence() <= a.preBenchmarkCheckpoint {
+			skipped++
+			continue
+		}
+
+		if err := xdr.MarshalFramed(writer, ledger); err != nil {
+			return 0, err
+		}
+		count++
+	}
+
+	// t.Logf("Wrote %d benchmark ledgers, skipped %d setup ledgers", count, skipped)
+	return count, nil
+}
+
+func (a *ApplyLoad) streamFixturesToFile() (int, error) {
+	checkpointReader, err := openCheckpointReader(a.workDir, a.cfg.NetworkPassphrase, a.preBenchmarkCheckpoint)
+	if err != nil {
+		return 0, err
+	}
+	defer checkpointReader.Close()
+
+	// Compute root account to filter it out (exists in any network with this passphrase)
+	rootAccountID := keypair.Root(a.cfg.NetworkPassphrase).Address()
+
+	outFile, err := os.Create(a.fixturesPath)
+	if err != nil {
+		return 0, err
+	}
+	defer outFile.Close()
+
+	writer, err := zstd.NewWriter(outFile)
+	if err != nil {
+		return 0, err
+	}
+	defer writer.Close()
+
+	count := 0
+	skipped := 0
+	for {
+		change, err := checkpointReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, err
+		}
+
+		if change.Post != nil {
+			entry := change.Post
+
+			// Skip protocol-level entries that would conflict with existing DB state:
+			// 1. Config settings - exist in any network
+			// 2. Root account - derived from network passphrase, created at genesis
+			if entry.Data.Type == xdr.LedgerEntryTypeConfigSetting {
+				skipped++
+				continue
+			}
+			if entry.Data.Type == xdr.LedgerEntryTypeAccount {
+				if entry.Data.Account.AccountId.Address() == rootAccountID {
+					skipped++
+					continue
+				}
+			}
+
+			if err := xdr.MarshalFramed(writer, entry); err != nil {
+				return 0, err
+			}
+			count++
+		}
+	}
+
+	// t.Logf("Wrote %d entries, skipped %d protocol entries", count, skipped)
+	return count, nil
+}
+
+func (a *ApplyLoad) verifyFixturesCompleteness() error {
+	if a.fixturesPath == "" {
+		return nil // no fixtures to verify
+	}
+	metadataPath := filepath.Join(a.workDir, a.cfg.MetadataOutputStream)
+
+	// Step 1: Load all ledger entry keys from fixtures into a set
+	knownKeys := make(map[string]bool)
+	checkpointReader, err := openCheckpointReader(a.workDir, a.cfg.NetworkPassphrase, a.preBenchmarkCheckpoint)
+	if err != nil {
+		return err
+	}
+	defer checkpointReader.Close()
+
+	for {
+		var change ingest.Change
+		var err error
+		if change, err = checkpointReader.Read(); err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		if change.Post != nil {
+			key, err := change.Post.LedgerKey()
+			if err != nil {
+				return err
+			}
+			keyB64, err := key.MarshalBinaryBase64()
+			if err != nil {
+				return err
+			}
+			knownKeys[keyB64] = true
+		}
+	}
+
+	// Step 2: Stream through generated ledgers and verify each change
+	file, err := os.Open(metadataPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	stream := xdr.NewStream(file)
+
+	for {
+		var ledger xdr.LedgerCloseMeta
+		if err := stream.ReadOne(&ledger); err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		// Extract changes from this ledger
+		changeReader, err := ingest.NewLedgerChangeReaderFromLedgerCloseMeta(a.cfg.NetworkPassphrase, ledger)
+		if err != nil {
+			return fmt.Errorf("error creating change reader: %w", err)
+		}
+
+		for {
+			change, err := changeReader.Read()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("error reading change: %w", err)
+			}
+
+			// If the change has a Pre state, the entry must already exist in our known set
+			if change.Pre != nil {
+				key, err := change.Pre.LedgerKey()
+				if err != nil {
+					return fmt.Errorf("error getting ledger key: %w", err)
+				}
+				keyB64, err := key.MarshalBinaryBase64()
+				if err != nil {
+					return fmt.Errorf("error marshalling ledger key: %w", err)
+				}
+				if !knownKeys[keyB64] {
+					return fmt.Errorf("ledger key not found in known set: %s", keyB64)
+				}
+			}
+
+			// Update our known set based on the Post state
+			if change.Post != nil {
+				// Entry exists after this change - add/keep in set
+				key, err := change.Post.LedgerKey()
+				if err != nil {
+					return fmt.Errorf("error getting ledger key: %w", err)
+				}
+				keyB64, err := key.MarshalBinaryBase64()
+				if err != nil {
+					return fmt.Errorf("error marshalling ledger key: %w", err)
+				}
+				knownKeys[keyB64] = true
+			} else if change.Pre != nil {
+				// Entry was deleted - remove from set
+				key, err := change.Pre.LedgerKey()
+				if err != nil {
+					return fmt.Errorf("error getting ledger key: %w", err)
+				}
+				keyB64, err := key.MarshalBinaryBase64()
+				if err != nil {
+					return fmt.Errorf("error marshalling ledger key: %w", err)
+				}
+				delete(knownKeys, keyB64)
+			}
+		}
+		if err := changeReader.Close(); err != nil {
+			return fmt.Errorf("error closing change reader: %w", err)
+		}
+	}
+	return nil
+}
+
+func openCheckpointReader(workDir, networkPassphrase string, checkpointLedger uint32) (ingest.ChangeReader, error) {
+	archivePath := filepath.Join(workDir, "history")
+	archive, err := historyarchive.Connect(
+		"file://"+archivePath,
+		historyarchive.ArchiveOptions{
+			NetworkPassphrase: networkPassphrase,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	checkpointReader, err := ingest.NewCheckpointChangeReader(context.TODO(), archive, checkpointLedger)
+	if err != nil {
+		return nil, err
+	}
+
+	return checkpointReader, nil
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		return err
+	}
+	return nil
+}

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -54,6 +54,11 @@ func NewApplyLoad(
 	if err != nil {
 		return nil, fmt.Errorf("error getting stellar-core version: %w", err)
 	}
+
+	if logger == nil {
+		logger = log.New()
+	}
+
 	logger.Infof("Using stellar-core: %s %s", coreBinaryPath, coreVersion)
 	logger.Infof("Using config: %s", configPath)
 
@@ -67,10 +72,6 @@ func NewApplyLoad(
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temporary work directory: %w", err)
 		}
-	}
-
-	if logger == nil {
-		logger = log.New()
 	}
 
 	return &ApplyLoad{
@@ -95,7 +96,7 @@ func (a *ApplyLoad) Cleanup() error {
 // RunApplyLoadAndWrite runs the apply-load process and writes outputs to files if paths are set.
 func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
 	// Run apply-load
-	if err := a.run(); err != nil {
+	if err := a.run(ctx); err != nil {
 		return err
 	}
 
@@ -125,7 +126,7 @@ func (a *ApplyLoad) RunApplyLoadAndWrite(ctx context.Context) error {
 }
 
 // run executes the stellar-core apply-load command and captures the pre-benchmark checkpoint from its output.
-func (a *ApplyLoad) run() error {
+func (a *ApplyLoad) run(ctx context.Context) error {
 	// Copy config to work dir (apply-load writes files relative to config location)
 	destConfigPath := filepath.Join(a.workDir, "apply-load.cfg")
 	if err := copyFile(a.configPath, destConfigPath); err != nil {
@@ -133,7 +134,7 @@ func (a *ApplyLoad) run() error {
 	}
 
 	// Step 1: Initialize database
-	newDBCmd := exec.Command(a.coreBinaryPath, "new-db", "--conf", destConfigPath)
+	newDBCmd := exec.CommandContext(ctx, a.coreBinaryPath, "new-db", "--conf", destConfigPath)
 	newDBCmd.Dir = a.workDir
 	output, err := newDBCmd.CombinedOutput()
 	if err != nil {
@@ -141,7 +142,7 @@ func (a *ApplyLoad) run() error {
 	}
 
 	// Step 2: Initialize history archive
-	newHistCmd := exec.Command(a.coreBinaryPath, "new-hist", a.cfg.HistoryArchiveName, "--conf", destConfigPath)
+	newHistCmd := exec.CommandContext(ctx, a.coreBinaryPath, "new-hist", a.cfg.HistoryArchiveName, "--conf", destConfigPath)
 	newHistCmd.Dir = a.workDir
 	output, err = newHistCmd.CombinedOutput()
 	if err != nil {
@@ -150,7 +151,7 @@ func (a *ApplyLoad) run() error {
 	a.logger.Infof("Initialized history archive: %s\n", a.cfg.HistoryArchiveName)
 
 	// Step 3: Execute stellar-core apply-load
-	applyLoadCmd := exec.Command(a.coreBinaryPath, "apply-load", "--conf", destConfigPath)
+	applyLoadCmd := exec.CommandContext(ctx, a.coreBinaryPath, "apply-load", "--conf", destConfigPath)
 	applyLoadCmd.Dir = a.workDir
 	output, err = applyLoadCmd.CombinedOutput()
 	if err != nil {

--- a/ingest/loadtest/apply_load.go
+++ b/ingest/loadtest/apply_load.go
@@ -86,7 +86,8 @@ func NewApplyLoad(
 	}, nil
 }
 
-// Cleanup removes the working directory and all its contents. Should be called after RunApplyLoadAndWrite.
+// Cleanup removes the working directory and all its contents.
+// Should be called after RunApplyLoadAndWrite if no separately managed work dir is used.
 func (a *ApplyLoad) Cleanup() error {
 	if a.workDir == "" {
 		return nil

--- a/ingest/loadtest/apply_load_test.go
+++ b/ingest/loadtest/apply_load_test.go
@@ -59,7 +59,7 @@ func TestParsePreBenchmarkCheckpoint(t *testing.T) {
 // shipped with this package. Updating default-apply-load.cfg without
 // updating the expected values here will fail this test.
 func TestParseConfig_DefaultCfg(t *testing.T) {
-	got, err := parseConfig("default-apply-load.cfg")
+	got, err := parseConfig("testdata/default-apply-load.cfg")
 	require.NoError(t, err)
 	assert.Equal(t, applyLoadConfig{
 		NetworkPassphrase:    "load test network",

--- a/ingest/loadtest/apply_load_test.go
+++ b/ingest/loadtest/apply_load_test.go
@@ -1,0 +1,133 @@
+package loadtest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePreBenchmarkCheckpoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		want    uint32
+		wantErr bool
+	}{
+		{
+			name:   "bare line",
+			output: "Published final checkpoint before benchmark: ledger 1234\n",
+			want:   1234,
+		},
+		{
+			name: "embedded in multi-line log output",
+			output: strings.Join([]string{
+				"2026-05-05T12:34:56 [INFO] starting apply-load",
+				"2026-05-05T12:35:00 [INFO] Published final checkpoint before benchmark: ledger 42",
+				"2026-05-05T12:35:01 [INFO] benchmark phase begins",
+			}, "\n"),
+			want: 42,
+		},
+		{
+			name:    "non-numeric ledger",
+			output:  "Published final checkpoint before benchmark: ledger abc",
+			wantErr: true,
+		},
+		{
+			name:    "empty input",
+			output:  "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePreBenchmarkCheckpoint(tt.output)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestParseConfig_DefaultCfg pins the parsed shape of the default config
+// shipped with this package. Updating default-apply-load.cfg without
+// updating the expected values here will fail this test.
+func TestParseConfig_DefaultCfg(t *testing.T) {
+	got, err := parseConfig("default-apply-load.cfg")
+	require.NoError(t, err)
+	assert.Equal(t, applyLoadConfig{
+		NetworkPassphrase:    "load test network",
+		MetadataOutputStream: "meta.xdr",
+		HistoryArchiveName:   "local",
+	}, got)
+}
+
+func TestParseConfig_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		wantErr  string // substring; empty means expect any non-nil error
+	}{
+		{
+			name: "missing NETWORK_PASSPHRASE",
+			contents: `
+METADATA_OUTPUT_STREAM = "metadata.xdr"
+[HISTORY.local]
+get   = "cp history/{0} {1}"
+`,
+			wantErr: "NETWORK_PASSPHRASE",
+		},
+		{
+			name: "missing METADATA_OUTPUT_STREAM",
+			contents: `
+NETWORK_PASSPHRASE = "x"
+[HISTORY.local]
+get   = "cp history/{0} {1}"
+`,
+			wantErr: "METADATA_OUTPUT_STREAM",
+		},
+		{
+			name: "missing HISTORY section",
+			contents: `
+NETWORK_PASSPHRASE = "x"
+METADATA_OUTPUT_STREAM = "metadata.xdr"
+`,
+			wantErr: "HISTORY",
+		},
+		{
+			name: "multiple history archives rejected",
+			contents: `
+NETWORK_PASSPHRASE = "x"
+METADATA_OUTPUT_STREAM = "metadata.xdr"
+[HISTORY.local]
+get = "cp history/{0} {1}"
+[HISTORY.backup]
+get = "cp history/{0} {1}"
+`,
+			wantErr: "exactly one history archive",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "apply-load.cfg")
+			require.NoError(t, os.WriteFile(path, []byte(tt.contents), 0o644))
+
+			_, err := parseConfig(path)
+			require.Error(t, err)
+			if tt.wantErr != "" {
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseConfig_FileNotFound(t *testing.T) {
+	_, err := parseConfig(filepath.Join(t.TempDir(), "does-not-exist.cfg"))
+	require.Error(t, err)
+}

--- a/ingest/loadtest/default-apply-load.cfg
+++ b/ingest/loadtest/default-apply-load.cfg
@@ -1,0 +1,145 @@
+# Default apply-load configuration for TestGenerateLedgers
+#
+# Based on: https://github.com/stellar/stellar-core/blob/d458d90d7df3031bd6e1f12d95b027d073caa0e1/docs/apply-load-for-meta.cfg
+# Override with LOADTEST_CORE_CONFIG_PATH env var for custom configurations.
+#
+# Differences from upstream:
+#   - NETWORK_PASSPHRASE: "load test network" (instead of "Standalone Network ; February 2017")
+#   - PARALLEL_LEDGER_APPLY: removed (unknown config option in some stellar-core versions)
+#   - LOG_FILE_PATH: "" (log to stdout so we can parse the pre-benchmark checkpoint)
+#   - APPLY_LOAD_NUM_LEDGERS: 30 (instead of 100, for faster test runs; 30 is core minimum)
+#   - APPLY_LOAD_CLASSIC_TXS_PER_LEDGER: 10 (instead of 1000, to keep fixture files small)
+
+# Custom meta path - if not set it will be written to a temp directory and
+# cleaned up after running the benchmark
+METADATA_OUTPUT_STREAM='meta.xdr'
+
+# Enable load generation
+ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true
+
+# Diagnostic events should generally be disabled, but can be enabled for debug
+ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = false
+
+# Network configuration to use during the benchmark
+# The fields here correspond to the network configuration settings.
+APPLY_LOAD_LEDGER_MAX_INSTRUCTIONS = 500000000
+APPLY_LOAD_TX_MAX_INSTRUCTIONS = 100000000
+
+APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS = 1
+
+APPLY_LOAD_TX_MAX_FOOTPRINT_SIZE = 200
+
+APPLY_LOAD_LEDGER_MAX_DISK_READ_LEDGER_ENTRIES = 1000
+APPLY_LOAD_TX_MAX_DISK_READ_LEDGER_ENTRIES = 100
+
+APPLY_LOAD_LEDGER_MAX_DISK_READ_BYTES = 200000
+APPLY_LOAD_TX_MAX_DISK_READ_BYTES = 130000
+
+APPLY_LOAD_LEDGER_MAX_WRITE_LEDGER_ENTRIES = 1000
+APPLY_LOAD_TX_MAX_WRITE_LEDGER_ENTRIES = 100
+
+APPLY_LOAD_LEDGER_MAX_WRITE_BYTES = 300000
+APPLY_LOAD_TX_MAX_WRITE_BYTES = 140000
+
+APPLY_LOAD_MAX_LEDGER_TX_SIZE_BYTES = 270000
+APPLY_LOAD_MAX_TX_SIZE_BYTES = 150000
+
+APPLY_LOAD_MAX_CONTRACT_EVENT_SIZE_BYTES = 10000
+APPLY_LOAD_MAX_SOROBAN_TX_COUNT = 1000
+
+# The following section contains various parameters for the generated load.
+
+# Number of ledgers to close for benchmark
+APPLY_LOAD_NUM_LEDGERS = 30
+
+# Generate that many simple Classic payment transactions in every benchmark ledger
+APPLY_LOAD_CLASSIC_TXS_PER_LEDGER = 10
+
+# Size of every synthetic data entry generated.
+# This setting affects both the size of the pre-generated Bucket List entries,
+# and the size of every entry that a Soroban transaction reads/writes.
+APPLY_LOAD_DATA_ENTRY_SIZE = 300
+
+# Bucket list pre-generation
+
+# The benchmark will pre-generate ledger entries using the simplified ledger
+# close process; the generated ledgers won't be reflected in the meta or
+# history checkpoints.
+
+# Faster settings, more shallow BL (up to level 6)
+# Number of ledgers to close
+APPLY_LOAD_BL_SIMULATED_LEDGERS = 10000
+# Write a batch of entries every that many ledgers
+APPLY_LOAD_BL_WRITE_FREQUENCY = 1000
+# Write that many entries in every batch
+APPLY_LOAD_BL_BATCH_SIZE = 1000
+# Write that many entries in every batch in the 'last' ledgers
+APPLY_LOAD_BL_LAST_BATCH_SIZE = 100
+# Write entry batches in every ledger of this many last ledgers
+APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 300
+
+# Slower settings, deeper BL (up to level 9)
+#APPLY_LOAD_BL_SIMULATED_LEDGERS = 300000
+#APPLY_LOAD_BL_WRITE_FREQUENCY = 10000
+#APPLY_LOAD_BL_BATCH_SIZE = 10000
+#APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 300
+#APPLY_LOAD_BL_LAST_BATCH_SIZE = 100
+
+# Settings for generated transactions
+# Every setting consists of the list of the possible values and the respective
+# _DISTRIBUTION list that defines the weight of every value. The values are then
+# sampled from the value list according to the distribution.
+
+# Core will try to pack as many generated transactions as possible,
+# so if it's important to maintain a constant number of transactions per ledger,
+# or to maintain constant utilization of every resources dimension in every
+# ledger, then sampling should be avoided.
+
+# It's generally a good idea to utilize as many dimensions as possible, so
+# the values here should be chosen carefully such that the ratio between the
+# generated value and the respective limit is the roughly same for most of the
+# resources.
+
+# Number of *disk* reads a transaction performs. Every disk read is restoration,
+# so it's also a write (accounted for in NUM_RW_ENTRIES).
+APPLY_LOAD_NUM_DISK_READ_ENTRIES = [1]
+APPLY_LOAD_NUM_DISK_READ_ENTRIES_DISTRIBUTION = [1]
+
+# Number of writes a transaction performs.
+APPLY_LOAD_NUM_RW_ENTRIES = [4]
+APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION = [1]
+
+# Number of events a transaction emits.
+APPLY_LOAD_EVENT_COUNT = [5]
+APPLY_LOAD_EVENT_COUNT_DISTRIBUTION = [1]
+
+# Size of the generated transaction.
+APPLY_LOAD_TX_SIZE_BYTES = [1080]
+APPLY_LOAD_TX_SIZE_BYTES_DISTRIBUTION = [1]
+
+# Number of instructions a transaction will use.
+APPLY_LOAD_INSTRUCTIONS = [2000000]
+APPLY_LOAD_INSTRUCTIONS_DISTRIBUTION = [1]
+
+
+# Minimal core config boilerplate
+
+RUN_STANDALONE=true
+NODE_IS_VALIDATOR=false
+UNSAFE_QUORUM=true
+NETWORK_PASSPHRASE="load test network"
+NODE_SEED="SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2 self"
+
+# Log to stdout instead of file (so we can parse the pre-benchmark checkpoint)
+LOG_FILE_PATH=""
+
+[QUORUM_SET]
+THRESHOLD_PERCENT=100
+VALIDATORS=["$self"]
+
+# Local history configuration to use for catching up to the synthetic
+# ledger state generated before the apply load benchmark is executed.
+[HISTORY.local]
+get="cp -r history/{0} {1}"
+put="cp -r {0} history/{1}"
+mkdir="mkdir -p history/{0}"

--- a/ingest/loadtest/testdata/default-apply-load.cfg
+++ b/ingest/loadtest/testdata/default-apply-load.cfg
@@ -1,7 +1,6 @@
-# Default apply-load configuration for TestGenerateLedgers
+# Default apply-load configuration
 #
 # Based on: https://github.com/stellar/stellar-core/blob/d458d90d7df3031bd6e1f12d95b027d073caa0e1/docs/apply-load-for-meta.cfg
-# Override with LOADTEST_CORE_CONFIG_PATH env var for custom configurations.
 #
 # Differences from upstream:
 #   - NETWORK_PASSPHRASE: "load test network" (instead of "Standalone Network ; February 2017")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go-stellar-sdk/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds tooling for synthetic ledger generation using stellar-core's `apply-load` command for ingestion load testing. Given an `apply-load` config, this enables one to generate an output that can be used for follow-up RPC or Horizon ingestion load tests through the pattern of `NewApplyLoad(...)` -> `ApplyLoad.RunApplyLoadAndWrite()` (+ `ApplyLoad.Cleanup()` ). 

Originally, this lived in `stellar-horizon` as an integration test. The core codeflow and design is the same here as it was there, except functions here no longer take a `*testing.T` and are oriented around a `*ApplyLoad` struct. It's migrated to the SDK to ensure that it may be common to ingestion load testing tools in both `stellar-horizon` and `stellar-rpc`.

### Why

See [stellar-rpc/711](https://github.com/stellar/stellar-rpc/issues/711). This PR focuses on making the utility for ingestion load-tests common so that it can be used in any repo that requires it.

### Known limitations

N/A.
