### PR TITLE
ingest/ledgerbackend: integrate XDR views into BSB + add GetLedgerRaw

### DIFF
--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -42,6 +42,10 @@ const (
 )
 
 type metaResult struct {
+	// raw is the XDR frame bytes for this ledger (without the frame length
+	// prefix). Owned by the metaResult — the reader allocates a fresh slice
+	// per frame so consumers can hold onto the bytes.
+	raw []byte
 	*xdr.LedgerCloseMeta
 	err error
 }
@@ -66,9 +70,8 @@ type metaResult struct {
 // until the xdr.LedgerCloseMeta channel is empty. This prevents memory
 // exhaustion when the network closes a series of large ledgers.
 type bufferedLedgerMetaReader struct {
-	r        *bufio.Reader
-	c        chan metaResult
-	frameBuf []byte // reusable frame buffer
+	r *bufio.Reader
+	c chan metaResult
 }
 
 // newBufferedLedgerMetaReader creates a new meta reader that will shutdown
@@ -81,19 +84,24 @@ func newBufferedLedgerMetaReader(reader io.Reader) *bufferedLedgerMetaReader {
 	}
 }
 
-// readLedgerMetaFromPipe unmarshalls the next ledger from meta pipe.
+// readLedgerMetaFromPipe reads the next framed ledger from the meta pipe and
+// returns both the raw frame bytes and the unmarshaled LedgerCloseMeta.
 // It can block for two reasons:
 //   - Meta pipe buffer is full so it will wait until it refills.
 //   - The next ledger available in the buffer exceeds the meta pipe buffer size.
 //     In such case the method will block until LedgerCloseMeta buffer is empty.
-func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() (*xdr.LedgerCloseMeta, error) {
+//
+// A fresh slice is allocated per frame so the returned bytes outlive the
+// reader's read state and can be passed through metaResult to consumers
+// that need raw bytes (e.g., GetLedgerRaw).
+func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() ([]byte, *xdr.LedgerCloseMeta, error) {
 	frameLength, err := xdr.ReadFrameLength(b.r)
 	if err != nil {
-		return nil, errors.Wrap(err, "error reading frame length")
+		return nil, nil, errors.Wrap(err, "error reading frame length")
 	}
 
 	if frameLength > maxLedgerMetaFrameSize {
-		return nil, fmt.Errorf("LedgerCloseMeta frame too large: %d bytes (max %d)", frameLength, maxLedgerMetaFrameSize)
+		return nil, nil, fmt.Errorf("LedgerCloseMeta frame too large: %d bytes (max %d)", frameLength, maxLedgerMetaFrameSize)
 	}
 
 	for frameLength > metaPipeBufferSize && len(b.c) > 0 {
@@ -101,22 +109,16 @@ func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() (*xdr.LedgerCloseMet
 		<-time.After(time.Second)
 	}
 
-	// Grow/reuse the frame buffer.
-	if uint32(cap(b.frameBuf)) < frameLength {
-		b.frameBuf = make([]byte, frameLength)
-	} else {
-		b.frameBuf = b.frameBuf[:frameLength]
-	}
-
-	if _, err = io.ReadFull(b.r, b.frameBuf); err != nil {
-		return nil, errors.Wrap(err, "reading LedgerCloseMeta frame body")
+	frame := make([]byte, frameLength)
+	if _, err = io.ReadFull(b.r, frame); err != nil {
+		return nil, nil, errors.Wrap(err, "reading LedgerCloseMeta frame body")
 	}
 
 	var xlcm xdr.LedgerCloseMeta
-	if err = xdr.SafeUnmarshal(b.frameBuf, &xlcm); err != nil {
-		return nil, errors.Wrap(err, "unmarshaling framed LedgerCloseMeta")
+	if err = xdr.SafeUnmarshal(frame, &xlcm); err != nil {
+		return nil, nil, errors.Wrap(err, "unmarshaling framed LedgerCloseMeta")
 	}
-	return &xlcm, nil
+	return frame, &xlcm, nil
 }
 
 func (b *bufferedLedgerMetaReader) getChannel() <-chan metaResult {
@@ -137,12 +139,12 @@ func (b *bufferedLedgerMetaReader) start() {
 		default:
 		}
 
-		meta, err := b.readLedgerMetaFromPipe()
+		raw, meta, err := b.readLedgerMetaFromPipe()
 		if err != nil {
-			b.c <- metaResult{nil, err}
+			b.c <- metaResult{nil, nil, err}
 			return
 		}
 
-		b.c <- metaResult{meta, nil}
+		b.c <- metaResult{raw, meta, nil}
 	}
 }

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -44,9 +44,9 @@ const (
 type metaResult struct {
 	// raw is the XDR frame bytes for this ledger (without the frame length
 	// prefix). Owned by the metaResult — the reader allocates a fresh slice
-	// per frame so consumers can hold onto the bytes.
+	// per frame so consumers can hold onto the bytes. Decoding happens
+	// lazily downstream so GetLedgerRaw can avoid the unmarshal entirely.
 	raw []byte
-	*xdr.LedgerCloseMeta
 	err error
 }
 
@@ -85,23 +85,25 @@ func newBufferedLedgerMetaReader(reader io.Reader) *bufferedLedgerMetaReader {
 }
 
 // readLedgerMetaFromPipe reads the next framed ledger from the meta pipe and
-// returns both the raw frame bytes and the unmarshaled LedgerCloseMeta.
+// returns the raw frame bytes. The XDR decode happens downstream on demand
+// (in GetLedger, or via views in handleMetaPipeResult) so GetLedgerRaw can
+// avoid the unmarshal entirely.
+//
 // It can block for two reasons:
 //   - Meta pipe buffer is full so it will wait until it refills.
 //   - The next ledger available in the buffer exceeds the meta pipe buffer size.
 //     In such case the method will block until LedgerCloseMeta buffer is empty.
 //
 // A fresh slice is allocated per frame so the returned bytes outlive the
-// reader's read state and can be passed through metaResult to consumers
-// that need raw bytes (e.g., GetLedgerRaw).
-func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() ([]byte, *xdr.LedgerCloseMeta, error) {
+// reader's read state.
+func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() ([]byte, error) {
 	frameLength, err := xdr.ReadFrameLength(b.r)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "error reading frame length")
+		return nil, errors.Wrap(err, "error reading frame length")
 	}
 
 	if frameLength > maxLedgerMetaFrameSize {
-		return nil, nil, fmt.Errorf("LedgerCloseMeta frame too large: %d bytes (max %d)", frameLength, maxLedgerMetaFrameSize)
+		return nil, fmt.Errorf("LedgerCloseMeta frame too large: %d bytes (max %d)", frameLength, maxLedgerMetaFrameSize)
 	}
 
 	for frameLength > metaPipeBufferSize && len(b.c) > 0 {
@@ -111,14 +113,9 @@ func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() ([]byte, *xdr.Ledger
 
 	frame := make([]byte, frameLength)
 	if _, err = io.ReadFull(b.r, frame); err != nil {
-		return nil, nil, errors.Wrap(err, "reading LedgerCloseMeta frame body")
+		return nil, errors.Wrap(err, "reading LedgerCloseMeta frame body")
 	}
-
-	var xlcm xdr.LedgerCloseMeta
-	if err = xdr.SafeUnmarshal(frame, &xlcm); err != nil {
-		return nil, nil, errors.Wrap(err, "unmarshaling framed LedgerCloseMeta")
-	}
-	return frame, &xlcm, nil
+	return frame, nil
 }
 
 func (b *bufferedLedgerMetaReader) getChannel() <-chan metaResult {
@@ -139,12 +136,12 @@ func (b *bufferedLedgerMetaReader) start() {
 		default:
 		}
 
-		raw, meta, err := b.readLedgerMetaFromPipe()
+		raw, err := b.readLedgerMetaFromPipe()
 		if err != nil {
-			b.c <- metaResult{nil, nil, err}
+			b.c <- metaResult{err: err}
 			return
 		}
 
-		b.c <- metaResult{raw, meta, nil}
+		b.c <- metaResult{raw: raw}
 	}
 }

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader_test.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader_test.go
@@ -31,14 +31,18 @@ func TestReadLedgerMetaFromPipe(t *testing.T) {
 	require.NoError(t, xdr.MarshalFramed(&buf, lcm))
 
 	reader := newBufferedLedgerMetaReader(&buf)
-	raw, result, err := reader.readLedgerMetaFromPipe()
+	raw, err := reader.readLedgerMetaFromPipe()
 	require.NoError(t, err)
-	assert.Equal(t, uint32(1234), uint32(result.LedgerHeaderHistoryEntry().Header.LedgerSeq))
 
-	// Raw frame bytes must round-trip back to the same LedgerCloseMeta.
-	// This catches off-by-one or framing bugs that would still leave the
-	// decoded form valid (e.g., extra trailing bytes consumed by SafeUnmarshal
-	// from the next frame).
+	// View-based access — no full decode required to read the sequence.
+	seq, err := xdr.LedgerCloseMetaView(raw).LedgerSequence()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1234), seq)
+
+	// Round-trip — bytes decode back to the same LedgerCloseMeta. Catches
+	// off-by-one or framing bugs that would still leave a view-readable
+	// header (e.g., extra trailing bytes consumed by SafeUnmarshal from the
+	// next frame).
 	var decoded xdr.LedgerCloseMeta
 	require.NoError(t, xdr.SafeUnmarshal(raw, &decoded))
 	assert.Equal(t, lcm, decoded)
@@ -52,7 +56,7 @@ func TestReadLedgerMetaFromPipeFrameTooLarge(t *testing.T) {
 	require.NoError(t, binary.Write(&buf, binary.BigEndian, frameHeader))
 
 	reader := newBufferedLedgerMetaReader(&buf)
-	_, _, err := reader.readLedgerMetaFromPipe()
+	_, err := reader.readLedgerMetaFromPipe()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "frame too large")
 }
@@ -67,13 +71,17 @@ func TestReadLedgerMetaFromPipeMultipleFrames(t *testing.T) {
 
 	reader := newBufferedLedgerMetaReader(&buf)
 
-	raw1, result1, err := reader.readLedgerMetaFromPipe()
+	raw1, err := reader.readLedgerMetaFromPipe()
 	require.NoError(t, err)
-	assert.Equal(t, uint32(100), uint32(result1.LedgerHeaderHistoryEntry().Header.LedgerSeq))
+	seq1, err := xdr.LedgerCloseMetaView(raw1).LedgerSequence()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(100), seq1)
 
-	raw2, result2, err := reader.readLedgerMetaFromPipe()
+	raw2, err := reader.readLedgerMetaFromPipe()
 	require.NoError(t, err)
-	assert.Equal(t, uint32(200), uint32(result2.LedgerHeaderHistoryEntry().Header.LedgerSeq))
+	seq2, err := xdr.LedgerCloseMetaView(raw2).LedgerSequence()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(200), seq2)
 
 	// Each frame's raw bytes must round-trip back to its own LedgerCloseMeta —
 	// guards against the reader bleeding bytes between frames.

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader_test.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader_test.go
@@ -31,9 +31,17 @@ func TestReadLedgerMetaFromPipe(t *testing.T) {
 	require.NoError(t, xdr.MarshalFramed(&buf, lcm))
 
 	reader := newBufferedLedgerMetaReader(&buf)
-	_, result, err := reader.readLedgerMetaFromPipe()
+	raw, result, err := reader.readLedgerMetaFromPipe()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1234), uint32(result.LedgerHeaderHistoryEntry().Header.LedgerSeq))
+
+	// Raw frame bytes must round-trip back to the same LedgerCloseMeta.
+	// This catches off-by-one or framing bugs that would still leave the
+	// decoded form valid (e.g., extra trailing bytes consumed by SafeUnmarshal
+	// from the next frame).
+	var decoded xdr.LedgerCloseMeta
+	require.NoError(t, xdr.SafeUnmarshal(raw, &decoded))
+	assert.Equal(t, lcm, decoded)
 }
 
 func TestReadLedgerMetaFromPipeFrameTooLarge(t *testing.T) {
@@ -59,11 +67,19 @@ func TestReadLedgerMetaFromPipeMultipleFrames(t *testing.T) {
 
 	reader := newBufferedLedgerMetaReader(&buf)
 
-	_, result1, err := reader.readLedgerMetaFromPipe()
+	raw1, result1, err := reader.readLedgerMetaFromPipe()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(100), uint32(result1.LedgerHeaderHistoryEntry().Header.LedgerSeq))
 
-	_, result2, err := reader.readLedgerMetaFromPipe()
+	raw2, result2, err := reader.readLedgerMetaFromPipe()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(200), uint32(result2.LedgerHeaderHistoryEntry().Header.LedgerSeq))
+
+	// Each frame's raw bytes must round-trip back to its own LedgerCloseMeta —
+	// guards against the reader bleeding bytes between frames.
+	var decoded1, decoded2 xdr.LedgerCloseMeta
+	require.NoError(t, xdr.SafeUnmarshal(raw1, &decoded1))
+	require.NoError(t, xdr.SafeUnmarshal(raw2, &decoded2))
+	assert.Equal(t, lcm1, decoded1)
+	assert.Equal(t, lcm2, decoded2)
 }

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader_test.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader_test.go
@@ -31,7 +31,7 @@ func TestReadLedgerMetaFromPipe(t *testing.T) {
 	require.NoError(t, xdr.MarshalFramed(&buf, lcm))
 
 	reader := newBufferedLedgerMetaReader(&buf)
-	result, err := reader.readLedgerMetaFromPipe()
+	_, result, err := reader.readLedgerMetaFromPipe()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1234), uint32(result.LedgerHeaderHistoryEntry().Header.LedgerSeq))
 }
@@ -44,7 +44,7 @@ func TestReadLedgerMetaFromPipeFrameTooLarge(t *testing.T) {
 	require.NoError(t, binary.Write(&buf, binary.BigEndian, frameHeader))
 
 	reader := newBufferedLedgerMetaReader(&buf)
-	_, err := reader.readLedgerMetaFromPipe()
+	_, _, err := reader.readLedgerMetaFromPipe()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "frame too large")
 }
@@ -59,11 +59,11 @@ func TestReadLedgerMetaFromPipeMultipleFrames(t *testing.T) {
 
 	reader := newBufferedLedgerMetaReader(&buf)
 
-	result1, err := reader.readLedgerMetaFromPipe()
+	_, result1, err := reader.readLedgerMetaFromPipe()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(100), uint32(result1.LedgerHeaderHistoryEntry().Header.LedgerSeq))
 
-	result2, err := reader.readLedgerMetaFromPipe()
+	_, result2, err := reader.readLedgerMetaFromPipe()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(200), uint32(result2.LedgerHeaderHistoryEntry().Header.LedgerSeq))
 }

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -119,12 +119,14 @@ func (bsb *BufferedStorageBackend) loadBatchForSequence(ctx context.Context, seq
 		bsb.batchBytes = nil
 	}
 
-	// Need next batch from the queue. Return it to the pool unless we
-	// successfully install it as the active batch — keeps malformed/parse-
-	// error paths from leaking pooled buffers.
-	batchBytes, err := bsb.ledgerBuffer.getFromLedgerQueue(ctx)
+	// Pull compressed batch from queue and decompress on consumer thread.
+	compressed, err := bsb.ledgerBuffer.getFromLedgerQueue(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed getting next ledger batch from queue")
+	}
+	batchBytes, err := bsb.ledgerBuffer.decompress(compressed)
+	if err != nil {
+		return errors.Wrap(err, "failed decompressing batch")
 	}
 	installed := false
 	defer func() {
@@ -192,7 +194,7 @@ func (bsb *BufferedStorageBackend) validateSequence(sequence uint32) error {
 		return errors.New("session is not prepared, call PrepareRange first")
 	}
 	if sequence < bsb.ledgerBuffer.ledgerRange.from {
-		return errors.New("requested sequence preceeds current LedgerRange")
+		return errors.New("requested sequence precedes current LedgerRange")
 	}
 	if bsb.ledgerBuffer.ledgerRange.bounded {
 		if sequence > bsb.ledgerBuffer.ledgerRange.to {
@@ -200,7 +202,7 @@ func (bsb *BufferedStorageBackend) validateSequence(sequence uint32) error {
 		}
 	}
 	if sequence < bsb.lastLedger {
-		return errors.New("requested sequence preceeds the lastLedger")
+		return errors.New("requested sequence precedes the lastLedger")
 	}
 	if sequence > bsb.nextExpectedSequence() {
 		return errors.New("requested sequence is not the lastLedger nor the next available ledger")

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -56,6 +56,10 @@ func NewBufferedStorageBackend(config BufferedStorageBackendConfig, dataStore da
 		return nil, errors.New("buffer size must be > 0")
 	}
 
+	if config.NumWorkers == 0 {
+		return nil, errors.New("number of workers must be > 0")
+	}
+
 	if config.NumWorkers > config.BufferSize {
 		return nil, errors.New("number of workers must be <= BufferSize")
 	}

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -115,11 +115,19 @@ func (bsb *BufferedStorageBackend) loadBatchForSequence(ctx context.Context, seq
 		bsb.batchBytes = nil
 	}
 
-	// Need next batch from the queue
+	// Need next batch from the queue. Return it to the pool unless we
+	// successfully install it as the active batch — keeps malformed/parse-
+	// error paths from leaking pooled buffers.
 	batchBytes, err := bsb.ledgerBuffer.getFromLedgerQueue(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed getting next ledger batch from queue")
 	}
+	installed := false
+	defer func() {
+		if !installed {
+			bsb.ledgerBuffer.returnBuffer(batchBytes)
+		}
+	}()
 
 	view := xdr.LedgerCloseMetaBatchView(batchBytes)
 
@@ -160,6 +168,7 @@ func (bsb *BufferedStorageBackend) loadBatchForSequence(ctx context.Context, seq
 	bsb.batchStart = start
 	bsb.batchEnd = end
 	bsb.batchIndex = 0
+	installed = true
 
 	return nil
 }

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -212,19 +212,21 @@ func (bsb *BufferedStorageBackend) getLedgerRaw(ctx context.Context, sequence ui
 	}
 
 	targetIndex := sequence - bsb.batchStart
-	if targetIndex < bsb.batchIndex {
-		return nil, fmt.Errorf("requested sequence %d already consumed from batch", sequence)
-	}
-
 	i := int(targetIndex)
 	if i >= len(bsb.ledgerSlices) {
 		return nil, fmt.Errorf("ledger index %d out of range for batch", i)
 	}
 	rawBytes := []byte(bsb.ledgerSlices[i])
-	bsb.batchIndex = targetIndex + 1
 
-	bsb.lastLedger = bsb.nextLedger
-	bsb.nextLedger++
+	// Only advance state when we're actually consuming a new ledger.
+	// Re-requests of the most-recently-served sequence return the cached
+	// bytes idempotently (matches CaptiveStellarCore.GetLedger behavior).
+	// validateSequence already rejects sequences earlier than lastLedger.
+	if targetIndex >= bsb.batchIndex {
+		bsb.batchIndex = targetIndex + 1
+		bsb.lastLedger = bsb.nextLedger
+		bsb.nextLedger++
+	}
 
 	return rawBytes, nil
 }

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -241,8 +241,8 @@ func (bsb *BufferedStorageBackend) getLedgerRaw(ctx context.Context, sequence ui
 //
 // The returned byte slice is a safe copy that the caller owns.
 func (bsb *BufferedStorageBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
-	bsb.bsBackendLock.Lock()
-	defer bsb.bsBackendLock.Unlock()
+	bsb.bsBackendLock.RLock()
+	defer bsb.bsBackendLock.RUnlock()
 
 	rawBytes, err := bsb.getLedgerRaw(ctx, sequence)
 	if err != nil {
@@ -255,8 +255,8 @@ func (bsb *BufferedStorageBackend) GetLedgerRaw(ctx context.Context, sequence ui
 
 // GetLedger returns the LedgerCloseMeta for the specified ledger sequence number.
 func (bsb *BufferedStorageBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
-	bsb.bsBackendLock.Lock()
-	defer bsb.bsBackendLock.Unlock()
+	bsb.bsBackendLock.RLock()
+	defer bsb.bsBackendLock.RUnlock()
 
 	// Use internal getLedgerRaw which returns aliased bytes — safe here because
 	// we decode immediately before the next call can recycle the buffer.
@@ -340,10 +340,12 @@ func (bsb *BufferedStorageBackend) isPrepared(ledgerRange Range) bool {
 // all subsequent calls to PrepareRange(), GetLedger(), etc will fail.
 // Close is thread-safe and can be called from another go routine.
 func (bsb *BufferedStorageBackend) Close() error {
-	bsb.bsBackendLock.Lock()
-	defer bsb.bsBackendLock.Unlock()
+	bsb.bsBackendLock.RLock()
+	defer bsb.bsBackendLock.RUnlock()
 
-	bsb.releaseCurrentBatch()
+	if bsb.ledgerBuffer != nil {
+		bsb.ledgerBuffer.close()
+	}
 	bsb.closed = true
 
 	return nil

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -155,16 +155,12 @@ func (bsb *BufferedStorageBackend) loadBatchForSequence(ctx context.Context, seq
 	if err != nil {
 		return fmt.Errorf("reading batch ledger metas: %w", err)
 	}
-	count, err := metas.Count()
-	if err != nil {
-		return fmt.Errorf("reading batch ledger count: %w", err)
-	}
-	if count == 0 {
-		return fmt.Errorf("batch is empty: startSequence=%d endSequence=%d", start, end)
-	}
 	slices, err := metas.All()
 	if err != nil {
 		return fmt.Errorf("materializing batch ledgers: %w", err)
+	}
+	if len(slices) == 0 {
+		return fmt.Errorf("batch is empty: startSequence=%d endSequence=%d", start, end)
 	}
 
 	bsb.batchBytes = batchBytes

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -5,6 +5,7 @@ package ledgerbackend
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -38,9 +39,15 @@ type BufferedStorageBackend struct {
 	schema     datastore.DataStoreSchema
 	prepared   *Range // Non-nil if any range is prepared
 	closed     bool   // False until the core is closed
-	lcmBatch   xdr.LedgerCloseMetaBatch
 	nextLedger uint32
 	lastLedger uint32
+
+	// Current batch state
+	batchBytes   []byte                    // raw decompressed bytes (for pool return)
+	ledgerSlices []xdr.LedgerCloseMetaView // per-ledger exact-extent views into batchBytes
+	batchStart   uint32
+	batchEnd     uint32
+	batchIndex   uint32 // how many ledgers consumed from this batch
 }
 
 // NewBufferedStorageBackend returns a new BufferedStorageBackend instance.
@@ -87,34 +94,80 @@ func (bsb *BufferedStorageBackend) GetLatestLedgerSequence(ctx context.Context) 
 	return latestSeq, nil
 }
 
-// getBatchForSequence checks if the requested sequence is in the cached batch.
-// Otherwise will continuously load in the next LedgerCloseMetaBatch until found.
-func (bsb *BufferedStorageBackend) getBatchForSequence(ctx context.Context, sequence uint32) error {
-	// Sequence inside the current cached LedgerCloseMetaBatch
-	if sequence >= uint32(bsb.lcmBatch.StartSequence) && sequence <= uint32(bsb.lcmBatch.EndSequence) {
+// loadBatchForSequence ensures the raw batch containing the given sequence is loaded.
+// If the sequence is within the current batch, it's a no-op.
+// Otherwise, it fetches the next batch from the ledger queue and pre-computes
+// byte offsets for each ledger boundary using the generated view API.
+func (bsb *BufferedStorageBackend) loadBatchForSequence(ctx context.Context, sequence uint32) error {
+	// Check if sequence is in the current batch
+	if bsb.batchBytes != nil && sequence >= bsb.batchStart && sequence <= bsb.batchEnd {
 		return nil
 	}
 
-	// Sequence is before the current LedgerCloseMetaBatch
-	// Does not support retrieving LedgerCloseMeta before the current cached batch
-	if sequence < uint32(bsb.lcmBatch.StartSequence) {
+	// Sequence is before the current batch
+	if bsb.batchBytes != nil && sequence < bsb.batchStart {
 		return errors.New("requested sequence precedes current LedgerCloseMetaBatch")
 	}
 
-	// Sequence is beyond the current LedgerCloseMetaBatch
-	var err error
-	bsb.lcmBatch, err = bsb.ledgerBuffer.getFromLedgerQueue(ctx)
+	// Return the old batch buffer to the pool before loading a new one.
+	if bsb.batchBytes != nil {
+		bsb.ledgerBuffer.returnBuffer(bsb.batchBytes)
+		bsb.batchBytes = nil
+	}
+
+	// Need next batch from the queue
+	batchBytes, err := bsb.ledgerBuffer.getFromLedgerQueue(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed getting next ledger batch from queue")
 	}
+
+	view := xdr.LedgerCloseMetaBatchView(batchBytes)
+
+	startView, err := view.StartSequence()
+	if err != nil {
+		return fmt.Errorf("reading batch start sequence: %w", err)
+	}
+	start, err := startView.Value()
+	if err != nil {
+		return fmt.Errorf("reading batch start sequence value: %w", err)
+	}
+	endView, err := view.EndSequence()
+	if err != nil {
+		return fmt.Errorf("reading batch end sequence: %w", err)
+	}
+	end, err := endView.Value()
+	if err != nil {
+		return fmt.Errorf("reading batch end sequence value: %w", err)
+	}
+	metas, err := view.LedgerCloseMetas()
+	if err != nil {
+		return fmt.Errorf("reading batch ledger metas: %w", err)
+	}
+	count, err := metas.Count()
+	if err != nil {
+		return fmt.Errorf("reading batch ledger count: %w", err)
+	}
+	if count == 0 {
+		return fmt.Errorf("batch is empty: startSequence=%d endSequence=%d", start, end)
+	}
+	slices, err := metas.All()
+	if err != nil {
+		return fmt.Errorf("materializing batch ledgers: %w", err)
+	}
+
+	bsb.batchBytes = batchBytes
+	bsb.ledgerSlices = slices
+	bsb.batchStart = start
+	bsb.batchEnd = end
+	bsb.batchIndex = 0
+
 	return nil
 }
 
 // nextExpectedSequence returns nextLedger (if currently set) or start of
 // prepared range. Otherwise it returns 0.
-// This is done because `nextLedger` is 0 between the moment Stellar-Core is
-// started and streaming the first ledger (in such case we return first ledger
-// in requested range).
+// nextLedger is 0 before the first batch is loaded; in that case we return
+// the first ledger in the prepared range.
 func (bsb *BufferedStorageBackend) nextExpectedSequence() uint32 {
 	if bsb.nextLedger == 0 && bsb.prepared != nil {
 		return bsb.prepared.from
@@ -122,50 +175,98 @@ func (bsb *BufferedStorageBackend) nextExpectedSequence() uint32 {
 	return bsb.nextLedger
 }
 
-// GetLedger returns the LedgerCloseMeta for the specified ledger sequence number
-func (bsb *BufferedStorageBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
-	bsb.bsBackendLock.RLock()
-	defer bsb.bsBackendLock.RUnlock()
-
+func (bsb *BufferedStorageBackend) validateSequence(sequence uint32) error {
 	if bsb.closed {
-		return xdr.LedgerCloseMeta{}, errors.New("BufferedStorageBackend is closed; cannot GetLedger")
+		return errors.New("BufferedStorageBackend is closed; cannot GetLedger")
 	}
-
 	if bsb.prepared == nil {
-		return xdr.LedgerCloseMeta{}, errors.New("session is not prepared, call PrepareRange first")
+		return errors.New("session is not prepared, call PrepareRange first")
 	}
-
 	if sequence < bsb.ledgerBuffer.ledgerRange.from {
-		return xdr.LedgerCloseMeta{}, errors.New("requested sequence preceeds current LedgerRange")
+		return errors.New("requested sequence preceeds current LedgerRange")
 	}
-
 	if bsb.ledgerBuffer.ledgerRange.bounded {
 		if sequence > bsb.ledgerBuffer.ledgerRange.to {
-			return xdr.LedgerCloseMeta{}, errors.New("requested sequence beyond current LedgerRange")
+			return errors.New("requested sequence beyond current LedgerRange")
 		}
 	}
-
 	if sequence < bsb.lastLedger {
-		return xdr.LedgerCloseMeta{}, errors.New("requested sequence preceeds the lastLedger")
+		return errors.New("requested sequence preceeds the lastLedger")
 	}
-
 	if sequence > bsb.nextExpectedSequence() {
-		return xdr.LedgerCloseMeta{}, errors.New("requested sequence is not the lastLedger nor the next available ledger")
+		return errors.New("requested sequence is not the lastLedger nor the next available ledger")
+	}
+	return nil
+}
+
+// getLedgerRaw is the internal implementation that returns raw XDR bytes for a
+// single LedgerCloseMeta. The returned bytes alias an internal buffer and are
+// only valid until the next getLedgerRaw call. Caller must hold bsBackendLock.
+func (bsb *BufferedStorageBackend) getLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
+	if err := bsb.validateSequence(sequence); err != nil {
+		return nil, err
 	}
 
-	err := bsb.getBatchForSequence(ctx, sequence)
-	if err != nil {
-		return xdr.LedgerCloseMeta{}, err
+	if err := bsb.loadBatchForSequence(ctx, sequence); err != nil {
+		return nil, err
 	}
 
-	ledgerCloseMeta, err := bsb.lcmBatch.GetLedger(sequence)
-	if err != nil {
-		return xdr.LedgerCloseMeta{}, err
+	targetIndex := sequence - bsb.batchStart
+	if targetIndex < bsb.batchIndex {
+		return nil, fmt.Errorf("requested sequence %d already consumed from batch", sequence)
 	}
+
+	i := int(targetIndex)
+	if i >= len(bsb.ledgerSlices) {
+		return nil, fmt.Errorf("ledger index %d out of range for batch", i)
+	}
+	rawBytes := []byte(bsb.ledgerSlices[i])
+	bsb.batchIndex = targetIndex + 1
+
 	bsb.lastLedger = bsb.nextLedger
 	bsb.nextLedger++
 
-	return ledgerCloseMeta, nil
+	return rawBytes, nil
+}
+
+// GetLedgerRaw returns the raw XDR bytes for a single LedgerCloseMeta
+// without performing XDR decoding. This is significantly faster than GetLedger
+// when the caller doesn't need a decoded struct (e.g., for forwarding,
+// replication, or when the caller will decode selectively).
+//
+// For the common case of LedgersPerFile=1, this avoids all XDR decoding
+// and simply returns the bytes after the batch header.
+//
+// The returned byte slice is a safe copy that the caller owns.
+func (bsb *BufferedStorageBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
+	bsb.bsBackendLock.Lock()
+	defer bsb.bsBackendLock.Unlock()
+
+	rawBytes, err := bsb.getLedgerRaw(ctx, sequence)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]byte, len(rawBytes))
+	copy(result, rawBytes)
+	return result, nil
+}
+
+// GetLedger returns the LedgerCloseMeta for the specified ledger sequence number.
+func (bsb *BufferedStorageBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
+	bsb.bsBackendLock.Lock()
+	defer bsb.bsBackendLock.Unlock()
+
+	// Use internal getLedgerRaw which returns aliased bytes — safe here because
+	// we decode immediately before the next call can recycle the buffer.
+	rawBytes, err := bsb.getLedgerRaw(ctx, sequence)
+	if err != nil {
+		return xdr.LedgerCloseMeta{}, err
+	}
+	var lcm xdr.LedgerCloseMeta
+	if err := xdr.SafeUnmarshal(rawBytes, &lcm); err != nil {
+		return xdr.LedgerCloseMeta{}, fmt.Errorf("error decoding ledger %d: %w", sequence, err)
+	}
+	return lcm, nil
 }
 
 // PrepareRange checks if the starting and ending (if bounded) ledgers exist.
@@ -237,16 +338,26 @@ func (bsb *BufferedStorageBackend) isPrepared(ledgerRange Range) bool {
 // all subsequent calls to PrepareRange(), GetLedger(), etc will fail.
 // Close is thread-safe and can be called from another go routine.
 func (bsb *BufferedStorageBackend) Close() error {
-	bsb.bsBackendLock.RLock()
-	defer bsb.bsBackendLock.RUnlock()
+	bsb.bsBackendLock.Lock()
+	defer bsb.bsBackendLock.Unlock()
 
-	if bsb.ledgerBuffer != nil {
-		bsb.ledgerBuffer.close()
-	}
-
+	bsb.releaseCurrentBatch()
 	bsb.closed = true
 
 	return nil
+}
+
+// releaseCurrentBatch returns the batch buffer to the pool and closes the ledger buffer.
+func (bsb *BufferedStorageBackend) releaseCurrentBatch() {
+	if bsb.batchBytes != nil && bsb.ledgerBuffer != nil {
+		bsb.ledgerBuffer.returnBuffer(bsb.batchBytes)
+	}
+	bsb.batchBytes = nil
+	bsb.ledgerSlices = nil
+	if bsb.ledgerBuffer != nil {
+		bsb.ledgerBuffer.close()
+		bsb.ledgerBuffer = nil
+	}
 }
 
 // startPreparingRange prepares the ledger range by setting the range in the ledgerBuffer
@@ -254,6 +365,8 @@ func (bsb *BufferedStorageBackend) startPreparingRange(ledgerRange Range) (bool,
 	if bsb.isPrepared(ledgerRange) {
 		return true, nil
 	}
+
+	bsb.releaseCurrentBatch()
 
 	var err error
 	bsb.ledgerBuffer, err = bsb.newLedgerBuffer(ledgerRange)

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -27,9 +27,20 @@ type BufferedStorageBackendConfig struct {
 
 // BufferedStorageBackend is a ledger backend that reads from a storage service.
 // The storage service contains files generated from the ledgerExporter.
+//
+// Except for the Close function, BufferedStorageBackend is not thread-safe and
+// should not be accessed by multiple go routines. Close is thread-safe and can
+// be called from another go routine. Once Close is called it will interrupt and
+// cancel any pending operations.
 type BufferedStorageBackend struct {
 	config BufferedStorageBackendConfig
 
+	// bsBackendLock is held by Close (write) so it can interrupt in-flight
+	// operations, and by every other method (read) so they observe a stable
+	// closed flag. Concurrent reads between non-Close methods are *not* made
+	// safe by this lock — the type's thread-safety contract requires callers
+	// to serialize externally; the read lock here only protects against
+	// concurrent Close.
 	bsBackendLock sync.RWMutex
 
 	// ledgerBuffer is the buffer for LedgerCloseMeta data read in parallel.
@@ -194,18 +205,21 @@ func (bsb *BufferedStorageBackend) validateSequence(sequence uint32) error {
 		return errors.New("session is not prepared, call PrepareRange first")
 	}
 	if sequence < bsb.ledgerBuffer.ledgerRange.from {
-		return errors.New("requested sequence precedes current LedgerRange")
+		return fmt.Errorf("requested sequence %d precedes current LedgerRange [%d, %d]",
+			sequence, bsb.ledgerBuffer.ledgerRange.from, bsb.ledgerBuffer.ledgerRange.to)
 	}
 	if bsb.ledgerBuffer.ledgerRange.bounded {
 		if sequence > bsb.ledgerBuffer.ledgerRange.to {
-			return errors.New("requested sequence beyond current LedgerRange")
+			return fmt.Errorf("requested sequence %d beyond current LedgerRange [%d, %d]",
+				sequence, bsb.ledgerBuffer.ledgerRange.from, bsb.ledgerBuffer.ledgerRange.to)
 		}
 	}
 	if sequence < bsb.lastLedger {
-		return errors.New("requested sequence precedes the lastLedger")
+		return fmt.Errorf("requested sequence %d precedes the lastLedger %d", sequence, bsb.lastLedger)
 	}
 	if sequence > bsb.nextExpectedSequence() {
-		return errors.New("requested sequence is not the lastLedger nor the next available ledger")
+		return fmt.Errorf("requested sequence %d is not the lastLedger %d nor the next available ledger %d",
+			sequence, bsb.lastLedger, bsb.nextExpectedSequence())
 	}
 	return nil
 }

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -186,7 +186,7 @@ func (bsb *BufferedStorageBackend) nextExpectedSequence() uint32 {
 
 func (bsb *BufferedStorageBackend) validateSequence(sequence uint32) error {
 	if bsb.closed {
-		return errors.New("BufferedStorageBackend is closed; cannot GetLedger")
+		return errors.New("BufferedStorageBackend is closed; cannot GetLedger or GetLedgerRaw")
 	}
 	if bsb.prepared == nil {
 		return errors.New("session is not prepared, call PrepareRange first")

--- a/ingest/ledgerbackend/buffered_storage_backend_bench_test.go
+++ b/ingest/ledgerbackend/buffered_storage_backend_bench_test.go
@@ -1,0 +1,158 @@
+package ledgerbackend
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/support/datastore"
+)
+
+// Benchmarks GetLedger / GetLedgerRaw throughput against a real GCS-backed
+// data store. Off by default — set BSB_BENCH_BUCKET to a valid GCS bucket
+// path and BSB_BENCH_FROM/BSB_BENCH_TO to the ledger range. Requires GCS
+// application-default credentials.
+//
+// Sweeps NumWorkers across {5, 10, 20, 50, 100} to identify the throughput
+// knee. BufferSize is fixed at 10000 — newLedgerBuffer caps it to the range
+// size internally, so the effective buffer is min(10000, range). This sizes
+// the pipeline so workers always see all queued tasks upfront and never
+// throttle on the per-consumer-pull pushTaskQueue feedback loop. Use
+// -benchtime=1x for a single pass per config.
+//
+// Example:
+//
+//	BSB_BENCH_BUCKET=sdf-ledger-close-meta/ledgers/pubnet \
+//	BSB_BENCH_FROM=58752000 BSB_BENCH_TO=58752999 \
+//	go test -run='^$' -bench=BenchmarkBSB -benchtime=1x \
+//	  ./ingest/ledgerbackend/
+
+const (
+	bsbBenchBucketEnv = "BSB_BENCH_BUCKET"
+	bsbBenchFromEnv   = "BSB_BENCH_FROM"
+	bsbBenchToEnv     = "BSB_BENCH_TO"
+	bsbBenchLPFEnv    = "BSB_BENCH_LEDGERS_PER_FILE"
+)
+
+var bsbBenchWorkerCounts = []uint32{5, 10, 20, 50, 100}
+
+type bsbBenchEnv struct {
+	bucket         string
+	fromLedger     uint32
+	toLedger       uint32
+	ledgersPerFile uint32
+}
+
+func loadBenchEnv(b *testing.B) bsbBenchEnv {
+	b.Helper()
+	bucket := os.Getenv(bsbBenchBucketEnv)
+	fromStr := os.Getenv(bsbBenchFromEnv)
+	toStr := os.Getenv(bsbBenchToEnv)
+	if bucket == "" || fromStr == "" || toStr == "" {
+		b.Skipf("set %s, %s, %s to run", bsbBenchBucketEnv, bsbBenchFromEnv, bsbBenchToEnv)
+	}
+	var from, to uint32
+	if _, err := fmt.Sscan(fromStr, &from); err != nil {
+		b.Fatalf("parse %s: %v", bsbBenchFromEnv, err)
+	}
+	if _, err := fmt.Sscan(toStr, &to); err != nil {
+		b.Fatalf("parse %s: %v", bsbBenchToEnv, err)
+	}
+	if to < from {
+		b.Fatalf("%s (%d) must be >= %s (%d)", bsbBenchToEnv, to, bsbBenchFromEnv, from)
+	}
+	lpf := uint32(1)
+	if v := os.Getenv(bsbBenchLPFEnv); v != "" {
+		if _, err := fmt.Sscan(v, &lpf); err != nil {
+			b.Fatalf("parse %s: %v", bsbBenchLPFEnv, err)
+		}
+	}
+	return bsbBenchEnv{bucket: bucket, fromLedger: from, toLedger: to, ledgersPerFile: lpf}
+}
+
+func setupBenchBSB(b *testing.B, env bsbBenchEnv, numWorkers uint32) *BufferedStorageBackend {
+	b.Helper()
+
+	schema := datastore.DataStoreSchema{
+		LedgersPerFile:    env.ledgersPerFile,
+		FilesPerPartition: 64000 / env.ledgersPerFile,
+		FileExtension:     "zstd",
+	}
+
+	store, err := datastore.NewDataStore(context.Background(), datastore.DataStoreConfig{
+		Type:   "GCS",
+		Params: map[string]string{"destination_bucket_path": env.bucket},
+		Schema: schema,
+	})
+	require.NoError(b, err)
+
+	bsb, err := NewBufferedStorageBackend(BufferedStorageBackendConfig{
+		BufferSize: 10000,
+		NumWorkers: numWorkers,
+		RetryLimit: 0,
+		RetryWait:  time.Microsecond,
+	}, store, schema)
+	require.NoError(b, err)
+
+	require.NoError(b, bsb.PrepareRange(context.Background(), BoundedRange(env.fromLedger, env.toLedger)))
+	return bsb
+}
+
+// runBSBBench drives `consume` over the full configured range for each
+// NumWorkers value in bsbBenchWorkerCounts. b.SetBytes is set to the ledger
+// count so the standard MB/s output column reads as ledgers/sec.
+func runBSBBench(b *testing.B, consume func(ctx context.Context, bsb *BufferedStorageBackend, seq uint32) error) {
+	env := loadBenchEnv(b)
+	for _, nw := range bsbBenchWorkerCounts {
+		b.Run(fmt.Sprintf("Workers=%d", nw), func(b *testing.B) {
+			ctx := context.Background()
+			count := env.toLedger - env.fromLedger + 1
+			b.SetBytes(int64(count))
+			for i := 0; i < b.N; i++ {
+				bsb := setupBenchBSB(b, env, nw)
+				b.StartTimer()
+				for seq := env.fromLedger; seq <= env.toLedger; seq++ {
+					if err := consume(ctx, bsb, seq); err != nil {
+						b.Fatalf("consume(%d): %v", seq, err)
+					}
+				}
+				b.StopTimer()
+				require.NoError(b, bsb.Close())
+			}
+		})
+	}
+}
+
+func BenchmarkBSBGetLedger(b *testing.B) {
+	runBSBBench(b, func(ctx context.Context, bsb *BufferedStorageBackend, seq uint32) error {
+		_, err := bsb.GetLedger(ctx, seq)
+		return err
+	})
+}
+
+func BenchmarkBSBGetLedgerRaw(b *testing.B) {
+	runBSBBench(b, func(ctx context.Context, bsb *BufferedStorageBackend, seq uint32) error {
+		_, err := bsb.GetLedgerRaw(ctx, seq)
+		return err
+	})
+}
+
+// BenchmarkBSBPipelineNoDecode measures the BSB worker→pipeline→queue overhead
+// alone — workers fetch compressed bytes, the consumer drains them from
+// ledgerQueue WITHOUT decompression or view-parsing. This isolates the
+// pipeline cost from XDR/zstd work, giving a clean comparison vs the parallel
+// store.GetFile probe (same underlying network work, different pipeline shape).
+func BenchmarkBSBPipelineNoDecode(b *testing.B) {
+	runBSBBench(b, func(ctx context.Context, bsb *BufferedStorageBackend, _ uint32) error {
+		compressed, err := bsb.ledgerBuffer.getFromLedgerQueue(ctx)
+		if err != nil {
+			return err
+		}
+		bsb.ledgerBuffer.compressedPool.Put(compressed)
+		return nil
+	})
+}

--- a/ingest/ledgerbackend/buffered_storage_backend_test.go
+++ b/ingest/ledgerbackend/buffered_storage_backend_test.go
@@ -379,7 +379,7 @@ func TestBSBGetLedger_ErrorPreceedingLedger(t *testing.T) {
 	assert.Equal(t, lcmArray[0], lcm)
 
 	_, err = bsb.GetLedger(ctx, uint32(2))
-	assert.EqualError(t, err, "requested sequence precedes current LedgerRange")
+	assert.EqualError(t, err, "requested sequence 2 precedes current LedgerRange [3, 5]")
 }
 
 func TestBSBGetLedger_NotPrepared(t *testing.T) {
@@ -404,10 +404,10 @@ func TestBSBGetLedger_SequenceNotInBatch(t *testing.T) {
 	assert.Eventually(t, func() bool { return len(bsb.ledgerBuffer.ledgerQueue) == 3 }, time.Second*5, time.Millisecond*50)
 
 	_, err := bsb.GetLedger(ctx, uint32(2))
-	assert.EqualError(t, err, "requested sequence precedes current LedgerRange")
+	assert.EqualError(t, err, "requested sequence 2 precedes current LedgerRange [3, 5]")
 
 	_, err = bsb.GetLedger(ctx, uint32(6))
-	assert.EqualError(t, err, "requested sequence beyond current LedgerRange")
+	assert.EqualError(t, err, "requested sequence 6 beyond current LedgerRange [3, 5]")
 }
 
 func TestBSBPrepareRange(t *testing.T) {

--- a/ingest/ledgerbackend/buffered_storage_backend_test.go
+++ b/ingest/ledgerbackend/buffered_storage_backend_test.go
@@ -513,7 +513,7 @@ func TestBSBClose(t *testing.T) {
 	assert.EqualError(t, err, "BufferedStorageBackend is closed; cannot GetLatestLedgerSequence")
 
 	_, err = bsb.GetLedger(ctx, 3)
-	assert.EqualError(t, err, "BufferedStorageBackend is closed; cannot GetLedger")
+	assert.EqualError(t, err, "BufferedStorageBackend is closed; cannot GetLedger or GetLedgerRaw")
 
 	err = bsb.PrepareRange(ctx, ledgerRange)
 	assert.EqualError(t, err, "BufferedStorageBackend is closed; cannot PrepareRange")

--- a/ingest/ledgerbackend/buffered_storage_backend_test.go
+++ b/ingest/ledgerbackend/buffered_storage_backend_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/go-stellar-sdk/support/compressxdr"
 	"github.com/stellar/go-stellar-sdk/support/datastore"
@@ -291,6 +292,46 @@ func TestBSBGetLedgerRaw_SingleLedgerPerFile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, lcmArray[i-startLedger], lcm)
 	}
+}
+
+// TestBSBGetLedger_IdempotentReRequest verifies that requesting the
+// most-recently-served sequence again returns the same ledger without
+// erroring or advancing state, matching CaptiveStellarCore's behavior.
+func TestBSBGetLedger_IdempotentReRequest(t *testing.T) {
+	startLedger := uint32(3)
+	endLedger := uint32(5)
+	ctx := context.Background()
+	lcmArray := createLCMForTesting(startLedger, endLedger)
+	bsb := createBufferedStorageBackendForTesting()
+	ledgerRange := BoundedRange(startLedger, endLedger)
+
+	mockDataStore := createMockdataStore(t, startLedger, endLedger, partitionSize, ledgerPerFileCount)
+	bsb.dataStore = mockDataStore
+
+	assert.NoError(t, bsb.PrepareRange(ctx, ledgerRange))
+	assert.Eventually(t, func() bool { return len(bsb.ledgerBuffer.ledgerQueue) == 3 }, time.Second*5, time.Millisecond*50)
+
+	// First call serves the ledger and advances state.
+	first, err := bsb.GetLedger(ctx, startLedger)
+	assert.NoError(t, err)
+	assert.Equal(t, lcmArray[0], first)
+
+	// Second call for the same sequence returns the same ledger without erroring.
+	second, err := bsb.GetLedger(ctx, startLedger)
+	assert.NoError(t, err)
+	assert.Equal(t, first, second)
+
+	// GetLedgerRaw on the same sequence is also idempotent.
+	rawBytes, err := bsb.GetLedgerRaw(ctx, startLedger)
+	assert.NoError(t, err)
+	var rawLCM xdr.LedgerCloseMeta
+	require.NoError(t, xdr.SafeUnmarshal(rawBytes, &rawLCM))
+	assert.Equal(t, first, rawLCM)
+
+	// Forward progress still works after re-requests.
+	next, err := bsb.GetLedger(ctx, startLedger+1)
+	assert.NoError(t, err)
+	assert.Equal(t, lcmArray[1], next)
 }
 
 func TestCloudStorageGetLedger_MultipleLedgerPerFile(t *testing.T) {

--- a/ingest/ledgerbackend/buffered_storage_backend_test.go
+++ b/ingest/ledgerbackend/buffered_storage_backend_test.go
@@ -90,7 +90,7 @@ func createMockdataStore(t *testing.T, start, end, partitionSize, count uint32) 
 			readCloser = createLCMBatchReader(i, i, count)
 			objectName = fmt.Sprintf("FFFFFFFF--0-%d/%08X--%d.xdr.zstd", partition, math.MaxUint32-i, i)
 		}
-		mockDataStore.On("GetFile", mock.Anything, objectName).Return(readCloser, nil).Times(1)
+		mockDataStore.On("GetFile", mock.Anything, objectName).Return(readCloser, int64(-1), nil).Times(1)
 	}
 
 	t.Cleanup(func() {
@@ -119,6 +119,12 @@ func createTestLedgerCloseMetaBatch(startSeq, endSeq, count uint32) xdr.LedgerCl
 		EndSequence:      xdr.Uint32(endSeq),
 		LedgerCloseMetas: ledgerCloseMetas,
 	}
+}
+
+func decodeLedgerCloseMetaBatch(data []byte) (xdr.LedgerCloseMetaBatch, error) {
+	var batch xdr.LedgerCloseMetaBatch
+	err := xdr.SafeUnmarshal(data, &batch)
+	return batch, err
 }
 
 func createLCMBatchReader(start, end, count uint32) io.ReadCloser {
@@ -184,7 +190,9 @@ func TestNewLedgerBufferSizeLessThanRangeSize(t *testing.T) {
 	assert.NoError(t, err)
 
 	for i := startLedger; i <= endLedger; i++ {
-		lcm, err := ledgerBuffer.getFromLedgerQueue(context.Background())
+		batchBytes, err := ledgerBuffer.getFromLedgerQueue(context.Background())
+		assert.NoError(t, err)
+		lcm, err := decodeLedgerCloseMetaBatch(batchBytes)
 		assert.NoError(t, err)
 		assert.Equal(t, xdr.Uint32(i), lcm.StartSequence)
 	}
@@ -206,7 +214,9 @@ func TestNewLedgerBufferSizeLargerThanRangeSize(t *testing.T) {
 	assert.NoError(t, err)
 
 	for i := startLedger; i <= endLedger; i++ {
-		lcm, err := ledgerBuffer.getFromLedgerQueue(context.Background())
+		batchBytes, err := ledgerBuffer.getFromLedgerQueue(context.Background())
+		assert.NoError(t, err)
+		lcm, err := decodeLedgerCloseMetaBatch(batchBytes)
 		assert.NoError(t, err)
 		assert.Equal(t, xdr.Uint32(i), lcm.StartSequence)
 	}
@@ -254,6 +264,33 @@ func TestBSBGetLedger_SingleLedgerPerFile(t *testing.T) {
 	lcm, err = bsb.GetLedger(ctx, uint32(5))
 	assert.NoError(t, err)
 	assert.Equal(t, lcmArray[2], lcm)
+}
+
+func TestBSBGetLedgerRaw_SingleLedgerPerFile(t *testing.T) {
+	startLedger := uint32(3)
+	endLedger := uint32(5)
+	ctx := context.Background()
+	lcmArray := createLCMForTesting(startLedger, endLedger)
+	bsb := createBufferedStorageBackendForTesting()
+	ledgerRange := BoundedRange(startLedger, endLedger)
+
+	mockDataStore := createMockdataStore(t, startLedger, endLedger, partitionSize, ledgerPerFileCount)
+	bsb.dataStore = mockDataStore
+
+	assert.NoError(t, bsb.PrepareRange(ctx, ledgerRange))
+	assert.Eventually(t, func() bool { return len(bsb.ledgerBuffer.ledgerQueue) == 3 }, time.Second*5, time.Millisecond*50)
+
+	for i := startLedger; i <= endLedger; i++ {
+		rawBytes, err := bsb.GetLedgerRaw(ctx, i)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, rawBytes)
+
+		// Verify raw bytes decode to the expected LedgerCloseMeta
+		var lcm xdr.LedgerCloseMeta
+		err = xdr.SafeUnmarshal(rawBytes, &lcm)
+		assert.NoError(t, err)
+		assert.Equal(t, lcmArray[i-startLedger], lcm)
+	}
 }
 
 func TestCloudStorageGetLedger_MultipleLedgerPerFile(t *testing.T) {
@@ -502,7 +539,7 @@ func TestLedgerBufferClose(t *testing.T) {
 
 	objectName := fmt.Sprintf("FFFFFFFF--0-%d/%08X--%d.xdr.zstd", partition, math.MaxUint32-3, 3)
 	afterPrepareRange := make(chan struct{})
-	mockDataStore.On("GetFile", mock.Anything, objectName).Return(io.NopCloser(&bytes.Buffer{}), context.Canceled).Run(func(args mock.Arguments) {
+	mockDataStore.On("GetFile", mock.Anything, objectName).Return(io.NopCloser(&bytes.Buffer{}), int64(-1), context.Canceled).Run(func(args mock.Arguments) {
 		<-afterPrepareRange
 		go bsb.ledgerBuffer.close()
 	}).Once()
@@ -516,7 +553,7 @@ func TestLedgerBufferClose(t *testing.T) {
 	assert.NoError(t, bsb.PrepareRange(ctx, ledgerRange))
 	close(afterPrepareRange)
 
-	bsb.ledgerBuffer.wg.Wait()
+	bsb.ledgerBuffer.workerWg.Wait()
 
 	_, err := bsb.GetLedger(ctx, 3)
 	assert.EqualError(t, err, "failed getting next ledger batch from queue: context canceled")
@@ -533,7 +570,7 @@ func TestLedgerBufferBoundedObjectNotFound(t *testing.T) {
 	partition := ledgerPerFileCount*partitionSize - 1
 
 	objectName := fmt.Sprintf("FFFFFFFF--0-%d/%08X--%d.xdr.zstd", partition, math.MaxUint32-3, 3)
-	mockDataStore.On("GetFile", mock.Anything, objectName).Return(io.NopCloser(&bytes.Buffer{}), os.ErrNotExist).Once()
+	mockDataStore.On("GetFile", mock.Anything, objectName).Return(io.NopCloser(&bytes.Buffer{}), int64(0), os.ErrNotExist).Once()
 	t.Cleanup(func() {
 		mockDataStore.AssertExpectations(t)
 	})
@@ -542,7 +579,7 @@ func TestLedgerBufferBoundedObjectNotFound(t *testing.T) {
 
 	assert.NoError(t, bsb.PrepareRange(ctx, ledgerRange))
 
-	bsb.ledgerBuffer.wg.Wait()
+	bsb.ledgerBuffer.workerWg.Wait()
 
 	_, err := bsb.GetLedger(ctx, 3)
 	assert.ErrorContains(t, err, "ledger object containing sequence 3 is missing")
@@ -563,7 +600,7 @@ func TestLedgerBufferUnboundedObjectNotFound(t *testing.T) {
 	objectName := fmt.Sprintf("FFFFFFFF--0-%d/%08X--%d.xdr.zstd", partition, math.MaxUint32-3, 3)
 	iteration := &atomic.Int32{}
 	cancelAfter := int32(bsb.config.RetryLimit) + 2
-	mockDataStore.On("GetFile", mock.Anything, objectName).Return(io.NopCloser(&bytes.Buffer{}), os.ErrNotExist).Run(func(args mock.Arguments) {
+	mockDataStore.On("GetFile", mock.Anything, objectName).Return(io.NopCloser(&bytes.Buffer{}), int64(0), os.ErrNotExist).Run(func(args mock.Arguments) {
 		if iteration.Load() >= cancelAfter {
 			cancel()
 		}
@@ -594,7 +631,7 @@ func TestLedgerBufferRetryLimit(t *testing.T) {
 
 	objectName := fmt.Sprintf("FFFFFFFF--0-%d/%08X--%d.xdr.zstd", partition, math.MaxUint32-3, 3)
 	mockDataStore.On("GetFile", mock.Anything, objectName).
-		Return(io.NopCloser(&bytes.Buffer{}), fmt.Errorf("transient error")).
+		Return(io.NopCloser(&bytes.Buffer{}), int64(-1), fmt.Errorf("transient error")).
 		Times(int(bsb.config.RetryLimit) + 1)
 	t.Cleanup(func() {
 		mockDataStore.AssertExpectations(t)
@@ -604,7 +641,7 @@ func TestLedgerBufferRetryLimit(t *testing.T) {
 
 	assert.NoError(t, bsb.PrepareRange(context.Background(), ledgerRange))
 
-	bsb.ledgerBuffer.wg.Wait()
+	bsb.ledgerBuffer.workerWg.Wait()
 
 	_, err := bsb.GetLedger(context.Background(), 3)
 	assert.ErrorContains(t, err, "failed getting next ledger batch from queue")

--- a/ingest/ledgerbackend/buffered_storage_backend_test.go
+++ b/ingest/ledgerbackend/buffered_storage_backend_test.go
@@ -191,7 +191,9 @@ func TestNewLedgerBufferSizeLessThanRangeSize(t *testing.T) {
 	assert.NoError(t, err)
 
 	for i := startLedger; i <= endLedger; i++ {
-		batchBytes, err := ledgerBuffer.getFromLedgerQueue(context.Background())
+		compressed, err := ledgerBuffer.getFromLedgerQueue(context.Background())
+		assert.NoError(t, err)
+		batchBytes, err := ledgerBuffer.decompress(compressed)
 		assert.NoError(t, err)
 		lcm, err := decodeLedgerCloseMetaBatch(batchBytes)
 		assert.NoError(t, err)
@@ -215,7 +217,9 @@ func TestNewLedgerBufferSizeLargerThanRangeSize(t *testing.T) {
 	assert.NoError(t, err)
 
 	for i := startLedger; i <= endLedger; i++ {
-		batchBytes, err := ledgerBuffer.getFromLedgerQueue(context.Background())
+		compressed, err := ledgerBuffer.getFromLedgerQueue(context.Background())
+		assert.NoError(t, err)
+		batchBytes, err := ledgerBuffer.decompress(compressed)
 		assert.NoError(t, err)
 		lcm, err := decodeLedgerCloseMetaBatch(batchBytes)
 		assert.NoError(t, err)
@@ -375,7 +379,7 @@ func TestBSBGetLedger_ErrorPreceedingLedger(t *testing.T) {
 	assert.Equal(t, lcmArray[0], lcm)
 
 	_, err = bsb.GetLedger(ctx, uint32(2))
-	assert.EqualError(t, err, "requested sequence preceeds current LedgerRange")
+	assert.EqualError(t, err, "requested sequence precedes current LedgerRange")
 }
 
 func TestBSBGetLedger_NotPrepared(t *testing.T) {
@@ -400,7 +404,7 @@ func TestBSBGetLedger_SequenceNotInBatch(t *testing.T) {
 	assert.Eventually(t, func() bool { return len(bsb.ledgerBuffer.ledgerQueue) == 3 }, time.Second*5, time.Millisecond*50)
 
 	_, err := bsb.GetLedger(ctx, uint32(2))
-	assert.EqualError(t, err, "requested sequence preceeds current LedgerRange")
+	assert.EqualError(t, err, "requested sequence precedes current LedgerRange")
 
 	_, err = bsb.GetLedger(ctx, uint32(6))
 	assert.EqualError(t, err, "requested sequence beyond current LedgerRange")
@@ -594,7 +598,7 @@ func TestLedgerBufferClose(t *testing.T) {
 	assert.NoError(t, bsb.PrepareRange(ctx, ledgerRange))
 	close(afterPrepareRange)
 
-	bsb.ledgerBuffer.workerWg.Wait()
+	bsb.ledgerBuffer.wg.Wait()
 
 	_, err := bsb.GetLedger(ctx, 3)
 	assert.EqualError(t, err, "failed getting next ledger batch from queue: context canceled")
@@ -620,7 +624,7 @@ func TestLedgerBufferBoundedObjectNotFound(t *testing.T) {
 
 	assert.NoError(t, bsb.PrepareRange(ctx, ledgerRange))
 
-	bsb.ledgerBuffer.workerWg.Wait()
+	bsb.ledgerBuffer.wg.Wait()
 
 	_, err := bsb.GetLedger(ctx, 3)
 	assert.ErrorContains(t, err, "ledger object containing sequence 3 is missing")
@@ -682,7 +686,7 @@ func TestLedgerBufferRetryLimit(t *testing.T) {
 
 	assert.NoError(t, bsb.PrepareRange(context.Background(), ledgerRange))
 
-	bsb.ledgerBuffer.workerWg.Wait()
+	bsb.ledgerBuffer.wg.Wait()
 
 	_, err := bsb.GetLedger(context.Background(), 3)
 	assert.ErrorContains(t, err, "failed getting next ledger batch from queue")

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -2,6 +2,7 @@ package ledgerbackend
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"os"
@@ -98,14 +99,12 @@ type CaptiveStellarCore struct {
 	// For testing
 	stellarCoreRunnerFactory func() stellarCoreRunnerInterface
 
-	// cachedRaw is the XDR wire bytes for the last fetched ledger; nil until
-	// the first ledger is consumed. Updated in fetchSequence(), shared by
-	// GetLedger() and GetLedgerRaw(). GetLedgerRaw returns a copy; GetLedger
-	// decodes on demand.
-	cachedRaw []byte
-	// cachedSeq is the sequence number of the cached ledger, extracted via
-	// view at handleMetaPipeResult time. Only valid when cachedRaw != nil.
-	cachedSeq uint32
+	// cached holds the most recently fetched ledger's XDR wire bytes and
+	// sequence. nil until the first ledger is consumed. Updated in
+	// fetchSequence(), shared by GetLedger() (decodes on demand) and
+	// GetLedgerRaw() (returns a copy). The two fields always move together —
+	// one validates the other.
+	cached *cachedLedger
 
 	// ledgerSequenceLock mutex is used to protect the member variables used in the
 	// read-only GetLatestLedgerSequence method from concurrent write operations.
@@ -124,6 +123,14 @@ type CaptiveStellarCore struct {
 	captiveCoreNewDBCounter  prometheus.Counter
 	stellarCoreClient        *stellarcore.Client
 	captiveCoreVersion       string // Updates when captive-core restarts
+}
+
+// cachedLedger bundles the raw XDR wire bytes of a fetched ledger with its
+// sequence number. The two fields always move together; one validates the
+// other.
+type cachedLedger struct {
+	Raw []byte
+	Seq uint32
 }
 
 // CaptiveCoreConfig contains all the parameters required to create a CaptiveStellarCore instance
@@ -551,8 +558,8 @@ func (c *CaptiveStellarCore) isPrepared(ledgerRange Range) bool {
 	}
 
 	cachedLedger := uint32(0)
-	if c.cachedRaw != nil {
-		cachedLedger = c.cachedSeq
+	if c.cached != nil {
+		cachedLedger = c.cached.Seq
 	}
 
 	if c.prepared == nil {
@@ -600,7 +607,7 @@ func (c *CaptiveStellarCore) GetLedger(ctx context.Context, sequence uint32) (xd
 	// Decode lazily from the cached raw bytes — only GetLedger callers pay the
 	// XDR unmarshal cost; GetLedgerRaw avoids it entirely.
 	var lcm xdr.LedgerCloseMeta
-	if err := xdr.SafeUnmarshal(c.cachedRaw, &lcm); err != nil {
+	if err := xdr.SafeUnmarshal(c.cached.Raw, &lcm); err != nil {
 		return xdr.LedgerCloseMeta{}, errors.Wrap(err, "decoding cached ledger meta")
 	}
 	return lcm, nil
@@ -615,15 +622,15 @@ func (c *CaptiveStellarCore) GetLedgerRaw(ctx context.Context, sequence uint32) 
 	if err := c.fetchSequence(ctx, sequence); err != nil {
 		return nil, err
 	}
-	out := make([]byte, len(c.cachedRaw))
-	copy(out, c.cachedRaw)
+	out := make([]byte, len(c.cached.Raw))
+	copy(out, c.cached.Raw)
 	return out, nil
 }
 
 // fetchSequence advances the captive-core stream until the cache holds the
 // requested ledger. The caller must hold c.stellarCoreLock.RLock().
 func (c *CaptiveStellarCore) fetchSequence(ctx context.Context, sequence uint32) error {
-	if c.cachedRaw != nil && sequence == c.cachedSeq {
+	if c.cached != nil && sequence == c.cached.Seq {
 		// GetLedger / GetLedgerRaw can be called multiple times using the same sequence,
 		// ex. to create change and transaction readers. If we have this ledger buffered,
 		// return it.
@@ -719,7 +726,7 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 		c.stellarCoreRunner.close()
 		return false, errors.Wrap(err, "reading previous ledger hash from frame")
 	}
-	newPreviousLedgerHash := previousHash.HexString()
+	newPreviousLedgerHash := hex.EncodeToString(previousHash)
 	if c.previousLedgerHash != nil && *c.previousLedgerHash != newPreviousLedgerHash {
 		// We got something unexpected; close and reset
 		c.stellarCoreRunner.close()
@@ -740,12 +747,11 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 		c.stellarCoreRunner.close()
 		return false, errors.Wrap(err, "reading ledger hash from frame")
 	}
-	currentLedgerHash := currentHash.HexString()
+	currentLedgerHash := hex.EncodeToString(currentHash)
 	c.previousLedgerHash = &currentLedgerHash
 
 	// Update cache with the latest value because we incremented nextLedger.
-	c.cachedRaw = result.raw
-	c.cachedSeq = seq
+	c.cached = &cachedLedger{Raw: result.raw, Seq: seq}
 
 	if seq == sequence {
 		// If we got the _last_ ledger in a segment, close before returning.

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -100,6 +100,9 @@ type CaptiveStellarCore struct {
 
 	// cachedMeta keeps that ledger data of the last fetched ledger. Updated in GetLedger().
 	cachedMeta *xdr.LedgerCloseMeta
+	// cachedRaw is the XDR wire bytes for cachedMeta — kept so GetLedgerRaw can
+	// return them without re-marshaling.
+	cachedRaw []byte
 
 	// ledgerSequenceLock mutex is used to protect the member variables used in the
 	// read-only GetLatestLedgerSequence method from concurrent write operations.
@@ -588,27 +591,49 @@ func (c *CaptiveStellarCore) isPrepared(ledgerRange Range) bool {
 func (c *CaptiveStellarCore) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
 	c.stellarCoreLock.RLock()
 	defer c.stellarCoreLock.RUnlock()
+	if err := c.fetchSequence(ctx, sequence); err != nil {
+		return xdr.LedgerCloseMeta{}, err
+	}
+	return *c.cachedMeta, nil
+}
 
+// GetLedgerRaw returns the XDR wire bytes for the requested sequence without
+// re-marshaling. Captive core's stream reader retains the frame bytes alongside
+// the decoded form, so this is a copy of already-read data.
+func (c *CaptiveStellarCore) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
+	c.stellarCoreLock.RLock()
+	defer c.stellarCoreLock.RUnlock()
+	if err := c.fetchSequence(ctx, sequence); err != nil {
+		return nil, err
+	}
+	out := make([]byte, len(c.cachedRaw))
+	copy(out, c.cachedRaw)
+	return out, nil
+}
+
+// fetchSequence advances the captive-core stream until the cache holds the
+// requested ledger. The caller must hold c.stellarCoreLock.RLock().
+func (c *CaptiveStellarCore) fetchSequence(ctx context.Context, sequence uint32) error {
 	if c.cachedMeta != nil && sequence == c.cachedMeta.LedgerSequence() {
 		// GetLedger can be called multiple times using the same sequence, ex. to create
-		// change and transaction readers. If we have this ledger buffered, let's return it.
-		return *c.cachedMeta, nil
+		// change and transaction readers. If we have this ledger buffered, return it.
+		return nil
 	}
 
 	if c.closed {
-		return xdr.LedgerCloseMeta{}, errors.New("stellar-core is no longer usable")
+		return errors.New("stellar-core is no longer usable")
 	}
 
 	if c.prepared == nil {
-		return xdr.LedgerCloseMeta{}, errors.New("session is not prepared, call PrepareRange first")
+		return errors.New("session is not prepared, call PrepareRange first")
 	}
 
 	if c.stellarCoreRunner == nil {
-		return xdr.LedgerCloseMeta{}, errors.New("stellar-core cannot be nil, call PrepareRange first")
+		return errors.New("stellar-core cannot be nil, call PrepareRange first")
 	}
 
 	if sequence < c.nextExpectedSequence() {
-		return xdr.LedgerCloseMeta{}, errors.Errorf(
+		return errors.Errorf(
 			"requested ledger %d is behind the captive core stream (expected=%d)",
 			sequence,
 			c.nextExpectedSequence(),
@@ -616,7 +641,7 @@ func (c *CaptiveStellarCore) GetLedger(ctx context.Context, sequence uint32) (xd
 	}
 
 	if c.lastLedger != nil && sequence > *c.lastLedger {
-		return xdr.LedgerCloseMeta{}, errors.Errorf(
+		return errors.Errorf(
 			"reading past bounded range (requested sequence=%d, last ledger in range=%d)",
 			sequence,
 			*c.lastLedger,
@@ -625,34 +650,37 @@ func (c *CaptiveStellarCore) GetLedger(ctx context.Context, sequence uint32) (xd
 
 	ch, ok := c.stellarCoreRunner.getMetaPipe()
 	if !ok {
-		return xdr.LedgerCloseMeta{}, errors.New("stellar-core is not running, call PrepareRange first")
+		return errors.New("stellar-core is not running, call PrepareRange first")
 	}
 
-	// Now loop along the range until we find the ledger we want.
+	// Loop along the range until we find the ledger we want.
 	for {
 		select {
 		case <-ctx.Done():
-			return xdr.LedgerCloseMeta{}, ctx.Err()
+			return ctx.Err()
 		case result, ok := <-ch:
-			found, ledger, err := c.handleMetaPipeResult(sequence, result, ok)
-			if found || err != nil {
-				return ledger, err
+			found, err := c.handleMetaPipeResult(sequence, result, ok)
+			if err != nil {
+				return err
+			}
+			if found {
+				return nil
 			}
 		}
 	}
 }
 
-func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaResult, ok bool) (bool, xdr.LedgerCloseMeta, error) {
+func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaResult, ok bool) (bool, error) {
 	if err := c.checkMetaPipeResult(result, ok); err != nil {
 		c.stellarCoreRunner.close()
-		return false, xdr.LedgerCloseMeta{}, err
+		return false, err
 	}
 
 	seq := result.LedgerCloseMeta.LedgerSequence()
 	// If we got something unexpected; close and reset
 	if c.nextLedger != 0 && seq != c.nextLedger {
 		c.stellarCoreRunner.close()
-		return false, xdr.LedgerCloseMeta{}, errors.Errorf(
+		return false, errors.Errorf(
 			"unexpected ledger sequence (expected=%d actual=%d)",
 			c.nextLedger,
 			seq,
@@ -660,7 +688,7 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 	} else if c.nextLedger == 0 && seq > c.prepared.from {
 		// First stream ledger is greater than prepared.from
 		c.stellarCoreRunner.close()
-		return false, xdr.LedgerCloseMeta{}, errors.Errorf(
+		return false, errors.Errorf(
 			"unexpected ledger sequence (expected=<=%d actual=%d)",
 			c.prepared.from,
 			seq,
@@ -671,7 +699,7 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 	if c.previousLedgerHash != nil && *c.previousLedgerHash != newPreviousLedgerHash {
 		// We got something unexpected; close and reset
 		c.stellarCoreRunner.close()
-		return false, xdr.LedgerCloseMeta{}, errors.Errorf(
+		return false, errors.Errorf(
 			"unexpected previous ledger hash for ledger %d (expected=%s actual=%s)",
 			seq,
 			*c.previousLedgerHash,
@@ -688,18 +716,19 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 
 	// Update cache with the latest value because we incremented nextLedger.
 	c.cachedMeta = result.LedgerCloseMeta
+	c.cachedRaw = result.raw
 
 	if seq == sequence {
 		// If we got the _last_ ledger in a segment, close before returning.
 		if c.lastLedger != nil && *c.lastLedger == seq {
 			if err := c.stellarCoreRunner.close(); err != nil {
-				return false, xdr.LedgerCloseMeta{}, errors.Wrap(err, "error closing session")
+				return false, errors.Wrap(err, "error closing session")
 			}
 		}
-		return true, *c.cachedMeta, nil
+		return true, nil
 	}
 
-	return false, xdr.LedgerCloseMeta{}, nil
+	return false, nil
 }
 
 func (c *CaptiveStellarCore) checkMetaPipeResult(result metaResult, ok bool) error {

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -98,7 +98,8 @@ type CaptiveStellarCore struct {
 	// For testing
 	stellarCoreRunnerFactory func() stellarCoreRunnerInterface
 
-	// cachedMeta keeps that ledger data of the last fetched ledger. Updated in GetLedger().
+	// cachedMeta keeps that ledger data of the last fetched ledger. Updated in fetchSequence(),
+	// shared by GetLedger() and GetLedgerRaw().
 	cachedMeta *xdr.LedgerCloseMeta
 	// cachedRaw is the XDR wire bytes for cachedMeta — kept so GetLedgerRaw can
 	// return them without re-marshaling.
@@ -615,8 +616,9 @@ func (c *CaptiveStellarCore) GetLedgerRaw(ctx context.Context, sequence uint32) 
 // requested ledger. The caller must hold c.stellarCoreLock.RLock().
 func (c *CaptiveStellarCore) fetchSequence(ctx context.Context, sequence uint32) error {
 	if c.cachedMeta != nil && sequence == c.cachedMeta.LedgerSequence() {
-		// GetLedger can be called multiple times using the same sequence, ex. to create
-		// change and transaction readers. If we have this ledger buffered, return it.
+		// GetLedger / GetLedgerRaw can be called multiple times using the same sequence,
+		// ex. to create change and transaction readers. If we have this ledger buffered,
+		// return it.
 		return nil
 	}
 

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -98,12 +98,17 @@ type CaptiveStellarCore struct {
 	// For testing
 	stellarCoreRunnerFactory func() stellarCoreRunnerInterface
 
-	// cachedMeta keeps that ledger data of the last fetched ledger. Updated in fetchSequence(),
-	// shared by GetLedger() and GetLedgerRaw().
-	cachedMeta *xdr.LedgerCloseMeta
-	// cachedRaw is the XDR wire bytes for cachedMeta — kept so GetLedgerRaw can
-	// return them without re-marshaling.
+	// cachedRaw is the XDR wire bytes for the last fetched ledger. Updated in
+	// fetchSequence(), shared by GetLedger() and GetLedgerRaw(). GetLedgerRaw
+	// returns a copy of these bytes; GetLedger decodes on demand.
 	cachedRaw []byte
+	// cachedSeq is the sequence number of the cached ledger, extracted via
+	// view at handleMetaPipeResult time. Used by the idempotent re-request
+	// fast path in fetchSequence so we don't have to decode just to check.
+	cachedSeq uint32
+	// cachedHasLedger reports whether cachedRaw/cachedSeq are populated
+	// (since cachedSeq=0 isn't distinguishable from "not yet set").
+	cachedHasLedger bool
 
 	// ledgerSequenceLock mutex is used to protect the member variables used in the
 	// read-only GetLatestLedgerSequence method from concurrent write operations.
@@ -549,8 +554,8 @@ func (c *CaptiveStellarCore) isPrepared(ledgerRange Range) bool {
 	}
 
 	cachedLedger := uint32(0)
-	if c.cachedMeta != nil {
-		cachedLedger = c.cachedMeta.LedgerSequence()
+	if c.cachedHasLedger {
+		cachedLedger = c.cachedSeq
 	}
 
 	if c.prepared == nil {
@@ -595,12 +600,18 @@ func (c *CaptiveStellarCore) GetLedger(ctx context.Context, sequence uint32) (xd
 	if err := c.fetchSequence(ctx, sequence); err != nil {
 		return xdr.LedgerCloseMeta{}, err
 	}
-	return *c.cachedMeta, nil
+	// Decode lazily from the cached raw bytes — only GetLedger callers pay the
+	// XDR unmarshal cost; GetLedgerRaw avoids it entirely.
+	var lcm xdr.LedgerCloseMeta
+	if err := xdr.SafeUnmarshal(c.cachedRaw, &lcm); err != nil {
+		return xdr.LedgerCloseMeta{}, errors.Wrap(err, "decoding cached ledger meta")
+	}
+	return lcm, nil
 }
 
 // GetLedgerRaw returns the XDR wire bytes for the requested sequence without
-// re-marshaling. Captive core's stream reader retains the frame bytes alongside
-// the decoded form, so this is a copy of already-read data.
+// any XDR decoding. The reader stores the frame bytes as they arrive from the
+// captive-core meta pipe, so this is a copy of already-read data.
 func (c *CaptiveStellarCore) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
 	c.stellarCoreLock.RLock()
 	defer c.stellarCoreLock.RUnlock()
@@ -615,7 +626,7 @@ func (c *CaptiveStellarCore) GetLedgerRaw(ctx context.Context, sequence uint32) 
 // fetchSequence advances the captive-core stream until the cache holds the
 // requested ledger. The caller must hold c.stellarCoreLock.RLock().
 func (c *CaptiveStellarCore) fetchSequence(ctx context.Context, sequence uint32) error {
-	if c.cachedMeta != nil && sequence == c.cachedMeta.LedgerSequence() {
+	if c.cachedHasLedger && sequence == c.cachedSeq {
 		// GetLedger / GetLedgerRaw can be called multiple times using the same sequence,
 		// ex. to create change and transaction readers. If we have this ledger buffered,
 		// return it.
@@ -678,7 +689,16 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 		return false, err
 	}
 
-	seq := result.LedgerCloseMeta.LedgerSequence()
+	// Validate the streamed frame using zero-copy views — only the header
+	// fields we need for sequence/hash checks. The full XDR decode is
+	// deferred to GetLedger so GetLedgerRaw avoids it entirely.
+	view := xdr.LedgerCloseMetaView(result.raw)
+	seq, err := view.LedgerSequence()
+	if err != nil {
+		c.stellarCoreRunner.close()
+		return false, errors.Wrap(err, "reading ledger sequence from frame")
+	}
+
 	// If we got something unexpected; close and reset
 	if c.nextLedger != 0 && seq != c.nextLedger {
 		c.stellarCoreRunner.close()
@@ -697,7 +717,12 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 		)
 	}
 
-	newPreviousLedgerHash := result.LedgerCloseMeta.PreviousLedgerHash().HexString()
+	previousHash, err := view.PreviousLedgerHash()
+	if err != nil {
+		c.stellarCoreRunner.close()
+		return false, errors.Wrap(err, "reading previous ledger hash from frame")
+	}
+	newPreviousLedgerHash := previousHash.HexString()
 	if c.previousLedgerHash != nil && *c.previousLedgerHash != newPreviousLedgerHash {
 		// We got something unexpected; close and reset
 		c.stellarCoreRunner.close()
@@ -710,15 +735,21 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 	}
 
 	c.ledgerSequenceLock.Lock()
-	c.nextLedger = result.LedgerSequence() + 1
+	c.nextLedger = seq + 1
 	c.ledgerSequenceLock.Unlock()
 
-	currentLedgerHash := result.LedgerCloseMeta.LedgerHash().HexString()
+	currentHash, err := view.LedgerHash()
+	if err != nil {
+		c.stellarCoreRunner.close()
+		return false, errors.Wrap(err, "reading ledger hash from frame")
+	}
+	currentLedgerHash := currentHash.HexString()
 	c.previousLedgerHash = &currentLedgerHash
 
 	// Update cache with the latest value because we incremented nextLedger.
-	c.cachedMeta = result.LedgerCloseMeta
 	c.cachedRaw = result.raw
+	c.cachedSeq = seq
+	c.cachedHasLedger = true
 
 	if seq == sequence {
 		// If we got the _last_ ledger in a segment, close before returning.

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -98,17 +98,14 @@ type CaptiveStellarCore struct {
 	// For testing
 	stellarCoreRunnerFactory func() stellarCoreRunnerInterface
 
-	// cachedRaw is the XDR wire bytes for the last fetched ledger. Updated in
-	// fetchSequence(), shared by GetLedger() and GetLedgerRaw(). GetLedgerRaw
-	// returns a copy of these bytes; GetLedger decodes on demand.
+	// cachedRaw is the XDR wire bytes for the last fetched ledger; nil until
+	// the first ledger is consumed. Updated in fetchSequence(), shared by
+	// GetLedger() and GetLedgerRaw(). GetLedgerRaw returns a copy; GetLedger
+	// decodes on demand.
 	cachedRaw []byte
 	// cachedSeq is the sequence number of the cached ledger, extracted via
-	// view at handleMetaPipeResult time. Used by the idempotent re-request
-	// fast path in fetchSequence so we don't have to decode just to check.
+	// view at handleMetaPipeResult time. Only valid when cachedRaw != nil.
 	cachedSeq uint32
-	// cachedHasLedger reports whether cachedRaw/cachedSeq are populated
-	// (since cachedSeq=0 isn't distinguishable from "not yet set").
-	cachedHasLedger bool
 
 	// ledgerSequenceLock mutex is used to protect the member variables used in the
 	// read-only GetLatestLedgerSequence method from concurrent write operations.
@@ -554,7 +551,7 @@ func (c *CaptiveStellarCore) isPrepared(ledgerRange Range) bool {
 	}
 
 	cachedLedger := uint32(0)
-	if c.cachedHasLedger {
+	if c.cachedRaw != nil {
 		cachedLedger = c.cachedSeq
 	}
 
@@ -626,7 +623,7 @@ func (c *CaptiveStellarCore) GetLedgerRaw(ctx context.Context, sequence uint32) 
 // fetchSequence advances the captive-core stream until the cache holds the
 // requested ledger. The caller must hold c.stellarCoreLock.RLock().
 func (c *CaptiveStellarCore) fetchSequence(ctx context.Context, sequence uint32) error {
-	if c.cachedHasLedger && sequence == c.cachedSeq {
+	if c.cachedRaw != nil && sequence == c.cachedSeq {
 		// GetLedger / GetLedgerRaw can be called multiple times using the same sequence,
 		// ex. to create change and transaction readers. If we have this ledger buffered,
 		// return it.
@@ -749,7 +746,6 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 	// Update cache with the latest value because we incremented nextLedger.
 	c.cachedRaw = result.raw
 	c.cachedSeq = seq
-	c.cachedHasLedger = true
 
 	if seq == sequence {
 		// If we got the _last_ ledger in a segment, close before returning.

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -13,6 +13,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/go-stellar-sdk/historyarchive"
 	"github.com/stellar/go-stellar-sdk/network"
@@ -783,6 +784,69 @@ func TestCaptiveGetLedger(t *testing.T) {
 
 	mockArchive.AssertExpectations(t)
 	mockRunner.AssertExpectations(t)
+}
+
+// TestCaptiveGetLedgerRaw verifies that GetLedgerRaw returns the raw frame
+// bytes captured by the meta pipe reader without re-marshaling, that the
+// bytes round-trip to the same LedgerCloseMeta, that re-requests are
+// idempotent, and that returned bytes are a copy (not aliased).
+func TestCaptiveGetLedgerRaw(t *testing.T) {
+	tt := assert.New(t)
+	metaChan := make(chan metaResult, 300)
+
+	// Pre-load ledgers 64-66 so PrepareRange can fast-forward to 65, then
+	// GetLedgerRaw can consume 65 and verify its raw bytes round-trip.
+	rawByLedger := map[uint32][]byte{}
+	for i := uint32(64); i <= 66; i++ {
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: i})
+		raw, err := meta.MarshalBinary()
+		require.NoError(t, err)
+		rawByLedger[i] = raw
+		metaChan <- metaResult{raw: raw, LedgerCloseMeta: &meta}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan), true)
+	mockRunner.On("context").Return(ctx)
+	mockRunner.On("getProcessExitError").Return(nil, false)
+	mockRunner.On("close").Return(nil).Maybe()
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.On("GetRootHAS").Return(historyarchive.HistoryArchiveState{
+		CurrentLedger: 200,
+	}, nil)
+
+	captiveBackend := &CaptiveStellarCore{
+		archive:                  mockArchive,
+		stellarCoreRunnerFactory: func() stellarCoreRunnerInterface { return mockRunner },
+		checkpointManager:        historyarchive.NewCheckpointManager(64),
+	}
+	require.NoError(t, captiveBackend.PrepareRange(ctx, BoundedRange(65, 66)))
+
+	out, err := captiveBackend.GetLedgerRaw(ctx, 65)
+	tt.NoError(err)
+	tt.Equal(rawByLedger[65], out)
+
+	// Round-trip — bytes decode back to the same ledger.
+	var decoded xdr.LedgerCloseMeta
+	require.NoError(t, xdr.SafeUnmarshal(out, &decoded))
+	tt.Equal(uint32(65), uint32(decoded.LedgerSequence()))
+
+	// Idempotent re-request returns the same cached bytes.
+	out2, err := captiveBackend.GetLedgerRaw(ctx, 65)
+	tt.NoError(err)
+	tt.Equal(out, out2)
+
+	// Returned bytes must be a copy of cachedRaw, not aliased.
+	if len(out) > 0 {
+		out[0] ^= 0xFF
+	}
+	out3, err := captiveBackend.GetLedgerRaw(ctx, 65)
+	tt.NoError(err)
+	tt.Equal(out2, out3, "GetLedgerRaw must return a copy, not an aliased slice")
 }
 
 // TestCaptiveGetLedgerCacheLatestLedger test the following case:

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -1460,8 +1460,10 @@ func TestCaptiveIsPrepared(t *testing.T) {
 				captiveBackend.lastLedger = &tc.lastLedger
 			}
 			if tc.cachedLedger > 0 {
-				captiveBackend.cachedSeq = tc.cachedLedger
-				captiveBackend.cachedRaw = []byte{} // sentinel: any non-nil value marks the cache as populated
+				captiveBackend.cached = &cachedLedger{
+					Seq: tc.cachedLedger,
+					Raw: []byte{}, // sentinel: any non-nil cached pointer marks the cache as populated
+				}
 			}
 
 			result := captiveBackend.isPrepared(tc.ledgerRange)

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -1461,7 +1461,7 @@ func TestCaptiveIsPrepared(t *testing.T) {
 			}
 			if tc.cachedLedger > 0 {
 				captiveBackend.cachedSeq = tc.cachedLedger
-				captiveBackend.cachedHasLedger = true
+				captiveBackend.cachedRaw = []byte{} // sentinel: any non-nil value marks the cache as populated
 			}
 
 			result := captiveBackend.isPrepared(tc.ledgerRange)

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -58,6 +58,15 @@ func (m *stellarCoreRunnerMock) close() error {
 	return a.Error(0)
 }
 
+// metaResultFor marshals a LedgerCloseMeta to its XDR wire bytes and wraps it
+// in a metaResult, matching the new reader contract that propagates only raw
+// bytes (decoding is deferred to GetLedger callers).
+func metaResultFor(t *testing.T, meta xdr.LedgerCloseMeta) metaResult {
+	raw, err := meta.MarshalBinary()
+	require.NoError(t, err)
+	return metaResult{raw: raw}
+}
+
 func buildLedgerCloseMeta(header testLedgerHeader) xdr.LedgerCloseMeta {
 	opResults := []xdr.OperationResult{}
 	opMeta := []xdr.OperationMeta{}
@@ -202,9 +211,7 @@ func TestCaptivePrepareRange(t *testing.T) {
 	// and then rewind to the `from` ledger.
 	for i := 64; i <= 100; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	ctx := context.Background()
@@ -284,9 +291,7 @@ func TestCaptivePrepareRangeTerminated(t *testing.T) {
 	// and then rewind to the `from` ledger.
 	for i := 64; i <= 100; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 	close(metaChan)
 	ctx := context.Background()
@@ -320,9 +325,7 @@ func TestCaptivePrepareRangeCloseNotFullyTerminated(t *testing.T) {
 	metaChan := make(chan metaResult, 100)
 	for i := 64; i <= 100; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -429,9 +432,7 @@ func TestCaptivePrepareRange_FromIsAheadOfRootHAS(t *testing.T) {
 
 	metaChan := make(chan metaResult, 100)
 	meta := buildLedgerCloseMeta(testLedgerHeader{sequence: 100})
-	metaChan <- metaResult{
-		LedgerCloseMeta: &meta,
-	}
+	metaChan <- metaResultFor(t, meta)
 	mockRunner.On("runFrom", uint32(99)).Return(nil).Once()
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan), true)
 	mockRunner.On("context").Return(ctx)
@@ -555,9 +556,7 @@ func TestCaptivePrepareRangeUnboundedRange_ReuseSession(t *testing.T) {
 	// and then rewind to the `from` ledger.
 	for i := 2; i <= 65; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	ctx := context.Background()
@@ -606,9 +605,7 @@ func TestGetLatestLedgerSequence(t *testing.T) {
 	// and then rewind to the `from` ledger.
 	for i := 2; i <= 200; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	ctx := context.Background()
@@ -650,9 +647,7 @@ func TestGetLatestLedgerSequenceRaceCondition(t *testing.T) {
 
 	for i := fromSeq; i <= toSeq; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: i})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	mockRunner := &stellarCoreRunnerMock{}
@@ -710,9 +705,7 @@ func TestCaptiveGetLedger(t *testing.T) {
 
 	for i := 64; i <= 66; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	ctx := context.Background()
@@ -802,7 +795,7 @@ func TestCaptiveGetLedgerRaw(t *testing.T) {
 		raw, err := meta.MarshalBinary()
 		require.NoError(t, err)
 		rawByLedger[i] = raw
-		metaChan <- metaResult{raw: raw, LedgerCloseMeta: &meta}
+		metaChan <- metaResult{raw: raw}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -864,9 +857,7 @@ func TestCaptiveGetLedgerCacheLatestLedger(t *testing.T) {
 
 	for i := 2; i <= 67; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -913,15 +904,11 @@ func TestCaptiveGetLedger_NextLedgerIsDifferentToLedgerFromBuffer(t *testing.T) 
 
 	for i := 64; i <= 65; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 	{
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(68)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	ctx := context.Background()
@@ -965,9 +952,7 @@ func TestCaptiveGetLedger_NextLedger0RangeFromIsSmallerThanLedgerFromBuffer(t *t
 
 	for i := 66; i <= 66; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	ctx := context.Background()
@@ -1058,9 +1043,7 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 
 	for i := 64; i <= 65; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 	metaChan <- metaResult{
 		err: fmt.Errorf("unmarshaling error"),
@@ -1119,9 +1102,7 @@ func TestCaptiveGetLedger_ErrClosingAfterLastLedger(t *testing.T) {
 
 	for i := 64; i <= 66; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	ctx := context.Background()
@@ -1161,9 +1142,7 @@ func TestCaptiveAfterClose(t *testing.T) {
 
 	for i := 64; i <= 66; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	mockRunner := &stellarCoreRunnerMock{}
@@ -1216,9 +1195,7 @@ func TestGetLedgerBoundsCheck(t *testing.T) {
 
 	for i := 128; i <= 130; i++ {
 		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(i)})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 	}
 
 	ctx := context.Background()
@@ -1270,14 +1247,15 @@ type GetLedgerTerminatedTestCase struct {
 	expectedError      string
 }
 
-func CaptiveGetLedgerTerminatedUnexpectedlyTestCases() []GetLedgerTerminatedTestCase {
-	ledger64 := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(64)})
+func CaptiveGetLedgerTerminatedUnexpectedlyTestCases(t *testing.T) []GetLedgerTerminatedTestCase {
+	ledger64Raw, err := buildLedgerCloseMeta(testLedgerHeader{sequence: uint32(64)}).MarshalBinary()
+	require.NoError(t, err)
 
 	return []GetLedgerTerminatedTestCase{
 		{
 			"stellar core exited unexpectedly without error",
 			context.Background(),
-			[]metaResult{{LedgerCloseMeta: &ledger64}},
+			[]metaResult{{raw: ledger64Raw}},
 			true,
 			nil,
 			"stellar core exited unexpectedly",
@@ -1285,7 +1263,7 @@ func CaptiveGetLedgerTerminatedUnexpectedlyTestCases() []GetLedgerTerminatedTest
 		{
 			"stellar core exited unexpectedly with an error",
 			context.Background(),
-			[]metaResult{{LedgerCloseMeta: &ledger64}},
+			[]metaResult{{raw: ledger64Raw}},
 			true,
 			fmt.Errorf("signal kill"),
 			"stellar core exited unexpectedly: signal kill",
@@ -1293,7 +1271,7 @@ func CaptiveGetLedgerTerminatedUnexpectedlyTestCases() []GetLedgerTerminatedTest
 		{
 			"stellar core exited unexpectedly without error and closed channel",
 			context.Background(),
-			[]metaResult{{LedgerCloseMeta: &ledger64}},
+			[]metaResult{{raw: ledger64Raw}},
 			true,
 			nil,
 			"stellar core exited unexpectedly",
@@ -1301,7 +1279,7 @@ func CaptiveGetLedgerTerminatedUnexpectedlyTestCases() []GetLedgerTerminatedTest
 		{
 			"stellar core exited unexpectedly with an error and closed channel",
 			context.Background(),
-			[]metaResult{{LedgerCloseMeta: &ledger64}},
+			[]metaResult{{raw: ledger64Raw}},
 			true,
 			fmt.Errorf("signal kill"),
 			"stellar core exited unexpectedly: signal kill",
@@ -1309,7 +1287,7 @@ func CaptiveGetLedgerTerminatedUnexpectedlyTestCases() []GetLedgerTerminatedTest
 		{
 			"meta pipe closed unexpectedly",
 			context.Background(),
-			[]metaResult{{LedgerCloseMeta: &ledger64}},
+			[]metaResult{{raw: ledger64Raw}},
 			false,
 			nil,
 			"meta pipe closed unexpectedly",
@@ -1317,8 +1295,8 @@ func CaptiveGetLedgerTerminatedUnexpectedlyTestCases() []GetLedgerTerminatedTest
 		{
 			"Parser error while reading from the pipe resulting in stellar-core exit",
 			context.Background(),
-			[]metaResult{{LedgerCloseMeta: &ledger64},
-				{LedgerCloseMeta: nil, err: errors.New("Parser error")}},
+			[]metaResult{{raw: ledger64Raw},
+				{err: errors.New("Parser error")}},
 			true,
 			nil,
 			"Parser error",
@@ -1326,8 +1304,8 @@ func CaptiveGetLedgerTerminatedUnexpectedlyTestCases() []GetLedgerTerminatedTest
 		{
 			"stellar core exited unexpectedly with an error resulting in meta pipe closed",
 			context.Background(),
-			[]metaResult{{LedgerCloseMeta: &ledger64},
-				{LedgerCloseMeta: &ledger64, err: errors.New("EOF while decoding")}},
+			[]metaResult{{raw: ledger64Raw},
+				{raw: ledger64Raw, err: errors.New("EOF while decoding")}},
 			true,
 			fmt.Errorf("signal kill"),
 			"stellar core exited unexpectedly: signal kill",
@@ -1336,7 +1314,7 @@ func CaptiveGetLedgerTerminatedUnexpectedlyTestCases() []GetLedgerTerminatedTest
 }
 
 func TestCaptiveGetLedgerTerminatedUnexpectedly(t *testing.T) {
-	for _, testCase := range CaptiveGetLedgerTerminatedUnexpectedlyTestCases() {
+	for _, testCase := range CaptiveGetLedgerTerminatedUnexpectedlyTestCases(t) {
 		t.Run(testCase.name, func(t *testing.T) {
 			metaChan := make(chan metaResult, 100)
 
@@ -1482,10 +1460,8 @@ func TestCaptiveIsPrepared(t *testing.T) {
 				captiveBackend.lastLedger = &tc.lastLedger
 			}
 			if tc.cachedLedger > 0 {
-				meta := buildLedgerCloseMeta(testLedgerHeader{
-					sequence: tc.cachedLedger,
-				})
-				captiveBackend.cachedMeta = &meta
+				captiveBackend.cachedSeq = tc.cachedLedger
+				captiveBackend.cachedHasLedger = true
 			}
 
 			result := captiveBackend.isPrepared(tc.ledgerRange)
@@ -1531,9 +1507,7 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 			hash:               fmt.Sprintf("%02x00000000000000000000000000000000000000000000000000000000000000", h),
 			previousLedgerHash: fmt.Sprintf("%02x00000000000000000000000000000000000000000000000000000000000000", h-1),
 		})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 		h++
 	}
 
@@ -1544,9 +1518,7 @@ func TestCaptivePreviousLedgerCheck(t *testing.T) {
 			hash:               "0000000000000000000000000000000000000000000000000000000000000000",
 			previousLedgerHash: "0000000000000000000000000000000000000000000000000000000000000000",
 		})
-		metaChan <- metaResult{
-			LedgerCloseMeta: &meta,
-		}
+		metaChan <- metaResultFor(t, meta)
 
 	}
 

--- a/ingest/ledgerbackend/ledger_backend.go
+++ b/ingest/ledgerbackend/ledger_backend.go
@@ -7,6 +7,11 @@ import (
 )
 
 // LedgerBackend represents the interface to a ledger data store.
+//
+// Except for the Close function, LedgerBackend implementations are not
+// thread-safe and should not be accessed by multiple go routines. Close
+// is thread-safe and can be called from another go routine. Once Close
+// is called it will interrupt and cancel any pending operations.
 type LedgerBackend interface {
 	// GetLatestLedgerSequence returns the sequence of the latest ledger available
 	// in the backend.

--- a/ingest/ledgerbackend/ledger_backend.go
+++ b/ingest/ledgerbackend/ledger_backend.go
@@ -13,6 +13,11 @@ type LedgerBackend interface {
 	GetLatestLedgerSequence(ctx context.Context) (sequence uint32, err error)
 	// GetLedger will block until the ledger is available.
 	GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error)
+	// GetLedgerRaw returns the XDR wire bytes for a single LedgerCloseMeta
+	// without performing XDR decoding. Useful for forwarding/replication or
+	// for callers that decode selectively. Blocks until the ledger is available.
+	// Implementations should return a copy of the bytes — the caller owns them.
+	GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error)
 	// PrepareRange prepares the given range (including from and to) to be loaded.
 	// Some backends (like captive stellar-core) need to initalize data to be
 	// able to stream ledgers. Blocks until the first ledger is available.

--- a/ingest/ledgerbackend/ledger_buffer.go
+++ b/ingest/ledgerbackend/ledger_buffer.go
@@ -156,9 +156,10 @@ func (bsb *BufferedStorageBackend) newLedgerBuffer(ledgerRange Range) (*ledgerBu
 	}
 
 	// Upon initialization, the ledgerBuffer invariant is maintained because
-	// we create bufferSize tasks while the len(ledgerQueue) and ledgerPriorityQueue.Len() are 0.
+	// we create up to bufferSize+1 tasks (bufferSize in the queue + 1 in-flight
+	// in a worker) while len(ledgerQueue) and ledgerPriorityQueue.Len() are 0.
 	// Effectively, this is len(taskQueue) + len(ledgerQueue) + ledgerPriorityQueue.Len() <= bufferSize
-	// which enforces a limit of max tasks (both pending and in-flight) to be less than or equal to bufferSize.
+	// which enforces a limit of max tasks (both pending and in-flight) to be less than or equal to bufferSize+1.
 	// Note: when a task is in-flight it is no longer in the taskQueue
 	// but for easier conceptualization, len(taskQueue) can be interpreted as both pending and in-flight tasks
 	// where we assume the workers are empty and not processing any tasks.

--- a/ingest/ledgerbackend/ledger_buffer.go
+++ b/ingest/ledgerbackend/ledger_buffer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/pkg/errors"
 
+	"github.com/stellar/go-stellar-sdk/support/collections/heap"
 	"github.com/stellar/go-stellar-sdk/support/datastore"
 )
 
@@ -21,10 +22,9 @@ import (
 // 1 GiB is well above any realistic Stellar batch size.
 const maxBatchObjectSize = 1 << 30
 
-// workerResult is sent from download workers to the writer goroutine.
-type workerResult struct {
+type ledgerBatchObject struct {
 	payload     []byte
-	startLedger uint32
+	startLedger int // Ledger sequence used as the priority for the priorityqueue.
 }
 
 // bufferPool provides reusable byte buffers using a channel-based pool.
@@ -63,36 +63,50 @@ func (p *bufferPool) Put(buf []byte) {
 }
 
 type ledgerBuffer struct {
+	// Passed through from BufferedStorageBackend to control lifetime of ledgerBuffer instance
 	config    BufferedStorageBackendConfig
 	dataStore datastore.DataStore
 	schema    datastore.DataStoreSchema
 
-	// zstdDecoder is a shared zstd decoder used by workers for decompression.
-	// DecodeAll is safe for concurrent use — it uses an internal pool of block decoders.
+	// zstdDecoder is a single zstd decoder used by the BSB consumer to
+	// decompress batches one-at-a-time. Sequential decompression keeps peak
+	// heap small and avoids the GC pressure that comes with N concurrent
+	// DecodeAll calls in workers.
 	zstdDecoder *zstd.Decoder
 
-	// decompressedPool reuses buffers for decompressed batch data.
+	// compressedPool reuses the small (~14 KB) buffers that workers fill from
+	// the data store. Workers Get from it; the consumer Puts back inside
+	// decompress() once the bytes have been decompressed.
+	compressedPool bufferPool
+
+	// decompressedPool reuses buffers for decompressed batch data — driven by
+	// the BSB consumer (via decompress + returnBuffer).
 	decompressedPool bufferPool
 
+	// context used to cancel workers within the ledgerBuffer
 	context context.Context
 	cancel  context.CancelCauseFunc
 
-	workerWg sync.WaitGroup
-	writerWg sync.WaitGroup
+	wg sync.WaitGroup
 
-	// closeOnce ensures close() is idempotent — it does close(resultChan)
-	// which would panic if called twice.
+	// closeOnce ensures close() is idempotent — cancel + Wait + decoder.Close
+	// are safe to repeat, but keeping the same shape here matches the rest of
+	// the lifecycle.
 	closeOnce sync.Once
 
-	// Pipeline: taskQueue -> workers -> resultChan -> writer -> ledgerQueue -> consumer
-	taskQueue   chan uint32
-	resultChan  chan workerResult
-	ledgerQueue chan []byte
+	// The pipes and data structures below help establish the ledgerBuffer invariant which is
+	// the number of tasks (both pending and in-flight) + len(ledgerQueue) + ledgerPriorityQueue.Len()
+	// is always less than or equal to bufferSize (= min(config.BufferSize, range_size+1), the cap of taskQueue/ledgerQueue)
+	taskQueue           chan uint32                   // Buffer next object read
+	ledgerQueue         chan []byte                   // Order corrected lcm batches (compressed)
+	ledgerPriorityQueue *heap.Heap[ledgerBatchObject] // Priority is set to the sequence number
+	priorityQueueLock   sync.Mutex
 
-	nextTaskLedger uint32
-	ledgerRange    Range
-
-	currentLedger     uint32
+	// Keep track of the ledgers to be processed and the next ordering
+	// the ledgers should be buffered
+	currentLedger     uint32 // The current ledger that should be popped from ledgerPriorityQueue
+	nextTaskLedger    uint32 // The next task ledger that should be added to taskQueue
+	ledgerRange       Range
 	currentLedgerLock sync.RWMutex
 }
 
@@ -114,30 +128,40 @@ func (bsb *BufferedStorageBackend) newLedgerBuffer(ledgerRange Range) (*ledgerBu
 	config := bsb.config
 	config.BufferSize = bufferSize
 
-	lb := &ledgerBuffer{
-		config:           config,
-		dataStore:        bsb.dataStore,
-		schema:           bsb.schema,
-		zstdDecoder:      decoder,
-		decompressedPool: newBufferPool(int(bufferSize) + 1),
-		taskQueue:        make(chan uint32, bufferSize),
-		resultChan:       make(chan workerResult, bufferSize),
-		ledgerQueue:      make(chan []byte, bufferSize),
-		currentLedger:    ledgerRange.from,
-		nextTaskLedger:   ledgerRange.from,
-		ledgerRange:      ledgerRange,
-		context:          ctx,
-		cancel:           cancel,
+	less := func(a, b ledgerBatchObject) bool {
+		return a.startLedger < b.startLedger
 	}
 
-	lb.workerWg.Add(int(bsb.config.NumWorkers))
+	lb := &ledgerBuffer{
+		config:              config,
+		dataStore:           bsb.dataStore,
+		schema:              bsb.schema,
+		zstdDecoder:         decoder,
+		compressedPool:      newBufferPool(int(bufferSize) + 1),
+		decompressedPool:    newBufferPool(2),
+		taskQueue:           make(chan uint32, bufferSize),
+		ledgerQueue:         make(chan []byte, bufferSize),
+		ledgerPriorityQueue: heap.New(less, int(bufferSize)),
+		currentLedger:       ledgerRange.from,
+		nextTaskLedger:      ledgerRange.from,
+		ledgerRange:         ledgerRange,
+		context:             ctx,
+		cancel:              cancel,
+	}
+
+	// Start workers to read LCM files
+	lb.wg.Add(int(bsb.config.NumWorkers))
 	for i := uint32(0); i < bsb.config.NumWorkers; i++ {
 		go lb.worker(ctx)
 	}
 
-	lb.writerWg.Add(1)
-	go lb.writer()
-
+	// Upon initialization, the ledgerBuffer invariant is maintained because
+	// we create bufferSize tasks while the len(ledgerQueue) and ledgerPriorityQueue.Len() are 0.
+	// Effectively, this is len(taskQueue) + len(ledgerQueue) + ledgerPriorityQueue.Len() <= bufferSize
+	// which enforces a limit of max tasks (both pending and in-flight) to be less than or equal to bufferSize.
+	// Note: when a task is in-flight it is no longer in the taskQueue
+	// but for easier conceptualization, len(taskQueue) can be interpreted as both pending and in-flight tasks
+	// where we assume the workers are empty and not processing any tasks.
 	for i := 0; i <= int(bufferSize); i++ {
 		lb.pushTaskQueue()
 	}
@@ -146,6 +170,7 @@ func (bsb *BufferedStorageBackend) newLedgerBuffer(ledgerRange Range) (*ledgerBu
 }
 
 func (lb *ledgerBuffer) pushTaskQueue() {
+	// In bounded mode, don't queue past the end boundary ledger for the specified range.
 	if lb.ledgerRange.bounded && lb.nextTaskLedger > lb.schema.GetSequenceNumberEndBoundary(lb.ledgerRange.to) {
 		return
 	}
@@ -160,6 +185,7 @@ func (lb *ledgerBuffer) pushTaskQueue() {
 	}
 }
 
+// sleepWithContext returns true upon sleeping without interruption from the context
 func (lb *ledgerBuffer) sleepWithContext(ctx context.Context, d time.Duration) bool {
 	timer := time.NewTimer(d)
 	select {
@@ -174,9 +200,7 @@ func (lb *ledgerBuffer) sleepWithContext(ctx context.Context, d time.Duration) b
 }
 
 func (lb *ledgerBuffer) worker(ctx context.Context) {
-	defer lb.workerWg.Done()
-
-	var compressedBuf []byte
+	defer lb.wg.Done()
 
 	for {
 		select {
@@ -184,9 +208,10 @@ func (lb *ledgerBuffer) worker(ctx context.Context) {
 			return
 		case sequence := <-lb.taskQueue:
 			for attempt := uint32(0); attempt <= lb.config.RetryLimit; {
-				ledgerObject, err := lb.downloadLedgerObject(ctx, sequence, &compressedBuf)
+				ledgerObject, err := lb.downloadLedgerObject(ctx, sequence)
 				if err != nil {
 					if errors.Is(err, os.ErrNotExist) {
+						// ledgerObject not found and unbounded
 						if !lb.ledgerRange.bounded {
 							if !lb.sleepWithContext(ctx, lb.config.RetryWait) {
 								return
@@ -196,6 +221,7 @@ func (lb *ledgerBuffer) worker(ctx context.Context) {
 						lb.cancel(errors.Wrapf(err, "ledger object containing sequence %v is missing", sequence))
 						return
 					}
+					// don't bother retrying if we've received the signal to shut down
 					if errors.Is(err, context.Canceled) {
 						return
 					}
@@ -211,9 +237,12 @@ func (lb *ledgerBuffer) worker(ctx context.Context) {
 					continue
 				}
 
-				select {
-				case lb.resultChan <- workerResult{payload: ledgerObject, startLedger: sequence}:
-				case <-ctx.Done():
+				// When we store an object we still maintain the ledger buffer invariant because
+				// at this point the current task is finished and we add 1 ledger object to the priority queue.
+				// Thus, the number of tasks decreases by 1 and the priority queue length increases by 1.
+				// This keeps the overall total the same (<= bufferSize). As long as the the ledger buffer invariant
+				// was maintained in the previous state, it is still maintained during this state transition.
+				if !lb.storeObject(ctx, ledgerObject, sequence) {
 					return
 				}
 				break
@@ -222,48 +251,52 @@ func (lb *ledgerBuffer) worker(ctx context.Context) {
 	}
 }
 
-// writer receives unordered results from workers, accumulates out-of-order
-// results in a map, and emits them to ledgerQueue in sequential order.
+// storeObject is called by a worker when its download completes. It pushes
+// the result onto the priority queue and drains everything now in-order to
+// ledgerQueue, all under priorityQueueLock. Returns false if the context was
+// cancelled mid-drain (caller should exit).
 //
-// Watches lb.context.Done() in addition to ranging on resultChan because a
-// worker can call lb.cancel(...) on fatal errors WITHOUT close() ever being
-// called — without the ctx.Done case, the writer would block forever in the
-// receive once items drained, leaking the goroutine.
-func (lb *ledgerBuffer) writer() {
-	defer lb.writerWg.Done()
+// Doing the ordering+emit work in worker context (rather than in a separate
+// writer goroutine) avoids an extra channel hop and the scheduler-delay
+// penalty that comes from goroutine wake-ups under heavy concurrent download
+// load.
+//
+// The send to ledgerQueue happens while priorityQueueLock is held. This is
+// intentional: when ledgerQueue is full the lock-blocked send naturally
+// throttles other workers' storeObject calls, providing backpressure that
+// caps in-flight memory. At BufferSize >= NumWorkers the queue rarely
+// fills, so the serialization cost is negligible in practice.
+func (lb *ledgerBuffer) storeObject(ctx context.Context, payload []byte, sequence uint32) bool {
+	lb.priorityQueueLock.Lock()
+	defer lb.priorityQueueLock.Unlock()
 
-	pending := make(map[uint32][]byte)
-	nextLedger := lb.ledgerRange.from
+	lb.ledgerPriorityQueue.Push(ledgerBatchObject{payload: payload, startLedger: int(sequence)})
 
-	for {
+	// Check if the nextLedger is the next item in the ledgerPriorityQueue
+	// The ledgerBuffer invariant is maintained here because items are transferred from the ledgerPriorityQueue to the ledgerQueue.
+	// Thus the overall sum of ledgerPriorityQueue.Len() + len(lb.ledgerQueue) remains the same.
+	for lb.ledgerPriorityQueue.Len() > 0 && lb.currentLedger == uint32(lb.ledgerPriorityQueue.Peek().startLedger) {
+		item := lb.ledgerPriorityQueue.Pop()
 		select {
+		case lb.ledgerQueue <- item.payload:
+		case <-ctx.Done():
+			return false
 		case <-lb.context.Done():
-			return
-		case result, ok := <-lb.resultChan:
-			if !ok {
-				return
-			}
-			pending[result.startLedger] = result.payload
-
-			for payload, ok := pending[nextLedger]; ok; payload, ok = pending[nextLedger] {
-				delete(pending, nextLedger)
-
-				lb.currentLedgerLock.Lock()
-				lb.currentLedger = nextLedger + lb.schema.LedgersPerFile
-				lb.currentLedgerLock.Unlock()
-
-				select {
-				case lb.ledgerQueue <- payload:
-				case <-lb.context.Done():
-					return
-				}
-				nextLedger += lb.schema.LedgersPerFile
-			}
+			return false
 		}
+		lb.currentLedgerLock.Lock()
+		lb.currentLedger += lb.schema.LedgersPerFile
+		lb.currentLedgerLock.Unlock()
 	}
+	return true
 }
 
-func (lb *ledgerBuffer) downloadLedgerObject(ctx context.Context, sequence uint32, compressedBuf *[]byte) ([]byte, error) {
+// downloadLedgerObject fetches the compressed object bytes only. Decompression
+// is deferred to the consumer (BSB.loadBatchForSequence) so that, with N
+// concurrent workers, only one zstd context is alive at a time — keeping peak
+// heap small and GC overhead low. The returned slice is from compressedPool;
+// the consumer returns it via returnCompressedBuffer after decompressing.
+func (lb *ledgerBuffer) downloadLedgerObject(ctx context.Context, sequence uint32) ([]byte, error) {
 	objectKey := lb.schema.GetObjectKeyFromSequenceNumber(sequence)
 
 	reader, compressedSize, err := lb.dataStore.GetFile(ctx, objectKey)
@@ -277,36 +310,45 @@ func (lb *ledgerBuffer) downloadLedgerObject(ctx context.Context, sequence uint3
 	// Content-Length triggering a huge allocation. Falls back to ReadAll
 	// which grows naturally and is bounded by what the reader actually
 	// produces.
+	var compressed []byte
 	if compressedSize > 0 && compressedSize <= maxBatchObjectSize {
-		if int64(cap(*compressedBuf)) < compressedSize {
-			*compressedBuf = make([]byte, compressedSize)
-		} else {
-			*compressedBuf = (*compressedBuf)[:compressedSize]
+		compressed = lb.compressedPool.Get(int(compressedSize))
+		if _, err = io.ReadFull(reader, compressed); err != nil {
+			lb.compressedPool.Put(compressed)
+			return nil, errors.Wrapf(err, "failed reading file: %s", objectKey)
 		}
-		_, err = io.ReadFull(reader, *compressedBuf)
 	} else {
-		*compressedBuf, err = io.ReadAll(reader)
-	}
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed reading file: %s", objectKey)
+		compressed, err = io.ReadAll(reader)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed reading file: %s", objectKey)
+		}
 	}
 
-	// Pre-allocate the decompression buffer from the pool if possible.
-	// Skip the pre-alloc if the header reports an implausibly large frame
-	// size — that's either a bug or a hostile input, and we'd rather let
-	// DecodeAll grow naturally than reserve a huge buffer up front.
+	return compressed, nil
+}
+
+// decompress turns a compressed batch into decompressed bytes and returns
+// the compressed buffer to the pool. Must be called only by the BSB
+// consumer: keeping a single zstd context active at a time avoids the GC
+// pressure that comes with N concurrent DecodeAll calls in workers.
+func (lb *ledgerBuffer) decompress(compressed []byte) ([]byte, error) {
+	defer lb.compressedPool.Put(compressed)
+
+	// Skip pool pre-alloc if the header reports an implausibly large frame
+	// size — that's either corrupt data or hostile input, and we'd rather
+	// let DecodeAll grow naturally than reserve a huge buffer up front.
 	var dst []byte
 	var header zstd.Header
-	if err = header.Decode(*compressedBuf); err == nil && header.HasFCS && header.FrameContentSize <= maxBatchObjectSize {
+	if err := header.Decode(compressed); err == nil && header.HasFCS && header.FrameContentSize <= maxBatchObjectSize {
 		dst = lb.decompressedPool.Get(int(header.FrameContentSize))[:0]
 	}
 
-	decompressed, err := lb.zstdDecoder.DecodeAll(*compressedBuf, dst)
+	decompressed, err := lb.zstdDecoder.DecodeAll(compressed, dst)
 	if err != nil {
 		if dst != nil {
 			lb.decompressedPool.Put(dst)
 		}
-		return nil, errors.Wrapf(err, "failed decompressing file: %s", objectKey)
+		return nil, errors.Wrap(err, "failed decompressing batch")
 	}
 
 	// If DecodeAll had to reallocate (dst too small), return the original
@@ -326,6 +368,11 @@ func (lb *ledgerBuffer) getFromLedgerQueue(ctx context.Context) ([]byte, error) 
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case batchBytes := <-lb.ledgerQueue:
+			// The ledger buffer invariant is maintained here because
+			// we create an extra task when consuming one item from the ledger queue.
+			// Thus len(ledgerQueue) decreases by 1 and the number of tasks increases by 1.
+			// The overall sum below remains the same:
+			// len(taskQueue) + len(ledgerQueue) + ledgerPriorityQueue.Len() <= bufferSize
 			lb.pushTaskQueue()
 			return batchBytes, nil
 		}
@@ -345,15 +392,15 @@ func (lb *ledgerBuffer) getLatestLedgerSequence() (uint32, error) {
 		return 0, nil
 	}
 
+	// Subtract 1 to get the latest ledger in buffer
 	return lb.currentLedger - 1, nil
 }
 
 func (lb *ledgerBuffer) close() {
 	lb.closeOnce.Do(func() {
 		lb.cancel(context.Canceled)
-		lb.workerWg.Wait()
-		close(lb.resultChan)
-		lb.writerWg.Wait()
+		// wait for all workers to finish terminating
+		lb.wg.Wait()
 		if lb.zstdDecoder != nil {
 			lb.zstdDecoder.Close()
 		}

--- a/ingest/ledgerbackend/ledger_buffer.go
+++ b/ingest/ledgerbackend/ledger_buffer.go
@@ -13,11 +13,13 @@ import (
 	"github.com/stellar/go-stellar-sdk/support/datastore"
 )
 
-// maxDecompressedBatchSize bounds the size of a single decompressed batch
-// to guard against corrupt or malicious zstd FrameContentSize headers from
-// triggering an arbitrarily large allocation. 1 GiB is well above any
-// realistic Stellar batch size.
-const maxDecompressedBatchSize = 1 << 30
+// maxBatchObjectSize bounds the size of a single batch object — used both for
+// the compressed-bytes pre-allocation (driven by data store Content-Length /
+// Attrs.Size) and the decompressed-bytes pre-allocation (driven by zstd's
+// FrameContentSize header). Either source could be a corrupt or hostile
+// number that would otherwise trigger an arbitrarily large allocation.
+// 1 GiB is well above any realistic Stellar batch size.
+const maxBatchObjectSize = 1 << 30
 
 // workerResult is sent from download workers to the writer goroutine.
 type workerResult struct {
@@ -77,6 +79,10 @@ type ledgerBuffer struct {
 
 	workerWg sync.WaitGroup
 	writerWg sync.WaitGroup
+
+	// closeOnce ensures close() is idempotent — it does close(resultChan)
+	// which would panic if called twice.
+	closeOnce sync.Once
 
 	// Pipeline: taskQueue -> workers -> resultChan -> writer -> ledgerQueue -> consumer
 	taskQueue   chan uint32
@@ -218,28 +224,41 @@ func (lb *ledgerBuffer) worker(ctx context.Context) {
 
 // writer receives unordered results from workers, accumulates out-of-order
 // results in a map, and emits them to ledgerQueue in sequential order.
+//
+// Watches lb.context.Done() in addition to ranging on resultChan because a
+// worker can call lb.cancel(...) on fatal errors WITHOUT close() ever being
+// called — without the ctx.Done case, the writer would block forever in the
+// receive once items drained, leaking the goroutine.
 func (lb *ledgerBuffer) writer() {
 	defer lb.writerWg.Done()
 
 	pending := make(map[uint32][]byte)
 	nextLedger := lb.ledgerRange.from
 
-	for result := range lb.resultChan {
-		pending[result.startLedger] = result.payload
-
-		for payload, ok := pending[nextLedger]; ok; payload, ok = pending[nextLedger] {
-			delete(pending, nextLedger)
-
-			lb.currentLedgerLock.Lock()
-			lb.currentLedger = nextLedger + lb.schema.LedgersPerFile
-			lb.currentLedgerLock.Unlock()
-
-			select {
-			case lb.ledgerQueue <- payload:
-			case <-lb.context.Done():
+	for {
+		select {
+		case <-lb.context.Done():
+			return
+		case result, ok := <-lb.resultChan:
+			if !ok {
 				return
 			}
-			nextLedger += lb.schema.LedgersPerFile
+			pending[result.startLedger] = result.payload
+
+			for payload, ok := pending[nextLedger]; ok; payload, ok = pending[nextLedger] {
+				delete(pending, nextLedger)
+
+				lb.currentLedgerLock.Lock()
+				lb.currentLedger = nextLedger + lb.schema.LedgersPerFile
+				lb.currentLedgerLock.Unlock()
+
+				select {
+				case lb.ledgerQueue <- payload:
+				case <-lb.context.Done():
+					return
+				}
+				nextLedger += lb.schema.LedgersPerFile
+			}
 		}
 	}
 }
@@ -258,7 +277,7 @@ func (lb *ledgerBuffer) downloadLedgerObject(ctx context.Context, sequence uint3
 	// Content-Length triggering a huge allocation. Falls back to ReadAll
 	// which grows naturally and is bounded by what the reader actually
 	// produces.
-	if compressedSize > 0 && compressedSize <= maxDecompressedBatchSize {
+	if compressedSize > 0 && compressedSize <= maxBatchObjectSize {
 		if int64(cap(*compressedBuf)) < compressedSize {
 			*compressedBuf = make([]byte, compressedSize)
 		} else {
@@ -278,7 +297,7 @@ func (lb *ledgerBuffer) downloadLedgerObject(ctx context.Context, sequence uint3
 	// DecodeAll grow naturally than reserve a huge buffer up front.
 	var dst []byte
 	var header zstd.Header
-	if err = header.Decode(*compressedBuf); err == nil && header.HasFCS && header.FrameContentSize <= maxDecompressedBatchSize {
+	if err = header.Decode(*compressedBuf); err == nil && header.HasFCS && header.FrameContentSize <= maxBatchObjectSize {
 		dst = lb.decompressedPool.Get(int(header.FrameContentSize))[:0]
 	}
 
@@ -330,11 +349,13 @@ func (lb *ledgerBuffer) getLatestLedgerSequence() (uint32, error) {
 }
 
 func (lb *ledgerBuffer) close() {
-	lb.cancel(context.Canceled)
-	lb.workerWg.Wait()
-	close(lb.resultChan)
-	lb.writerWg.Wait()
-	if lb.zstdDecoder != nil {
-		lb.zstdDecoder.Close()
-	}
+	lb.closeOnce.Do(func() {
+		lb.cancel(context.Canceled)
+		lb.workerWg.Wait()
+		close(lb.resultChan)
+		lb.writerWg.Wait()
+		if lb.zstdDecoder != nil {
+			lb.zstdDecoder.Close()
+		}
+	})
 }

--- a/ingest/ledgerbackend/ledger_buffer.go
+++ b/ingest/ledgerbackend/ledger_buffer.go
@@ -143,8 +143,15 @@ func (lb *ledgerBuffer) pushTaskQueue() {
 	if lb.ledgerRange.bounded && lb.nextTaskLedger > lb.schema.GetSequenceNumberEndBoundary(lb.ledgerRange.to) {
 		return
 	}
-	lb.taskQueue <- lb.nextTaskLedger
-	lb.nextTaskLedger += lb.schema.LedgersPerFile
+	// Guard the send with lb.context.Done() so a consumer can't deadlock
+	// here if cancellation arrives mid-send: workers exit on ctx.Done and
+	// stop draining taskQueue, which would otherwise leave this goroutine
+	// stuck on the unbounded send forever.
+	select {
+	case lb.taskQueue <- lb.nextTaskLedger:
+		lb.nextTaskLedger += lb.schema.LedgersPerFile
+	case <-lb.context.Done():
+	}
 }
 
 func (lb *ledgerBuffer) sleepWithContext(ctx context.Context, d time.Duration) bool {
@@ -246,7 +253,12 @@ func (lb *ledgerBuffer) downloadLedgerObject(ctx context.Context, sequence uint3
 	}
 	defer reader.Close()
 
-	if compressedSize > 0 {
+	// Skip the size-based pre-allocation if the data store reports an
+	// implausibly large object size — guards against a corrupt/hostile
+	// Content-Length triggering a huge allocation. Falls back to ReadAll
+	// which grows naturally and is bounded by what the reader actually
+	// produces.
+	if compressedSize > 0 && compressedSize <= maxDecompressedBatchSize {
 		if int64(cap(*compressedBuf)) < compressedSize {
 			*compressedBuf = make([]byte, compressedSize)
 		} else {

--- a/ingest/ledgerbackend/ledger_buffer.go
+++ b/ingest/ledgerbackend/ledger_buffer.go
@@ -13,6 +13,12 @@ import (
 	"github.com/stellar/go-stellar-sdk/support/datastore"
 )
 
+// maxDecompressedBatchSize bounds the size of a single decompressed batch
+// to guard against corrupt or malicious zstd FrameContentSize headers from
+// triggering an arbitrarily large allocation. 1 GiB is well above any
+// realistic Stellar batch size.
+const maxDecompressedBatchSize = 1 << 30
+
 // workerResult is sent from download workers to the writer goroutine.
 type workerResult struct {
 	payload     []byte
@@ -255,9 +261,12 @@ func (lb *ledgerBuffer) downloadLedgerObject(ctx context.Context, sequence uint3
 	}
 
 	// Pre-allocate the decompression buffer from the pool if possible.
+	// Skip the pre-alloc if the header reports an implausibly large frame
+	// size — that's either a bug or a hostile input, and we'd rather let
+	// DecodeAll grow naturally than reserve a huge buffer up front.
 	var dst []byte
 	var header zstd.Header
-	if err = header.Decode(*compressedBuf); err == nil && header.HasFCS {
+	if err = header.Decode(*compressedBuf); err == nil && header.HasFCS && header.FrameContentSize <= maxDecompressedBatchSize {
 		dst = lb.decompressedPool.Get(int(header.FrameContentSize))[:0]
 	}
 

--- a/ingest/ledgerbackend/ledger_buffer.go
+++ b/ingest/ledgerbackend/ledger_buffer.go
@@ -1,102 +1,139 @@
 package ledgerbackend
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"os"
 	"sync"
 	"time"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/pkg/errors"
 
-	"github.com/stellar/go-stellar-sdk/support/collections/heap"
-	"github.com/stellar/go-stellar-sdk/support/compressxdr"
 	"github.com/stellar/go-stellar-sdk/support/datastore"
-	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
-type ledgerBatchObject struct {
+// workerResult is sent from download workers to the writer goroutine.
+type workerResult struct {
 	payload     []byte
-	startLedger int // Ledger sequence used as the priority for the priorityqueue.
+	startLedger uint32
+}
+
+// bufferPool provides reusable byte buffers using a channel-based pool.
+// Unlike sync.Pool, buffers are NOT subject to GC collection, eliminating
+// repeated madvise/memclr overhead from re-allocating large buffers.
+type bufferPool struct {
+	ch chan []byte
+}
+
+func newBufferPool(size int) bufferPool {
+	return bufferPool{ch: make(chan []byte, size)}
+}
+
+func (p *bufferPool) Get(size int) []byte {
+	select {
+	case buf := <-p.ch:
+		if cap(buf) >= size {
+			return buf[:size]
+		}
+		// Undersized — discard it (let GC collect) so the pool naturally
+		// fills with correctly-sized buffers as new ones are allocated.
+	default:
+	}
+	// Allocate 25% extra capacity to absorb ledger size variation.
+	return make([]byte, size, size+size/4)
+}
+
+func (p *bufferPool) Put(buf []byte) {
+	if buf == nil {
+		return
+	}
+	select {
+	case p.ch <- buf[:0]:
+	default:
+	}
 }
 
 type ledgerBuffer struct {
-	// Passed through from BufferedStorageBackend to control lifetime of ledgerBuffer instance
 	config    BufferedStorageBackendConfig
 	dataStore datastore.DataStore
 	schema    datastore.DataStoreSchema
 
-	// context used to cancel workers within the ledgerBuffer
+	// zstdDecoder is a shared zstd decoder used by workers for decompression.
+	// DecodeAll is safe for concurrent use — it uses an internal pool of block decoders.
+	zstdDecoder *zstd.Decoder
+
+	// decompressedPool reuses buffers for decompressed batch data.
+	decompressedPool bufferPool
+
 	context context.Context
 	cancel  context.CancelCauseFunc
 
-	wg sync.WaitGroup
+	workerWg sync.WaitGroup
+	writerWg sync.WaitGroup
 
-	// The pipes and data structures below help establish the ledgerBuffer invariant which is
-	// the number of tasks (both pending and in-flight) + len(ledgerQueue) + ledgerPriorityQueue.Len()
-	// is always less than or equal to the config.BufferSize
-	taskQueue           chan uint32                   // Buffer next object read
-	ledgerQueue         chan []byte                   // Order corrected lcm batches
-	ledgerPriorityQueue *heap.Heap[ledgerBatchObject] // Priority is set to the sequence number
-	priorityQueueLock   sync.Mutex
+	// Pipeline: taskQueue -> workers -> resultChan -> writer -> ledgerQueue -> consumer
+	taskQueue   chan uint32
+	resultChan  chan workerResult
+	ledgerQueue chan []byte
 
-	// Keep track of the ledgers to be processed and the next ordering
-	// the ledgers should be buffered
-	currentLedger     uint32 // The current ledger that should be popped from ledgerPriorityQueue
-	nextTaskLedger    uint32 // The next task ledger that should be added to taskQueue
-	ledgerRange       Range
+	nextTaskLedger uint32
+	ledgerRange    Range
+
+	currentLedger     uint32
 	currentLedgerLock sync.RWMutex
 }
 
 func (bsb *BufferedStorageBackend) newLedgerBuffer(ledgerRange Range) (*ledgerBuffer, error) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 
-	less := func(a, b ledgerBatchObject) bool {
-		return a.startLedger < b.startLedger
-	}
-	// ensure BufferSize does not exceed the total range
+	// Use a local buffer size to avoid mutating the shared config.
+	bufferSize := bsb.config.BufferSize
 	if ledgerRange.bounded {
-		bsb.config.BufferSize = uint32(min(int(bsb.config.BufferSize), int(ledgerRange.to-ledgerRange.from)+1))
-	}
-	pq := heap.New(less, int(bsb.config.BufferSize))
-
-	ledgerBuffer := &ledgerBuffer{
-		config:              bsb.config,
-		dataStore:           bsb.dataStore,
-		schema:              bsb.schema,
-		taskQueue:           make(chan uint32, bsb.config.BufferSize),
-		ledgerQueue:         make(chan []byte, bsb.config.BufferSize),
-		ledgerPriorityQueue: pq,
-		currentLedger:       ledgerRange.from,
-		nextTaskLedger:      ledgerRange.from,
-		ledgerRange:         ledgerRange,
-		context:             ctx,
-		cancel:              cancel,
+		bufferSize = uint32(min(int(bufferSize), int(ledgerRange.to-ledgerRange.from)+1))
 	}
 
-	// Start workers to read LCM files
-	ledgerBuffer.wg.Add(int(bsb.config.NumWorkers))
+	decoder, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
+	if err != nil {
+		cancel(err)
+		return nil, errors.Wrap(err, "failed to create zstd decoder")
+	}
+
+	config := bsb.config
+	config.BufferSize = bufferSize
+
+	lb := &ledgerBuffer{
+		config:           config,
+		dataStore:        bsb.dataStore,
+		schema:           bsb.schema,
+		zstdDecoder:      decoder,
+		decompressedPool: newBufferPool(int(bufferSize) + 1),
+		taskQueue:        make(chan uint32, bufferSize),
+		resultChan:       make(chan workerResult, bufferSize),
+		ledgerQueue:      make(chan []byte, bufferSize),
+		currentLedger:    ledgerRange.from,
+		nextTaskLedger:   ledgerRange.from,
+		ledgerRange:      ledgerRange,
+		context:          ctx,
+		cancel:           cancel,
+	}
+
+	lb.workerWg.Add(int(bsb.config.NumWorkers))
 	for i := uint32(0); i < bsb.config.NumWorkers; i++ {
-		go ledgerBuffer.worker(ctx)
+		go lb.worker(ctx)
 	}
 
-	// Upon initialization, the ledgerBuffer invariant is maintained because
-	// we create bsb.config.BufferSize tasks while the len(ledgerQueue) and ledgerPriorityQueue.Len() are 0.
-	// Effectively, this is len(taskQueue) + len(ledgerQueue) + ledgerPriorityQueue.Len() <= bsb.config.BufferSize
-	// which enforces a limit of max tasks (both pending and in-flight) to be less than or equal to bsb.config.BufferSize.
-	// Note: when a task is in-flight it is no longer in the taskQueue
-	// but for easier conceptualization, len(taskQueue) can be interpreted as both pending and in-flight tasks
-	// where we assume the workers are empty and not processing any tasks.
-	for i := 0; i <= int(bsb.config.BufferSize); i++ {
-		ledgerBuffer.pushTaskQueue()
+	lb.writerWg.Add(1)
+	go lb.writer()
+
+	for i := 0; i <= int(bufferSize); i++ {
+		lb.pushTaskQueue()
 	}
 
-	return ledgerBuffer, nil
+	return lb, nil
 }
 
 func (lb *ledgerBuffer) pushTaskQueue() {
-	// In bounded mode, don't queue past the end boundary ledger for the specified range.
 	if lb.ledgerRange.bounded && lb.nextTaskLedger > lb.schema.GetSequenceNumberEndBoundary(lb.ledgerRange.to) {
 		return
 	}
@@ -104,7 +141,6 @@ func (lb *ledgerBuffer) pushTaskQueue() {
 	lb.nextTaskLedger += lb.schema.LedgersPerFile
 }
 
-// sleepWithContext returns true upon sleeping without interruption from the context
 func (lb *ledgerBuffer) sleepWithContext(ctx context.Context, d time.Duration) bool {
 	timer := time.NewTimer(d)
 	select {
@@ -119,7 +155,9 @@ func (lb *ledgerBuffer) sleepWithContext(ctx context.Context, d time.Duration) b
 }
 
 func (lb *ledgerBuffer) worker(ctx context.Context) {
-	defer lb.wg.Done()
+	defer lb.workerWg.Done()
+
+	var compressedBuf []byte
 
 	for {
 		select {
@@ -127,10 +165,9 @@ func (lb *ledgerBuffer) worker(ctx context.Context) {
 			return
 		case sequence := <-lb.taskQueue:
 			for attempt := uint32(0); attempt <= lb.config.RetryLimit; {
-				ledgerObject, err := lb.downloadLedgerObject(ctx, sequence)
+				ledgerObject, err := lb.downloadLedgerObject(ctx, sequence, &compressedBuf)
 				if err != nil {
 					if errors.Is(err, os.ErrNotExist) {
-						// ledgerObject not found and unbounded
 						if !lb.ledgerRange.bounded {
 							if !lb.sleepWithContext(ctx, lb.config.RetryWait) {
 								return
@@ -140,7 +177,6 @@ func (lb *ledgerBuffer) worker(ctx context.Context) {
 						lb.cancel(errors.Wrapf(err, "ledger object containing sequence %v is missing", sequence))
 						return
 					}
-					// don't bother retrying if we've received the signal to shut down
 					if errors.Is(err, context.Canceled) {
 						return
 					}
@@ -156,99 +192,128 @@ func (lb *ledgerBuffer) worker(ctx context.Context) {
 					continue
 				}
 
-				// When we store an object we still maintain the ledger buffer invariant because
-				// at this point the current task is finished and we add 1 ledger object to the priority queue.
-				// Thus, the number of tasks decreases by 1 and the priority queue length increases by 1.
-				// This keeps the overall total the same (<= BufferSize). As long as the the ledger buffer invariant
-				// was maintained in the previous state, it is still maintained during this state transition.
-				lb.storeObject(ledgerObject, sequence)
+				select {
+				case lb.resultChan <- workerResult{payload: ledgerObject, startLedger: sequence}:
+				case <-ctx.Done():
+					return
+				}
 				break
 			}
 		}
 	}
 }
 
-func (lb *ledgerBuffer) downloadLedgerObject(ctx context.Context, sequence uint32) ([]byte, error) {
-	objectKey := lb.schema.GetObjectKeyFromSequenceNumber(sequence)
+// writer receives unordered results from workers, accumulates out-of-order
+// results in a map, and emits them to ledgerQueue in sequential order.
+func (lb *ledgerBuffer) writer() {
+	defer lb.writerWg.Done()
 
-	reader, err := lb.dataStore.GetFile(ctx, objectKey)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to retrieve file: %s", objectKey)
-	}
+	pending := make(map[uint32][]byte)
+	nextLedger := lb.ledgerRange.from
 
-	defer reader.Close()
+	for result := range lb.resultChan {
+		pending[result.startLedger] = result.payload
 
-	objectBytes, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed reading file: %s", objectKey)
-	}
+		for payload, ok := pending[nextLedger]; ok; payload, ok = pending[nextLedger] {
+			delete(pending, nextLedger)
 
-	return objectBytes, nil
-}
+			lb.currentLedgerLock.Lock()
+			lb.currentLedger = nextLedger + lb.schema.LedgersPerFile
+			lb.currentLedgerLock.Unlock()
 
-func (lb *ledgerBuffer) storeObject(ledgerObject []byte, sequence uint32) {
-	lb.priorityQueueLock.Lock()
-	defer lb.priorityQueueLock.Unlock()
-
-	lb.currentLedgerLock.Lock()
-	defer lb.currentLedgerLock.Unlock()
-
-	lb.ledgerPriorityQueue.Push(ledgerBatchObject{
-		payload:     ledgerObject,
-		startLedger: int(sequence),
-	})
-
-	// Check if the nextLedger is the next item in the ledgerPriorityQueue
-	// The ledgerBuffer invariant is maintained here because items are transferred from the ledgerPriorityQueue to the ledgerQueue.
-	// Thus the overall sum of ledgerPriorityQueue.Len() + len(lb.ledgerQueue) remains the same.
-	for lb.ledgerPriorityQueue.Len() > 0 && lb.currentLedger == uint32(lb.ledgerPriorityQueue.Peek().startLedger) {
-		item := lb.ledgerPriorityQueue.Pop()
-		lb.ledgerQueue <- item.payload
-		lb.currentLedger += lb.schema.LedgersPerFile
-	}
-}
-
-func (lb *ledgerBuffer) getFromLedgerQueue(ctx context.Context) (xdr.LedgerCloseMetaBatch, error) {
-	for {
-		select {
-		case <-lb.context.Done():
-			return xdr.LedgerCloseMetaBatch{}, context.Cause(lb.context)
-		case <-ctx.Done():
-			return xdr.LedgerCloseMetaBatch{}, ctx.Err()
-		case compressedBinary := <-lb.ledgerQueue:
-			// The ledger buffer invariant is maintained here because
-			// we create an extra task when consuming one item from the ledger queue.
-			// Thus len(ledgerQueue) decreases by 1 and the number of tasks increases by 1.
-			// The overall sum below remains the same:
-			// len(taskQueue) + len(ledgerQueue) + ledgerPriorityQueue.Len() <= bsb.config.BufferSize
-			lb.pushTaskQueue()
-
-			lcmBatch := xdr.LedgerCloseMetaBatch{}
-			decoder := compressxdr.NewXDRDecoder(compressxdr.DefaultCompressor, &lcmBatch)
-			_, err := decoder.ReadFrom(bytes.NewReader(compressedBinary))
-			if err != nil {
-				return xdr.LedgerCloseMetaBatch{}, err
+			select {
+			case lb.ledgerQueue <- payload:
+			case <-lb.context.Done():
+				return
 			}
-
-			return lcmBatch, nil
+			nextLedger += lb.schema.LedgersPerFile
 		}
 	}
 }
 
+func (lb *ledgerBuffer) downloadLedgerObject(ctx context.Context, sequence uint32, compressedBuf *[]byte) ([]byte, error) {
+	objectKey := lb.schema.GetObjectKeyFromSequenceNumber(sequence)
+
+	reader, compressedSize, err := lb.dataStore.GetFile(ctx, objectKey)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to retrieve file: %s", objectKey)
+	}
+	defer reader.Close()
+
+	if compressedSize > 0 {
+		if int64(cap(*compressedBuf)) < compressedSize {
+			*compressedBuf = make([]byte, compressedSize)
+		} else {
+			*compressedBuf = (*compressedBuf)[:compressedSize]
+		}
+		_, err = io.ReadFull(reader, *compressedBuf)
+	} else {
+		*compressedBuf, err = io.ReadAll(reader)
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed reading file: %s", objectKey)
+	}
+
+	// Pre-allocate the decompression buffer from the pool if possible.
+	var dst []byte
+	var header zstd.Header
+	if err = header.Decode(*compressedBuf); err == nil && header.HasFCS {
+		dst = lb.decompressedPool.Get(int(header.FrameContentSize))[:0]
+	}
+
+	decompressed, err := lb.zstdDecoder.DecodeAll(*compressedBuf, dst)
+	if err != nil {
+		if dst != nil {
+			lb.decompressedPool.Put(dst)
+		}
+		return nil, errors.Wrapf(err, "failed decompressing file: %s", objectKey)
+	}
+
+	// If DecodeAll had to reallocate (dst too small), return the original
+	// pool buffer so it isn't leaked.
+	if dst != nil && cap(decompressed) != cap(dst) {
+		lb.decompressedPool.Put(dst)
+	}
+
+	return decompressed, nil
+}
+
+func (lb *ledgerBuffer) getFromLedgerQueue(ctx context.Context) ([]byte, error) {
+	for {
+		select {
+		case <-lb.context.Done():
+			return nil, context.Cause(lb.context)
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case batchBytes := <-lb.ledgerQueue:
+			lb.pushTaskQueue()
+			return batchBytes, nil
+		}
+	}
+}
+
+// returnBuffer returns a decompressed batch buffer to the pool for reuse.
+func (lb *ledgerBuffer) returnBuffer(buf []byte) {
+	lb.decompressedPool.Put(buf)
+}
+
 func (lb *ledgerBuffer) getLatestLedgerSequence() (uint32, error) {
-	lb.currentLedgerLock.Lock()
-	defer lb.currentLedgerLock.Unlock()
+	lb.currentLedgerLock.RLock()
+	defer lb.currentLedgerLock.RUnlock()
 
 	if lb.currentLedger == lb.ledgerRange.from {
 		return 0, nil
 	}
 
-	// Subtract 1 to get the latest ledger in buffer
 	return lb.currentLedger - 1, nil
 }
 
 func (lb *ledgerBuffer) close() {
 	lb.cancel(context.Canceled)
-	// wait for all workers to finish terminating
-	lb.wg.Wait()
+	lb.workerWg.Wait()
+	close(lb.resultChan)
+	lb.writerWg.Wait()
+	if lb.zstdDecoder != nil {
+		lb.zstdDecoder.Close()
+	}
 }

--- a/ingest/ledgerbackend/metrics.go
+++ b/ingest/ledgerbackend/metrics.go
@@ -42,3 +42,17 @@ func (m metricsLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (x
 	m.ledgerFetchDurationSummary.Observe(time.Since(startTime).Seconds())
 	return lcm, nil
 }
+
+// GetLedgerRaw is a passthrough to the wrapped backend, recording the same
+// ledgerFetchDurationSummary as GetLedger — both code paths are "fetches"
+// from the backend's perspective; the latency profile is dominated by I/O,
+// not by the marshal step.
+func (m metricsLedgerBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
+	startTime := time.Now()
+	raw, err := m.LedgerBackend.GetLedgerRaw(ctx, sequence)
+	if err != nil {
+		return nil, err
+	}
+	m.ledgerFetchDurationSummary.Observe(time.Since(startTime).Seconds())
+	return raw, nil
+}

--- a/ingest/ledgerbackend/metrics_test.go
+++ b/ingest/ledgerbackend/metrics_test.go
@@ -1,0 +1,46 @@
+package ledgerbackend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// TestMetricsGetLedgerRaw verifies that GetLedgerRaw on the metrics-decorated
+// backend records the same ledgerFetchDurationSummary as GetLedger (both are
+// "fetches" from the backend's perspective).
+func TestMetricsGetLedgerRaw(t *testing.T) {
+	ctx := context.Background()
+	mock := &MockDatabaseBackend{}
+	mock.On("GetLedgerRaw", ctx, uint32(5)).Return([]byte{0x01, 0x02, 0x03}, nil).Once()
+	mock.On("GetLedger", ctx, uint32(6)).Return(xdr.LedgerCloseMeta{}, nil).Once()
+	defer mock.AssertExpectations(t)
+
+	registry := prometheus.NewRegistry()
+	backend := WithMetrics(mock, registry, "test")
+
+	_, err := backend.GetLedgerRaw(ctx, 5)
+	require.NoError(t, err)
+	_, err = backend.GetLedger(ctx, 6)
+	require.NoError(t, err)
+
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+
+	var summary *io_prometheus_client.Summary
+	for _, mf := range metrics {
+		if mf.GetName() == "test_ingest_ledger_fetch_duration_seconds" {
+			require.Len(t, mf.Metric, 1)
+			summary = mf.Metric[0].Summary
+			break
+		}
+	}
+	require.NotNil(t, summary, "ledger_fetch_duration_seconds summary not found")
+	require.Equal(t, uint64(2), summary.GetSampleCount(),
+		"GetLedger and GetLedgerRaw should both record into the same summary")
+}

--- a/ingest/ledgerbackend/mock_database_backend.go
+++ b/ingest/ledgerbackend/mock_database_backend.go
@@ -34,6 +34,11 @@ func (m *MockDatabaseBackend) GetLedger(ctx context.Context, sequence uint32) (x
 	return args.Get(0).(xdr.LedgerCloseMeta), args.Error(1)
 }
 
+func (m *MockDatabaseBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
+	args := m.Called(ctx, sequence)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 func (m *MockDatabaseBackend) Close() error {
 	args := m.Called()
 	return args.Error(0)

--- a/ingest/ledgerbackend/rpc_backend.go
+++ b/ingest/ledgerbackend/rpc_backend.go
@@ -206,7 +206,7 @@ func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uin
 // PrepareRange initiates retrieval of requested ledger range.
 // It does minimal validation of data on RPC up front.
 // It wil check if starting point of range is withing current historical retention window of the RPC server.
-// It cannot gaurantee ledgers within historical ranges will be available when requested later by GetLedger.
+// It cannot gaurantee ledgers within historical ranges will be available when requested later by GetLedger or GetLedgerRaw.
 // See Also: GetLedger for more details on how the RPCLedgerBackend handles ledger availability.
 func (b *RPCLedgerBackend) PrepareRange(ctx context.Context, ledgerRange Range) error {
 	b.bufferLock.Lock()

--- a/ingest/ledgerbackend/rpc_backend.go
+++ b/ingest/ledgerbackend/rpc_backend.go
@@ -158,7 +158,7 @@ func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uin
 	}
 
 	if b.preparedRange == nil {
-		return rpcBufferedLedger{}, fmt.Errorf("RPCLedgerBackend must be prepared before calling GetLedger")
+		return rpcBufferedLedger{}, fmt.Errorf("RPCLedgerBackend must be prepared before calling GetLedger or GetLedgerRaw")
 	}
 
 	if sequence < b.preparedRange.from || (b.preparedRange.bounded && sequence > b.preparedRange.to) {

--- a/ingest/ledgerbackend/rpc_backend.go
+++ b/ingest/ledgerbackend/rpc_backend.go
@@ -38,17 +38,12 @@ type RPCLedgerGetter interface {
 	GetHealth(ctx context.Context) (protocol.GetHealthResponse, error) // <-- Added
 }
 
-// rpcBufferedLedger holds the XDR wire bytes for a single ledger plus its
-// sequence number (extracted via view at fetch time so we don't have to
-// decode just to populate the buffer key). GetLedger decodes lazily;
-// GetLedgerRaw avoids the unmarshal entirely.
-type rpcBufferedLedger struct {
-	raw []byte
-}
-
 type RPCLedgerBackend struct {
-	client             RPCLedgerGetter
-	buffer             map[uint32]rpcBufferedLedger
+	client RPCLedgerGetter
+	// buffer maps ledger sequence to the raw XDR wire bytes from the most
+	// recent RPC fetch. GetLedger decodes lazily from these bytes;
+	// GetLedgerRaw returns a copy without decoding.
+	buffer             map[uint32][]byte
 	bufferSize         uint32
 	preparedRange      *Range
 	nextLedger         uint32
@@ -128,14 +123,14 @@ func (b *RPCLedgerBackend) GetLatestLedgerSequence(ctx context.Context) (sequenc
 func (b *RPCLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
 	b.bufferLock.Lock()
 	defer b.bufferLock.Unlock()
-	l, err := b.fetchSequenceLocked(ctx, sequence)
+	raw, err := b.fetchSequenceLocked(ctx, sequence)
 	if err != nil {
 		return xdr.LedgerCloseMeta{}, err
 	}
 	// Decode lazily from the cached raw bytes — only GetLedger callers pay
 	// the XDR unmarshal cost; GetLedgerRaw avoids it entirely.
 	var lcm xdr.LedgerCloseMeta
-	if err := xdr.SafeUnmarshal(l.raw, &lcm); err != nil {
+	if err := xdr.SafeUnmarshal(raw, &lcm); err != nil {
 		return xdr.LedgerCloseMeta{}, fmt.Errorf("failed to unmarshal cached ledger: %w", err)
 	}
 	return lcm, nil
@@ -147,28 +142,28 @@ func (b *RPCLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.
 func (b *RPCLedgerBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
 	b.bufferLock.Lock()
 	defer b.bufferLock.Unlock()
-	l, err := b.fetchSequenceLocked(ctx, sequence)
+	raw, err := b.fetchSequenceLocked(ctx, sequence)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]byte, len(l.raw))
-	copy(out, l.raw)
+	out := make([]byte, len(raw))
+	copy(out, raw)
 	return out, nil
 }
 
 // fetchSequenceLocked is the shared body of GetLedger / GetLedgerRaw. The
 // caller must hold b.bufferLock. On success, advances b.nextLedger.
-func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uint32) (rpcBufferedLedger, error) {
+func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uint32) ([]byte, error) {
 	if err := b.checkClosed(); err != nil {
-		return rpcBufferedLedger{}, err
+		return nil, err
 	}
 
 	if b.preparedRange == nil {
-		return rpcBufferedLedger{}, fmt.Errorf("RPCLedgerBackend must be prepared before calling GetLedger or GetLedgerRaw")
+		return nil, fmt.Errorf("RPCLedgerBackend must be prepared before calling GetLedger or GetLedgerRaw")
 	}
 
 	if sequence < b.preparedRange.from || (b.preparedRange.bounded && sequence > b.preparedRange.to) {
-		return rpcBufferedLedger{}, fmt.Errorf("requested ledger %d is outside prepared range [%d, %d]",
+		return nil, fmt.Errorf("requested ledger %d is outside prepared range [%d, %d]",
 			sequence, b.preparedRange.from, b.preparedRange.to)
 	}
 
@@ -176,33 +171,33 @@ func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uin
 	// the current buffer, return it without advancing nextLedger. Matches the
 	// behavior of CaptiveStellarCore and BufferedStorageBackend.
 	if sequence < b.nextLedger {
-		if l, exists := b.buffer[sequence]; exists {
-			return l, nil
+		if raw, exists := b.buffer[sequence]; exists {
+			return raw, nil
 		}
-		return rpcBufferedLedger{}, fmt.Errorf("requested ledger %d precedes next expected %d", sequence, b.nextLedger)
+		return nil, fmt.Errorf("requested ledger %d precedes next expected %d", sequence, b.nextLedger)
 	}
 
 	if sequence != b.nextLedger {
-		return rpcBufferedLedger{}, fmt.Errorf("requested ledger %d is not the expected ledger %d", sequence, b.nextLedger)
+		return nil, fmt.Errorf("requested ledger %d is not the expected ledger %d", sequence, b.nextLedger)
 	}
 
 	for {
-		l, err := b.getBufferedLedger(ctx, sequence)
+		raw, err := b.getBufferedLedger(ctx, sequence)
 		if err == nil {
 			b.nextLedger = sequence + 1
-			return l, nil
+			return raw, nil
 		}
 
 		var beyondErr *rpcLedgerBeyondLatestError
 		if !(errors.As(err, &beyondErr)) {
-			return rpcBufferedLedger{}, err
+			return nil, err
 		}
 
 		select {
 		case <-b.closed:
-			return rpcBufferedLedger{}, fmt.Errorf("RPCLedgerBackend is closed: %w", err)
+			return nil, fmt.Errorf("RPCLedgerBackend is closed: %w", err)
 		case <-ctx.Done():
-			return rpcBufferedLedger{}, ctx.Err()
+			return nil, ctx.Err()
 		case <-time.After(time.Duration(rpcBackendDefaultWaitIntervalSeconds) * time.Second):
 			continue
 		}
@@ -278,21 +273,21 @@ func (b *RPCLedgerBackend) checkClosed() error {
 }
 
 func (b *RPCLedgerBackend) initBuffer() {
-	b.buffer = make(map[uint32]rpcBufferedLedger)
+	b.buffer = make(map[uint32][]byte)
 }
 
-func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint32) (rpcBufferedLedger, error) {
-	if l, exists := b.buffer[sequence]; exists {
-		return l, nil
+func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint32) ([]byte, error) {
+	if raw, exists := b.buffer[sequence]; exists {
+		return raw, nil
 	}
 
 	// Check if requested ledger is beyond the RPC retention window using GetHealth
 	health, err := b.client.GetHealth(ctx)
 	if err != nil {
-		return rpcBufferedLedger{}, fmt.Errorf("failed to get health from RPC: %w", err)
+		return nil, fmt.Errorf("failed to get health from RPC: %w", err)
 	}
 	if sequence > health.LatestLedger {
-		return rpcBufferedLedger{}, &rpcLedgerBeyondLatestError{}
+		return nil, &rpcLedgerBeyondLatestError{}
 	}
 
 	// attempt to fetch a small batch from RPC starting from the requested sequence
@@ -305,7 +300,7 @@ func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint3
 
 	ledgers, err := b.client.GetLedgers(ctx, req)
 	if err != nil {
-		return rpcBufferedLedger{}, err
+		return nil, err
 	}
 
 	b.initBuffer()
@@ -315,9 +310,9 @@ func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint3
 	for _, ledger := range ledgers.Ledgers {
 		raw, err := base64.StdEncoding.DecodeString(ledger.LedgerMetadata)
 		if err != nil {
-			return rpcBufferedLedger{}, fmt.Errorf("failed to base64-decode ledger %d: %w", ledger.Sequence, err)
+			return nil, fmt.Errorf("failed to base64-decode ledger %d: %w", ledger.Sequence, err)
 		}
-		b.buffer[ledger.Sequence] = rpcBufferedLedger{raw: raw}
+		b.buffer[ledger.Sequence] = raw
 	}
 
 	latestSeq := uint32(0)
@@ -326,9 +321,9 @@ func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint3
 	}
 	b.latestBufferLedger.Store(latestSeq)
 
-	if l, exists := b.buffer[sequence]; exists {
-		return l, nil
+	if raw, exists := b.buffer[sequence]; exists {
+		return raw, nil
 	}
 
-	return rpcBufferedLedger{}, &RPCLedgerMissingError{Sequence: sequence}
+	return nil, &RPCLedgerMissingError{Sequence: sequence}
 }

--- a/ingest/ledgerbackend/rpc_backend.go
+++ b/ingest/ledgerbackend/rpc_backend.go
@@ -205,8 +205,8 @@ func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uin
 
 // PrepareRange initiates retrieval of requested ledger range.
 // It does minimal validation of data on RPC up front.
-// It wil check if starting point of range is withing current historical retention window of the RPC server.
-// It cannot gaurantee ledgers within historical ranges will be available when requested later by GetLedger or GetLedgerRaw.
+// It will check if starting point of range is within current historical retention window of the RPC server.
+// It cannot guarantee ledgers within historical ranges will be available when requested later by GetLedger or GetLedgerRaw.
 // See Also: GetLedger for more details on how the RPCLedgerBackend handles ledger availability.
 func (b *RPCLedgerBackend) PrepareRange(ctx context.Context, ledgerRange Range) error {
 	b.bufferLock.Lock()

--- a/ingest/ledgerbackend/rpc_backend.go
+++ b/ingest/ledgerbackend/rpc_backend.go
@@ -38,12 +38,12 @@ type RPCLedgerGetter interface {
 	GetHealth(ctx context.Context) (protocol.GetHealthResponse, error) // <-- Added
 }
 
-// rpcBufferedLedger holds both the XDR wire bytes and the decoded form for a
-// single ledger so GetLedger and GetLedgerRaw can be served from a single
-// fetch + base64-decode without re-marshaling.
+// rpcBufferedLedger holds the XDR wire bytes for a single ledger plus its
+// sequence number (extracted via view at fetch time so we don't have to
+// decode just to populate the buffer key). GetLedger decodes lazily;
+// GetLedgerRaw avoids the unmarshal entirely.
 type rpcBufferedLedger struct {
-	raw  []byte
-	meta xdr.LedgerCloseMeta
+	raw []byte
 }
 
 type RPCLedgerBackend struct {
@@ -132,12 +132,18 @@ func (b *RPCLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.
 	if err != nil {
 		return xdr.LedgerCloseMeta{}, err
 	}
-	return l.meta, nil
+	// Decode lazily from the cached raw bytes — only GetLedger callers pay
+	// the XDR unmarshal cost; GetLedgerRaw avoids it entirely.
+	var lcm xdr.LedgerCloseMeta
+	if err := xdr.SafeUnmarshal(l.raw, &lcm); err != nil {
+		return xdr.LedgerCloseMeta{}, fmt.Errorf("failed to unmarshal cached ledger: %w", err)
+	}
+	return lcm, nil
 }
 
 // GetLedgerRaw returns the XDR wire bytes for the requested sequence without
-// re-marshaling. The buffer holds the base64-decoded bytes that were used to
-// produce the decoded form, so this is a copy of already-fetched data.
+// any XDR decoding. The buffer holds the base64-decoded bytes from the RPC
+// response, so this is a copy of already-fetched data.
 func (b *RPCLedgerBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
 	b.bufferLock.Lock()
 	defer b.bufferLock.Unlock()
@@ -304,20 +310,14 @@ func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint3
 
 	b.initBuffer()
 
-	// Populate buffer with new ledgers — base64-decode once into raw bytes,
-	// then unmarshal those same bytes. This way GetLedgerRaw returns the raw
-	// bytes without re-encoding and GetLedger returns the decoded form without
-	// re-decoding.
+	// Populate buffer with new ledgers — base64-decode once into raw bytes.
+	// GetLedger decodes lazily from these bytes; GetLedgerRaw returns a copy.
 	for _, ledger := range ledgers.Ledgers {
 		raw, err := base64.StdEncoding.DecodeString(ledger.LedgerMetadata)
 		if err != nil {
 			return rpcBufferedLedger{}, fmt.Errorf("failed to base64-decode ledger %d: %w", ledger.Sequence, err)
 		}
-		var lcm xdr.LedgerCloseMeta
-		if err := xdr.SafeUnmarshal(raw, &lcm); err != nil {
-			return rpcBufferedLedger{}, fmt.Errorf("failed to unmarshal ledger %d: %w", ledger.Sequence, err)
-		}
-		b.buffer[ledger.Sequence] = rpcBufferedLedger{raw: raw, meta: lcm}
+		b.buffer[ledger.Sequence] = rpcBufferedLedger{raw: raw}
 	}
 
 	latestSeq := uint32(0)

--- a/ingest/ledgerbackend/rpc_backend.go
+++ b/ingest/ledgerbackend/rpc_backend.go
@@ -2,6 +2,7 @@ package ledgerbackend
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -37,9 +38,17 @@ type RPCLedgerGetter interface {
 	GetHealth(ctx context.Context) (protocol.GetHealthResponse, error) // <-- Added
 }
 
+// rpcBufferedLedger holds both the XDR wire bytes and the decoded form for a
+// single ledger so GetLedger and GetLedgerRaw can be served from a single
+// fetch + base64-decode without re-marshaling.
+type rpcBufferedLedger struct {
+	raw  []byte
+	meta xdr.LedgerCloseMeta
+}
+
 type RPCLedgerBackend struct {
 	client             RPCLedgerGetter
-	buffer             map[uint32]xdr.LedgerCloseMeta
+	buffer             map[uint32]rpcBufferedLedger
 	bufferSize         uint32
 	preparedRange      *Range
 	nextLedger         uint32
@@ -119,41 +128,75 @@ func (b *RPCLedgerBackend) GetLatestLedgerSequence(ctx context.Context) (sequenc
 func (b *RPCLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
 	b.bufferLock.Lock()
 	defer b.bufferLock.Unlock()
-
-	if err := b.checkClosed(); err != nil {
+	l, err := b.fetchSequenceLocked(ctx, sequence)
+	if err != nil {
 		return xdr.LedgerCloseMeta{}, err
+	}
+	return l.meta, nil
+}
+
+// GetLedgerRaw returns the XDR wire bytes for the requested sequence without
+// re-marshaling. The buffer holds the base64-decoded bytes that were used to
+// produce the decoded form, so this is a copy of already-fetched data.
+func (b *RPCLedgerBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
+	b.bufferLock.Lock()
+	defer b.bufferLock.Unlock()
+	l, err := b.fetchSequenceLocked(ctx, sequence)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, len(l.raw))
+	copy(out, l.raw)
+	return out, nil
+}
+
+// fetchSequenceLocked is the shared body of GetLedger / GetLedgerRaw. The
+// caller must hold b.bufferLock. On success, advances b.nextLedger.
+func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uint32) (rpcBufferedLedger, error) {
+	if err := b.checkClosed(); err != nil {
+		return rpcBufferedLedger{}, err
 	}
 
 	if b.preparedRange == nil {
-		return xdr.LedgerCloseMeta{}, fmt.Errorf("RPCLedgerBackend must be prepared before calling GetLedger")
+		return rpcBufferedLedger{}, fmt.Errorf("RPCLedgerBackend must be prepared before calling GetLedger")
 	}
 
 	if sequence < b.preparedRange.from || (b.preparedRange.bounded && sequence > b.preparedRange.to) {
-		return xdr.LedgerCloseMeta{}, fmt.Errorf("requested ledger %d is outside prepared range [%d, %d]",
+		return rpcBufferedLedger{}, fmt.Errorf("requested ledger %d is outside prepared range [%d, %d]",
 			sequence, b.preparedRange.from, b.preparedRange.to)
 	}
 
+	// Idempotent re-request: if a previously-served ledger is still cached in
+	// the current buffer, return it without advancing nextLedger. Matches the
+	// behavior of CaptiveStellarCore and BufferedStorageBackend.
+	if sequence < b.nextLedger {
+		if l, exists := b.buffer[sequence]; exists {
+			return l, nil
+		}
+		return rpcBufferedLedger{}, fmt.Errorf("requested ledger %d precedes next expected %d", sequence, b.nextLedger)
+	}
+
 	if sequence != b.nextLedger {
-		return xdr.LedgerCloseMeta{}, fmt.Errorf("requested ledger %d is not the expected ledger %d", sequence, b.nextLedger)
+		return rpcBufferedLedger{}, fmt.Errorf("requested ledger %d is not the expected ledger %d", sequence, b.nextLedger)
 	}
 
 	for {
-		lcm, err := b.getBufferedLedger(ctx, sequence)
+		l, err := b.getBufferedLedger(ctx, sequence)
 		if err == nil {
 			b.nextLedger = sequence + 1
-			return lcm, nil
+			return l, nil
 		}
 
 		var beyondErr *rpcLedgerBeyondLatestError
 		if !(errors.As(err, &beyondErr)) {
-			return xdr.LedgerCloseMeta{}, err
+			return rpcBufferedLedger{}, err
 		}
 
 		select {
 		case <-b.closed:
-			return xdr.LedgerCloseMeta{}, fmt.Errorf("RPCLedgerBackend is closed: %w", err)
+			return rpcBufferedLedger{}, fmt.Errorf("RPCLedgerBackend is closed: %w", err)
 		case <-ctx.Done():
-			return xdr.LedgerCloseMeta{}, ctx.Err()
+			return rpcBufferedLedger{}, ctx.Err()
 		case <-time.After(time.Duration(rpcBackendDefaultWaitIntervalSeconds) * time.Second):
 			continue
 		}
@@ -229,22 +272,21 @@ func (b *RPCLedgerBackend) checkClosed() error {
 }
 
 func (b *RPCLedgerBackend) initBuffer() {
-	b.buffer = make(map[uint32]xdr.LedgerCloseMeta)
+	b.buffer = make(map[uint32]rpcBufferedLedger)
 }
 
-func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
-	// Check if ledger is in buffer
-	if lcm, exists := b.buffer[sequence]; exists {
-		return lcm, nil
+func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint32) (rpcBufferedLedger, error) {
+	if l, exists := b.buffer[sequence]; exists {
+		return l, nil
 	}
 
 	// Check if requested ledger is beyond the RPC retention window using GetHealth
 	health, err := b.client.GetHealth(ctx)
 	if err != nil {
-		return xdr.LedgerCloseMeta{}, fmt.Errorf("failed to get health from RPC: %w", err)
+		return rpcBufferedLedger{}, fmt.Errorf("failed to get health from RPC: %w", err)
 	}
 	if sequence > health.LatestLedger {
-		return xdr.LedgerCloseMeta{}, &rpcLedgerBeyondLatestError{}
+		return rpcBufferedLedger{}, &rpcLedgerBeyondLatestError{}
 	}
 
 	// attempt to fetch a small batch from RPC starting from the requested sequence
@@ -257,18 +299,25 @@ func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint3
 
 	ledgers, err := b.client.GetLedgers(ctx, req)
 	if err != nil {
-		return xdr.LedgerCloseMeta{}, err
+		return rpcBufferedLedger{}, err
 	}
 
 	b.initBuffer()
 
-	// Populate buffer with new ledgers
+	// Populate buffer with new ledgers — base64-decode once into raw bytes,
+	// then unmarshal those same bytes. This way GetLedgerRaw returns the raw
+	// bytes without re-encoding and GetLedger returns the decoded form without
+	// re-decoding.
 	for _, ledger := range ledgers.Ledgers {
-		var lcm xdr.LedgerCloseMeta
-		if err := xdr.SafeUnmarshalBase64(ledger.LedgerMetadata, &lcm); err != nil {
-			return xdr.LedgerCloseMeta{}, fmt.Errorf("failed to unmarshal ledger %d: %w", ledger.Sequence, err)
+		raw, err := base64.StdEncoding.DecodeString(ledger.LedgerMetadata)
+		if err != nil {
+			return rpcBufferedLedger{}, fmt.Errorf("failed to base64-decode ledger %d: %w", ledger.Sequence, err)
 		}
-		b.buffer[ledger.Sequence] = lcm
+		var lcm xdr.LedgerCloseMeta
+		if err := xdr.SafeUnmarshal(raw, &lcm); err != nil {
+			return rpcBufferedLedger{}, fmt.Errorf("failed to unmarshal ledger %d: %w", ledger.Sequence, err)
+		}
+		b.buffer[ledger.Sequence] = rpcBufferedLedger{raw: raw, meta: lcm}
 	}
 
 	latestSeq := uint32(0)
@@ -277,10 +326,9 @@ func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint3
 	}
 	b.latestBufferLedger.Store(latestSeq)
 
-	// Check if requested ledger is in new buffer
-	if lcm, exists := b.buffer[sequence]; exists {
-		return lcm, nil
+	if l, exists := b.buffer[sequence]; exists {
+		return l, nil
 	}
 
-	return xdr.LedgerCloseMeta{}, &RPCLedgerMissingError{Sequence: sequence}
+	return rpcBufferedLedger{}, &RPCLedgerMissingError{Sequence: sequence}
 }

--- a/ingest/ledgerbackend/rpc_backend_test.go
+++ b/ingest/ledgerbackend/rpc_backend_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -127,6 +128,68 @@ func TestRPCGetLedger(t *testing.T) {
 	_, err = rpcBackend.GetLedger(ctx, sequence)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "RPCLedgerBackend is closed")
+}
+
+// TestRPCGetLedgerRaw exercises the GetLedgerRaw zero-copy path: the RPC
+// response's base64-encoded LedgerMetadata is decoded once into raw bytes,
+// the same bytes are returned (as a copy) without re-marshaling, and the
+// bytes round-trip to a valid LedgerCloseMeta.
+func TestRPCGetLedgerRaw(t *testing.T) {
+	rpcBackend, mockClient := setupRPCTest(t)
+	ctx := context.Background()
+	sequence := uint32(12345)
+
+	mockClient.On("GetHealth", ctx).Return(protocol.GetHealthResponse{
+		LatestLedger: sequence + 10,
+	}, nil)
+
+	lcm := xdr.LedgerCloseMeta{
+		V: 0,
+		V0: &xdr.LedgerCloseMetaV0{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					LedgerSeq: xdr.Uint32(sequence),
+				},
+			},
+		},
+	}
+	encodedLCM, err := xdr.MarshalBase64(lcm)
+	assert.NoError(t, err)
+
+	mockClient.On("GetLedgers", ctx, protocol.GetLedgersRequest{
+		StartLedger: sequence,
+		Pagination:  &protocol.LedgerPaginationOptions{Limit: uint(rpcBackendDefaultBufferSize)},
+	}).Return(protocol.GetLedgersResponse{
+		Ledgers:      []protocol.LedgerInfo{{Sequence: sequence, LedgerMetadata: encodedLCM}},
+		LatestLedger: sequence + 10,
+	}, nil).Once()
+
+	preparedRange := Range{from: sequence, to: sequence + 10, bounded: true}
+	rpcBackend.PrepareRange(ctx, preparedRange)
+
+	rawBytes, err := rpcBackend.GetLedgerRaw(ctx, sequence)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, rawBytes)
+
+	// Round-trip: bytes should decode to the original LedgerCloseMeta.
+	var decoded xdr.LedgerCloseMeta
+	require.NoError(t, xdr.SafeUnmarshal(rawBytes, &decoded))
+	assert.Equal(t, lcm, decoded)
+
+	// Idempotent re-request: GetLedgerRaw on the same sequence returns the
+	// cached bytes without making another RPC call.
+	rawBytes2, err := rpcBackend.GetLedgerRaw(ctx, sequence)
+	assert.NoError(t, err)
+	assert.Equal(t, rawBytes, rawBytes2)
+
+	// Returned bytes must be a copy, not aliased — mutating one must not
+	// affect a subsequent fetch.
+	if len(rawBytes) > 0 {
+		rawBytes[0] ^= 0xFF
+	}
+	rawBytes3, err := rpcBackend.GetLedgerRaw(ctx, sequence)
+	assert.NoError(t, err)
+	assert.Equal(t, rawBytes2, rawBytes3, "GetLedgerRaw must return a copy, not an aliased slice")
 }
 
 func TestRPCBackendImplementsInterface(t *testing.T) {

--- a/ingest/ledgerbackend/rpc_backend_test.go
+++ b/ingest/ledgerbackend/rpc_backend_test.go
@@ -92,10 +92,13 @@ func TestRPCGetLedger(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, sequence, uint32(actualLCM.V0.LedgerHeader.Header.LedgerSeq))
 
-	// Test requesteed ledger is not contiguous, ascending from last invocation
-	_, err = rpcBackend.GetLedger(ctx, sequence)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "requested ledger 12345 is not the expected ledger 12346")
+	// Test idempotent re-request of the previously-served ledger: the ledger
+	// is still in the buffer, so the call returns it without advancing
+	// nextLedger or making another RPC call. Matches the behavior of
+	// CaptiveStellarCore and BufferedStorageBackend.
+	cachedLCM, err := rpcBackend.GetLedger(ctx, sequence)
+	assert.NoError(t, err)
+	assert.Equal(t, actualLCM, cachedLCM)
 
 	// Test requested ledger is outside of prepared range
 	_, err = rpcBackend.GetLedger(ctx, sequence+50)

--- a/ingest/loadtest/ledger_backend.go
+++ b/ingest/loadtest/ledger_backend.go
@@ -406,6 +406,18 @@ func (r *LedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.Led
 	return r.cachedLedger, nil
 }
 
+// GetLedgerRaw is a baseline implementation that calls GetLedger and marshals
+// the result. The load-test backend reads ledgers from an XDR stream and may
+// merge with real ledgers from the wrapped backend; this routes through the
+// merged-stream path rather than maintaining a parallel raw-bytes cache.
+func (r *LedgerBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
+	lcm, err := r.GetLedger(ctx, sequence)
+	if err != nil {
+		return nil, err
+	}
+	return lcm.MarshalBinary()
+}
+
 func (r *LedgerBackend) Close() error {
 	r.lock.Lock()
 	defer r.lock.Unlock()

--- a/ingest/loadtest/ledger_backend_test.go
+++ b/ingest/loadtest/ledger_backend_test.go
@@ -26,6 +26,11 @@ func (m *mockLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr
 	return args.Get(0).(xdr.LedgerCloseMeta), args.Error(1)
 }
 
+func (m *mockLedgerBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
+	args := m.Called(ctx, sequence)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 func (m *mockLedgerBackend) PrepareRange(ctx context.Context, ledgerRange ledgerbackend.Range) error {
 	args := m.Called(ctx, ledgerRange)
 	return args.Error(0)

--- a/ingest/producer.go
+++ b/ingest/producer.go
@@ -35,7 +35,11 @@ func DefaultBufferedStorageBackendConfig(ledgersPerFile uint32) ledgerbackend.Bu
 
 	switch {
 	case ledgersPerFile < 64:
-		config.BufferSize = 100
+		// Large buffer so a bounded range fits entirely; workers see all
+		// queued tasks upfront instead of throttling on the per-consumer-pull
+		// pushTaskQueue feedback loop. newLedgerBuffer caps it to the range
+		// size, so 10k is an upper bound rather than a fixed allocation.
+		config.BufferSize = 10000
 		config.NumWorkers = 10
 		return config
 	default:

--- a/ingest/producer_test.go
+++ b/ingest/producer_test.go
@@ -115,7 +115,7 @@ func TestBSBProducerFnConfigError(t *testing.T) {
 		return nil
 	}
 	mockDataStore.On("GetFile", mock.Anything, ".config.json").
-		Return(io.NopCloser(bytes.NewReader(configManifestJSON(t))), nil).Once()
+		Return(io.NopCloser(bytes.NewReader(configManifestJSON(t))), int64(-1), nil).Once()
 	mockDataStore.On("ListFilePaths", mock.Anything, datastore.ListFileOptions{}).Return(nil, nil)
 
 	datastoreFactory = func(_ context.Context, _ datastore.DataStoreConfig) (datastore.DataStore, error) {
@@ -135,7 +135,7 @@ func TestBSBProducerFnInvalidRange(t *testing.T) {
 	}
 	mockDataStore := new(datastore.MockDataStore)
 	mockDataStore.On("GetFile", mock.Anything, ".config.json").
-		Return(io.NopCloser(bytes.NewReader(configManifestJSON(t))), nil).Once()
+		Return(io.NopCloser(bytes.NewReader(configManifestJSON(t))), int64(-1), nil).Once()
 	mockDataStore.On("ListFilePaths", mock.Anything, datastore.ListFileOptions{}).Return(nil, nil)
 
 	appCallback := func(lcm xdr.LedgerCloseMeta) error {
@@ -162,12 +162,12 @@ func TestBSBProducerFnGetLedgerError(t *testing.T) {
 	pubConfig.BufferedStorageConfig.RetryLimit = 0
 	mockDataStore := new(datastore.MockDataStore)
 	mockDataStore.On("GetFile", mock.Anything, ".config.json").
-		Return(io.NopCloser(bytes.NewReader(configManifestJSON(t))), nil).Once()
+		Return(io.NopCloser(bytes.NewReader(configManifestJSON(t))), int64(-1), nil).Once()
 
-	mockDataStore.On("GetFile", mock.Anything, "FFFFFFFD--2.xdr.zst").Return(nil, os.ErrNotExist).Once()
+	mockDataStore.On("GetFile", mock.Anything, "FFFFFFFD--2.xdr.zst").Return(nil, int64(0), os.ErrNotExist).Once()
 	// since buffer is multi-worker async, it may get to this on other worker, but not deterministic,
 	// don't assert on it
-	mockDataStore.On("GetFile", mock.Anything, "FFFFFFFC--3.xdr.zst").Return(makeSingleLCMBatch(3), nil).Maybe()
+	mockDataStore.On("GetFile", mock.Anything, "FFFFFFFC--3.xdr.zst").Return(makeSingleLCMBatch(3), int64(-1), nil).Maybe()
 	mockDataStore.On("ListFilePaths", mock.Anything, datastore.ListFileOptions{}).Return(nil, nil)
 
 	appCallback := func(lcm xdr.LedgerCloseMeta) error {
@@ -231,13 +231,13 @@ func createMockdataStore(t *testing.T, start, end, partitionSize uint32) *datast
 	require.NoError(t, err)
 
 	mockDataStore.On("GetFile", mock.Anything, ".config.json").
-		Return(io.NopCloser(bytes.NewReader(configJSON)), nil).Once()
+		Return(io.NopCloser(bytes.NewReader(configJSON)), int64(-1), nil).Once()
 	mockDataStore.On("ListFilePaths", mock.Anything, datastore.ListFileOptions{}).Return(nil, nil)
 
 	partition := partitionSize - 1
 	for i := start; i <= end; i++ {
 		objectName := fmt.Sprintf("FFFFFFFF--0-%d/%08X--%d.xdr.zst", partition, math.MaxUint32-i, i)
-		mockDataStore.On("GetFile", mock.Anything, objectName).Return(makeSingleLCMBatch(i), nil).Once()
+		mockDataStore.On("GetFile", mock.Anything, objectName).Return(makeSingleLCMBatch(i), int64(-1), nil).Once()
 	}
 
 	t.Cleanup(func() {

--- a/ingest/producer_test.go
+++ b/ingest/producer_test.go
@@ -26,7 +26,7 @@ func TestDefaultBSBConfigs(t *testing.T) {
 	smallConfig := ledgerbackend.BufferedStorageBackendConfig{
 		RetryLimit: 5,
 		RetryWait:  30 * time.Second,
-		BufferSize: 100,
+		BufferSize: 10000,
 		NumWorkers: 10,
 	}
 

--- a/support/datastore/configure.go
+++ b/support/datastore/configure.go
@@ -61,7 +61,7 @@ func createManifest(ctx context.Context, dataStore DataStore, cfg DataStoreConfi
 }
 
 func readManifest(ctx context.Context, dataStore DataStore, filename string) (DatastoreManifest, error) {
-	reader, err := dataStore.GetFile(ctx, filename)
+	reader, _, err := dataStore.GetFile(ctx, filename)
 	if err != nil {
 		return DatastoreManifest{}, fmt.Errorf("unable to open manifest file %q: %w", filename, err)
 	}

--- a/support/datastore/configure_test.go
+++ b/support/datastore/configure_test.go
@@ -40,7 +40,7 @@ func TestConfigureDatastore(t *testing.T) {
 		mockDataStore := new(MockDataStore)
 		ctx := context.Background()
 
-		mockDataStore.On("GetFile", ctx, manifestFilename).Return(nil, os.ErrNotExist).Once()
+		mockDataStore.On("GetFile", ctx, manifestFilename).Return(nil, int64(0), os.ErrNotExist).Once()
 		mockDataStore.On("PutFileIfNotExists", ctx, manifestFilename, bytes.NewReader(configJSON),
 			mock.Anything).Return(true, nil).Once()
 
@@ -57,7 +57,7 @@ func TestConfigureDatastore(t *testing.T) {
 		ctx := context.Background()
 
 		mockDataStore.On("GetFile", ctx, manifestFilename).
-			Return(io.NopCloser(bytes.NewReader(configJSON)), nil).Once()
+			Return(io.NopCloser(bytes.NewReader(configJSON)), int64(-1), nil).Once()
 
 		manifest, ok, err := PublishConfig(ctx, mockDataStore, defaultCfg)
 		require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestConfigureDatastore(t *testing.T) {
 		mockDataStore := new(MockDataStore)
 		ctx := context.Background()
 
-		mockDataStore.On("GetFile", ctx, manifestFilename).Return(nil, os.ErrNotExist).Once()
+		mockDataStore.On("GetFile", ctx, manifestFilename).Return(nil, int64(0), os.ErrNotExist).Once()
 		mockDataStore.On("PutFileIfNotExists", ctx, manifestFilename, bytes.NewReader(configJSON), mock.Anything).
 			Return(false, errors.New("boom")).Once()
 
@@ -192,7 +192,7 @@ func TestLoadSchema(t *testing.T) {
 	// Manifest file exists and is valid (happy path)
 	t.Run("Manifest found and valid", func(t *testing.T) {
 		mockOS := new(MockDataStore)
-		mockOS.On("GetFile", ctx, manifestFilename).Return(io.NopCloser(bytes.NewReader(validManifestBytes)), nil).Once()
+		mockOS.On("GetFile", ctx, manifestFilename).Return(io.NopCloser(bytes.NewReader(validManifestBytes)), int64(-1), nil).Once()
 		mockOS.On("ListFilePaths", ctx, ListFileOptions{}).Return(nil, nil)
 		schema, err := LoadSchema(ctx, mockOS, defaultCfg)
 		require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestLoadSchema(t *testing.T) {
 	// Manifest file not found (backward compatibility), fallback to config
 	t.Run("Manifest not found", func(t *testing.T) {
 		mockOS := new(MockDataStore)
-		mockOS.On("GetFile", ctx, manifestFilename).Return(nil, os.ErrNotExist).Once()
+		mockOS.On("GetFile", ctx, manifestFilename).Return(nil, int64(0), os.ErrNotExist).Once()
 		mockOS.On("ListFilePaths", ctx, ListFileOptions{}).Return(nil, nil)
 
 		schema, err := LoadSchema(ctx, mockOS, defaultCfg)
@@ -218,7 +218,7 @@ func TestLoadSchema(t *testing.T) {
 
 	t.Run("Manifest found but invalid JSON", func(t *testing.T) {
 		mockOS := new(MockDataStore)
-		mockOS.On("GetFile", ctx, manifestFilename).Return(io.NopCloser(bytes.NewReader([]byte(`{"invalid": "json"`))), nil).Once()
+		mockOS.On("GetFile", ctx, manifestFilename).Return(io.NopCloser(bytes.NewReader([]byte(`{"invalid": "json"`))), int64(-1), nil).Once()
 		mockOS.On("ListFilePaths", ctx, ListFileOptions{}).Return(nil, nil)
 
 		schema, err := LoadSchema(ctx, mockOS, defaultCfg)
@@ -236,7 +236,7 @@ func TestLoadSchema(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		mockOS.On("GetFile", ctx, manifestFilename).Return(io.NopCloser(bytes.NewReader(invalidManifestBytes)), nil).Once()
+		mockOS.On("GetFile", ctx, manifestFilename).Return(io.NopCloser(bytes.NewReader(invalidManifestBytes)), int64(-1), nil).Once()
 		mockOS.On("ListFilePaths", ctx, ListFileOptions{}).Return(nil, nil)
 
 		schema, err := LoadSchema(ctx, mockOS, defaultCfg)
@@ -248,7 +248,7 @@ func TestLoadSchema(t *testing.T) {
 
 	t.Run("Manifest not found, and incomplete config", func(t *testing.T) {
 		mockOS := new(MockDataStore)
-		mockOS.On("GetFile", ctx, manifestFilename).Return(nil, os.ErrNotExist).Once()
+		mockOS.On("GetFile", ctx, manifestFilename).Return(nil, int64(0), os.ErrNotExist).Once()
 		mockOS.On("ListFilePaths", ctx, ListFileOptions{}).Return(nil, nil)
 
 		schema, err := LoadSchema(ctx, mockOS, DataStoreConfig{})

--- a/support/datastore/datastore.go
+++ b/support/datastore/datastore.go
@@ -41,7 +41,9 @@ type ListFileOptions struct {
 type DataStore interface {
 	GetFileMetadata(ctx context.Context, path string) (map[string]string, error)
 	GetFileLastModified(ctx context.Context, filePath string) (time.Time, error)
-	GetFile(ctx context.Context, path string) (io.ReadCloser, error)
+	// GetFile retrieves a file and returns its contents as a reader along with
+	// the file's size in bytes. Size is -1 if unknown (e.g., chunked transfer).
+	GetFile(ctx context.Context, path string) (io.ReadCloser, int64, error)
 	PutFile(ctx context.Context, path string, in io.WriterTo, metaData map[string]string) error
 	PutFileIfNotExists(ctx context.Context, path string, in io.WriterTo, metaData map[string]string) (bool, error)
 	Exists(ctx context.Context, path string) (bool, error)

--- a/support/datastore/filesystem.go
+++ b/support/datastore/filesystem.go
@@ -102,16 +102,22 @@ func (f *FilesystemDataStore) GetFileLastModified(ctx context.Context, path stri
 }
 
 // GetFile returns a reader for the file at the given path.
-func (f *FilesystemDataStore) GetFile(ctx context.Context, path string) (io.ReadCloser, error) {
-	file, err := os.Open(f.fullPath(path))
+func (f *FilesystemDataStore) GetFile(ctx context.Context, path string) (io.ReadCloser, int64, error) {
+	fullPath := f.fullPath(path)
+	file, err := os.Open(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, os.ErrNotExist
+			return nil, 0, os.ErrNotExist
 		}
-		return nil, fmt.Errorf("error opening file %s: %w", path, err)
+		return nil, 0, fmt.Errorf("error opening file %s: %w", path, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, 0, fmt.Errorf("error stating file %s: %w", path, err)
 	}
 	log.Debugf("File retrieved successfully: %s", path)
-	return file, nil
+	return file, info.Size(), nil
 }
 
 // GetFileMetadata returns an empty map as filesystem storage does not support metadata.

--- a/support/datastore/filesystem.go
+++ b/support/datastore/filesystem.go
@@ -101,7 +101,7 @@ func (f *FilesystemDataStore) GetFileLastModified(ctx context.Context, path stri
 	return info.ModTime(), nil
 }
 
-// GetFile returns a reader for the file at the given path.
+// GetFile returns a reader for the file at the given path along with the file's size in bytes.
 func (f *FilesystemDataStore) GetFile(ctx context.Context, path string) (io.ReadCloser, int64, error) {
 	fullPath := f.fullPath(path)
 	file, err := os.Open(fullPath)

--- a/support/datastore/filesystem_test.go
+++ b/support/datastore/filesystem_test.go
@@ -66,8 +66,9 @@ func TestFilesystemPutFile(t *testing.T) {
 	err = store.PutFile(context.Background(), "file.txt", writerTo, nil)
 	require.NoError(t, err)
 
-	reader, err := store.GetFile(context.Background(), "file.txt")
+	reader, size, err := store.GetFile(context.Background(), "file.txt")
 	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), size)
 	requireReaderContentEquals(t, reader, content)
 
 	metadata, err := store.GetFileMetadata(context.Background(), "file.txt")
@@ -80,8 +81,9 @@ func TestFilesystemPutFile(t *testing.T) {
 	err = store.PutFile(context.Background(), "file.txt", writerTo, nil)
 	require.NoError(t, err)
 
-	reader, err = store.GetFile(context.Background(), "file.txt")
+	reader, size, err = store.GetFile(context.Background(), "file.txt")
 	require.NoError(t, err)
+	require.Equal(t, int64(len(otherContent)), size)
 	requireReaderContentEquals(t, reader, otherContent)
 }
 
@@ -98,7 +100,7 @@ func TestFilesystemPutFileCreatesDirectories(t *testing.T) {
 	err = store.PutFile(context.Background(), "a/b/c/file.txt", writerTo, nil)
 	require.NoError(t, err)
 
-	reader, err := store.GetFile(context.Background(), "a/b/c/file.txt")
+	reader, _, err := store.GetFile(context.Background(), "a/b/c/file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, content)
 }
@@ -123,7 +125,7 @@ func TestFilesystemPutFileIfNotExists(t *testing.T) {
 	require.False(t, ok)
 
 	// Verify content unchanged
-	reader, err := store.GetFile(context.Background(), "file.txt")
+	reader, _, err := store.GetFile(context.Background(), "file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, existingContent)
 
@@ -133,7 +135,7 @@ func TestFilesystemPutFileIfNotExists(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	reader, err = store.GetFile(context.Background(), "other-file.txt")
+	reader, _, err = store.GetFile(context.Background(), "other-file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, newContent)
 }
@@ -169,7 +171,7 @@ func TestFilesystemGetNonExistentFile(t *testing.T) {
 	err = os.WriteFile(filepath.Join(dir, "file.txt"), content, 0600)
 	require.NoError(t, err)
 
-	_, err = store.GetFile(context.Background(), "other-file.txt")
+	_, _, err = store.GetFile(context.Background(), "other-file.txt")
 	require.ErrorIs(t, err, os.ErrNotExist)
 
 	metadata, err := store.GetFileMetadata(context.Background(), "other-file.txt")

--- a/support/datastore/gcs.go
+++ b/support/datastore/gcs.go
@@ -113,6 +113,9 @@ func (b GCSDataStore) GetFile(ctx context.Context, filePath string) (io.ReadClos
 		}
 		return nil, 0, fmt.Errorf("error retrieving file %s: %w", filePath, err)
 	}
+	// r.Attrs.Size is the stored object size from GCS metadata. Because we set
+	// ReadCompressed(true) above, GCS will not perform decompressive transcoding,
+	// so this size matches the byte count the caller will read from r.
 	size := r.Attrs.Size
 	log.Debugf("File retrieved successfully: %s", filePath)
 	return r, size, nil

--- a/support/datastore/gcs.go
+++ b/support/datastore/gcs.go
@@ -213,16 +213,11 @@ func (b GCSDataStore) putFile(ctx context.Context, filePath string, in io.Writer
 func (b GCSDataStore) ListFilePaths(ctx context.Context, options ListFileOptions) ([]string, error) {
 	var fullPrefix string
 
-	// When 'prefix' is empty, ensure the base prefix ends with a slash (e.g., "a/b/")
-	// so the query returns only objects within that directory, not similarly named paths like "a/b-1".
-	if options.Prefix == "" {
-		fullPrefix = b.prefix
-		if !strings.HasSuffix(fullPrefix, "/") {
-			fullPrefix += "/"
-		}
-	} else {
-		// Join the caller-provided prefix with the datastore prefix
-		fullPrefix = path.Join(b.prefix, options.Prefix)
+	// Ensure the prefix ends with a slash so the query returns only objects
+	// within that directory, not similarly named paths like "a/b-1".
+	fullPrefix = path.Join(b.prefix, options.Prefix)
+	if fullPrefix != "" {
+		fullPrefix += "/"
 	}
 
 	var StartAfter string

--- a/support/datastore/gcs.go
+++ b/support/datastore/gcs.go
@@ -95,7 +95,7 @@ func (b GCSDataStore) GetFileLastModified(ctx context.Context, filePath string) 
 }
 
 // GetFile retrieves a file from the GCS bucket.
-func (b GCSDataStore) GetFile(ctx context.Context, filePath string) (io.ReadCloser, error) {
+func (b GCSDataStore) GetFile(ctx context.Context, filePath string) (io.ReadCloser, int64, error) {
 	filePath = path.Join(b.prefix, filePath)
 	// setting ReadCompressed(true) will avoid transcoding of compressed files by including
 	// an "Accept-Encoding: gzip" header in the request:
@@ -106,15 +106,16 @@ func (b GCSDataStore) GetFile(ctx context.Context, filePath string) (io.ReadClos
 	r, err := b.bucket.Object(filePath).ReadCompressed(true).NewReader(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrObjectNotExist) {
-			return nil, os.ErrNotExist
+			return nil, 0, os.ErrNotExist
 		}
 		if gcsError, ok := err.(*googleapi.Error); ok {
 			log.Debugf("GCS error: %s %s", gcsError.Message, gcsError.Body)
 		}
-		return nil, fmt.Errorf("error retrieving file %s: %w", filePath, err)
+		return nil, 0, fmt.Errorf("error retrieving file %s: %w", filePath, err)
 	}
+	size := r.Attrs.Size
 	log.Debugf("File retrieved successfully: %s", filePath)
-	return r, nil
+	return r, size, nil
 }
 
 // PutFileIfNotExists uploads a file to GCS only if it doesn't already exist.
@@ -209,11 +210,16 @@ func (b GCSDataStore) putFile(ctx context.Context, filePath string, in io.Writer
 func (b GCSDataStore) ListFilePaths(ctx context.Context, options ListFileOptions) ([]string, error) {
 	var fullPrefix string
 
-	// Ensure the prefix ends with a slash so the query returns only objects
-	// within that directory, not similarly named paths like "a/b-1".
-	fullPrefix = path.Join(b.prefix, options.Prefix)
-	if fullPrefix != "" {
-		fullPrefix += "/"
+	// When 'prefix' is empty, ensure the base prefix ends with a slash (e.g., "a/b/")
+	// so the query returns only objects within that directory, not similarly named paths like "a/b-1".
+	if options.Prefix == "" {
+		fullPrefix = b.prefix
+		if !strings.HasSuffix(fullPrefix, "/") {
+			fullPrefix += "/"
+		}
+	} else {
+		// Join the caller-provided prefix with the datastore prefix
+		fullPrefix = path.Join(b.prefix, options.Prefix)
 	}
 
 	var StartAfter string

--- a/support/datastore/gcs_test.go
+++ b/support/datastore/gcs_test.go
@@ -437,6 +437,40 @@ func TestGCSListFilePaths(t *testing.T) {
 	require.Equal(t, []string{"a", "b"}, paths)
 }
 
+func TestGCSListFilePaths_NoPrefix(t *testing.T) {
+	server := fakestorage.NewServer([]fakestorage.Object{
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "a"},
+			Content:     []byte("1"),
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "b"},
+			Content:     []byte("1"),
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "c"},
+			Content:     []byte("1"),
+		},
+	})
+	defer server.Stop()
+
+	store, err := FromGCSClient(context.Background(), server.Client(), "test-bucket")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	paths, err := store.ListFilePaths(context.Background(), ListFileOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b", "c"}, paths)
+
+	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{Limit: 2})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, paths)
+
+	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{StartAfter: "a"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"b", "c"}, paths)
+}
+
 func TestGCSListFilePaths_WithPrefix(t *testing.T) {
 	server := fakestorage.NewServer([]fakestorage.Object{
 		{

--- a/support/datastore/gcs_test.go
+++ b/support/datastore/gcs_test.go
@@ -101,7 +101,7 @@ func TestGCSPutFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(len(content)), writerTo.total)
 
-	reader, err := store.GetFile(context.Background(), "file.txt")
+	reader, _, err := store.GetFile(context.Background(), "file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, content)
 
@@ -117,7 +117,7 @@ func TestGCSPutFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(len(otherContent)), writerTo.total)
 
-	reader, err = store.GetFile(context.Background(), "file.txt")
+	reader, _, err = store.GetFile(context.Background(), "file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, otherContent)
 
@@ -154,7 +154,7 @@ func TestGCSPutFileIfNotExists(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, int64(len(newContent)), writerTo.total)
 
-	reader, err := store.GetFile(context.Background(), "file.txt")
+	reader, _, err := store.GetFile(context.Background(), "file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, existingContent)
 
@@ -170,7 +170,7 @@ func TestGCSPutFileIfNotExists(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, int64(len(newContent)), writerTo.total)
 
-	reader, err = store.GetFile(context.Background(), "other-file.txt")
+	reader, _, err = store.GetFile(context.Background(), "other-file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, newContent)
 
@@ -357,7 +357,7 @@ func TestGCSGetNonExistentFile(t *testing.T) {
 		require.NoError(t, store.Close())
 	})
 
-	_, err = store.GetFile(context.Background(), "other-file.txt")
+	_, _, err = store.GetFile(context.Background(), "other-file.txt")
 	require.ErrorIs(t, err, os.ErrNotExist)
 
 	metadata, err := store.GetFileMetadata(context.Background(), "other-file.txt")
@@ -399,7 +399,7 @@ func TestGCSGetFileValidatesCRC32C(t *testing.T) {
 		require.NoError(t, store.Close())
 	})
 
-	reader, err := store.GetFile(context.Background(), "file.gz")
+	reader, _, err := store.GetFile(context.Background(), "file.gz")
 	require.NoError(t, err)
 	buf.Reset()
 	_, err = io.Copy(&buf, reader)
@@ -435,40 +435,6 @@ func TestGCSListFilePaths(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"a", "b"}, paths)
-}
-
-func TestGCSListFilePaths_NoPrefix(t *testing.T) {
-	server := fakestorage.NewServer([]fakestorage.Object{
-		{
-			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "a"},
-			Content:     []byte("1"),
-		},
-		{
-			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "b"},
-			Content:     []byte("1"),
-		},
-		{
-			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "c"},
-			Content:     []byte("1"),
-		},
-	})
-	defer server.Stop()
-
-	store, err := FromGCSClient(context.Background(), server.Client(), "test-bucket")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = store.Close() })
-
-	paths, err := store.ListFilePaths(context.Background(), ListFileOptions{})
-	require.NoError(t, err)
-	require.Equal(t, []string{"a", "b", "c"}, paths)
-
-	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{Limit: 2})
-	require.NoError(t, err)
-	require.Equal(t, []string{"a", "b"}, paths)
-
-	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{StartAfter: "a"})
-	require.NoError(t, err)
-	require.Equal(t, []string{"b", "c"}, paths)
 }
 
 func TestGCSListFilePaths_WithPrefix(t *testing.T) {

--- a/support/datastore/mocks.go
+++ b/support/datastore/mocks.go
@@ -36,13 +36,13 @@ func (m *MockDataStore) GetFileLastModified(ctx context.Context, filePath string
 	return time.Time{}, args.Error(1)
 }
 
-func (m *MockDataStore) GetFile(ctx context.Context, path string) (io.ReadCloser, error) {
+func (m *MockDataStore) GetFile(ctx context.Context, path string) (io.ReadCloser, int64, error) {
 	args := m.Called(ctx, path)
 	closer := (io.ReadCloser)(nil)
 	if args.Get(0) != nil {
 		closer = args.Get(0).(io.ReadCloser)
 	}
-	return closer, args.Error(1)
+	return closer, args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockDataStore) PutFile(ctx context.Context, path string, in io.WriterTo, metadata map[string]string) error {

--- a/support/datastore/s3.go
+++ b/support/datastore/s3.go
@@ -293,16 +293,11 @@ func (b S3DataStore) putFile(ctx context.Context, filePath string, in io.WriterT
 func (b S3DataStore) ListFilePaths(ctx context.Context, options ListFileOptions) ([]string, error) {
 	var fullPrefix string
 
-	// When 'prefix' is empty, ensure the base prefix ends with a slash (e.g., "a/b/")
-	// so the query returns only objects within that directory, not similarly named paths like "a/b-1".
-	if options.Prefix == "" {
-		fullPrefix = b.prefix
-		if !strings.HasSuffix(fullPrefix, "/") {
-			fullPrefix += "/"
-		}
-	} else {
-		// Join the caller-provided prefix with the datastore prefix
-		fullPrefix = path.Join(b.prefix, options.Prefix)
+	// Ensure the prefix ends with a slash so the query returns only objects
+	// within that directory, not similarly named paths like "a/b-1".
+	fullPrefix = path.Join(b.prefix, options.Prefix)
+	if fullPrefix != "" {
+		fullPrefix += "/"
 	}
 
 	var StartAfter string

--- a/support/datastore/s3.go
+++ b/support/datastore/s3.go
@@ -153,7 +153,7 @@ func (b S3DataStore) GetFileLastModified(ctx context.Context, filePath string) (
 }
 
 // GetFile retrieves a file from the S3-compatible bucket.
-func (b S3DataStore) GetFile(ctx context.Context, filePath string) (io.ReadCloser, error) {
+func (b S3DataStore) GetFile(ctx context.Context, filePath string) (io.ReadCloser, int64, error) {
 	filePath = path.Join(b.prefix, filePath)
 	input := &s3.GetObjectInput{
 		Bucket:       aws.String(b.bucket),
@@ -165,13 +165,18 @@ func (b S3DataStore) GetFile(ctx context.Context, filePath string) (io.ReadClose
 	if err != nil {
 		log.Debugf("Error retrieving file '%s': %v", filePath, err)
 		if isNotFoundError(err) {
-			return nil, os.ErrNotExist
+			return nil, 0, os.ErrNotExist
 		}
-		return nil, fmt.Errorf("error retrieving file %s: %w", filePath, err)
+		return nil, 0, fmt.Errorf("error retrieving file %s: %w", filePath, err)
+	}
+
+	var size int64 = -1
+	if output.ContentLength != nil {
+		size = *output.ContentLength
 	}
 
 	log.Debugf("File retrieved successfully: %s", filePath)
-	return output.Body, nil
+	return output.Body, size, nil
 }
 
 // PutFile uploads a file to S3-compatible bucket
@@ -288,11 +293,16 @@ func (b S3DataStore) putFile(ctx context.Context, filePath string, in io.WriterT
 func (b S3DataStore) ListFilePaths(ctx context.Context, options ListFileOptions) ([]string, error) {
 	var fullPrefix string
 
-	// Ensure the prefix ends with a slash so the query returns only objects
-	// within that directory, not similarly named paths like "a/b-1".
-	fullPrefix = path.Join(b.prefix, options.Prefix)
-	if fullPrefix != "" {
-		fullPrefix += "/"
+	// When 'prefix' is empty, ensure the base prefix ends with a slash (e.g., "a/b/")
+	// so the query returns only objects within that directory, not similarly named paths like "a/b-1".
+	if options.Prefix == "" {
+		fullPrefix = b.prefix
+		if !strings.HasSuffix(fullPrefix, "/") {
+			fullPrefix += "/"
+		}
+	} else {
+		// Join the caller-provided prefix with the datastore prefix
+		fullPrefix = path.Join(b.prefix, options.Prefix)
 	}
 
 	var StartAfter string

--- a/support/datastore/s3_test.go
+++ b/support/datastore/s3_test.go
@@ -256,6 +256,28 @@ func TestS3ListFilePaths(t *testing.T) {
 	require.Equal(t, []string{"a", "b"}, paths)
 }
 
+func TestS3ListFilePaths_NoPrefix(t *testing.T) {
+	ctx := context.Background()
+	store, teardown := setupTestS3DataStore(t, ctx, "test-bucket", map[string]mockS3Object{
+		"a": {body: []byte("1")},
+		"b": {body: []byte("1")},
+		"c": {body: []byte("1")},
+	})
+	defer teardown()
+
+	paths, err := store.ListFilePaths(context.Background(), ListFileOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b", "c"}, paths)
+
+	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{Limit: 2})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, paths)
+
+	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{StartAfter: "a"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"b", "c"}, paths)
+}
+
 func TestS3ListFilePaths_WithPrefix(t *testing.T) {
 	ctx := context.Background()
 	store, teardown := setupTestS3DataStore(t, ctx, "test-bucket/objects/testnet", map[string]mockS3Object{

--- a/support/datastore/s3_test.go
+++ b/support/datastore/s3_test.go
@@ -256,28 +256,6 @@ func TestS3ListFilePaths(t *testing.T) {
 	require.Equal(t, []string{"a", "b"}, paths)
 }
 
-func TestS3ListFilePaths_NoPrefix(t *testing.T) {
-	ctx := context.Background()
-	store, teardown := setupTestS3DataStore(t, ctx, "test-bucket", map[string]mockS3Object{
-		"a": {body: []byte("1")},
-		"b": {body: []byte("1")},
-		"c": {body: []byte("1")},
-	})
-	defer teardown()
-
-	paths, err := store.ListFilePaths(context.Background(), ListFileOptions{})
-	require.NoError(t, err)
-	require.Equal(t, []string{"a", "b", "c"}, paths)
-
-	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{Limit: 2})
-	require.NoError(t, err)
-	require.Equal(t, []string{"a", "b"}, paths)
-
-	paths, err = store.ListFilePaths(context.Background(), ListFileOptions{StartAfter: "a"})
-	require.NoError(t, err)
-	require.Equal(t, []string{"b", "c"}, paths)
-}
-
 func TestS3ListFilePaths_WithPrefix(t *testing.T) {
 	ctx := context.Background()
 	store, teardown := setupTestS3DataStore(t, ctx, "test-bucket/objects/testnet", map[string]mockS3Object{
@@ -473,7 +451,7 @@ func TestS3PutFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(len(content)), writerTo.total)
 
-	reader, err := store.GetFile(ctx, "file.txt")
+	reader, _, err := store.GetFile(ctx, "file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, content)
 
@@ -489,7 +467,7 @@ func TestS3PutFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(len(otherContent)), writerTo.total)
 
-	reader, err = store.GetFile(ctx, "file.txt")
+	reader, _, err = store.GetFile(ctx, "file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, otherContent)
 
@@ -530,7 +508,7 @@ func TestS3PutFileIfNotExists(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, int64(len(newContent)), writerTo.total)
 
-	reader, err := store.GetFile(ctx, "file.txt")
+	reader, _, err := store.GetFile(ctx, "file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, existingContent)
 
@@ -546,7 +524,7 @@ func TestS3PutFileIfNotExists(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, int64(len(newContent)), writerTo.total)
 
-	reader, err = store.GetFile(ctx, "other-file.txt")
+	reader, _, err = store.GetFile(ctx, "other-file.txt")
 	require.NoError(t, err)
 	requireReaderContentEquals(t, reader, newContent)
 
@@ -669,7 +647,7 @@ func TestS3GetNonExistentFile(t *testing.T) {
 	store, teardown := setupTestS3DataStore(t, ctx, "test-bucket/objects/testnet", map[string]mockS3Object{})
 	defer teardown()
 
-	_, err := store.GetFile(ctx, "other-file.txt")
+	_, _, err := store.GetFile(ctx, "other-file.txt")
 	require.ErrorIs(t, err, os.ErrNotExist)
 
 	metadata, err := store.GetFileMetadata(ctx, "other-file.txt")
@@ -688,7 +666,7 @@ func TestS3GetFileValidatesCRC32C(t *testing.T) {
 		}})
 	defer teardown()
 
-	reader, err := store.GetFile(ctx, "file.txt")
+	reader, _, err := store.GetFile(ctx, "file.txt")
 	require.NoError(t, err)
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, reader)

--- a/xdr/ledger_close_meta_view.go
+++ b/xdr/ledger_close_meta_view.go
@@ -2,9 +2,12 @@ package xdr
 
 // Convenience helpers on LedgerCloseMetaView that decode just the header
 // fields commonly needed for streaming validation, without the full XDR
-// decode of the body. Mirrors the equivalent methods on LedgerCloseMeta
-// (in ledger_close_meta.go) so callers can switch between decoded and
-// view forms without churn.
+// decode of the body.
+//
+// Byte-sequence accessors (e.g., LedgerHash) return slices into the source
+// bytes — zero-copy, but the slice pins the source bytes alive. Callers
+// that need to hold the value past the source's lifetime should copy it
+// into a fixed-size type themselves.
 
 func (v LedgerCloseMetaView) ledgerHeaderHistoryEntry() (LedgerHeaderHistoryEntryView, error) {
 	disc, err := v.V()
@@ -60,44 +63,36 @@ func (v LedgerCloseMetaView) LedgerSequence() (uint32, error) {
 	return uint32(seq), nil
 }
 
-// LedgerHash returns the hash of the closed ledger.
-func (v LedgerCloseMetaView) LedgerHash() (Hash, error) {
+// LedgerHash returns the 32-byte hash of the closed ledger as a slice into
+// the source bytes. Zero copy; the slice is valid as long as the source
+// LedgerCloseMetaView's bytes are.
+func (v LedgerCloseMetaView) LedgerHash() ([]byte, error) {
 	header, err := v.ledgerHeaderHistoryEntry()
 	if err != nil {
-		return Hash{}, err
+		return nil, err
 	}
 	hashView, err := header.Hash()
 	if err != nil {
-		return Hash{}, err
+		return nil, err
 	}
-	bytes, err := hashView.Value()
-	if err != nil {
-		return Hash{}, err
-	}
-	var h Hash
-	copy(h[:], bytes)
-	return h, nil
+	return hashView.Value()
 }
 
-// PreviousLedgerHash returns the hash of the parent ledger.
-func (v LedgerCloseMetaView) PreviousLedgerHash() (Hash, error) {
+// PreviousLedgerHash returns the 32-byte hash of the parent ledger as a
+// slice into the source bytes. Zero copy; the slice is valid as long as
+// the source LedgerCloseMetaView's bytes are.
+func (v LedgerCloseMetaView) PreviousLedgerHash() ([]byte, error) {
 	header, err := v.ledgerHeaderHistoryEntry()
 	if err != nil {
-		return Hash{}, err
+		return nil, err
 	}
 	headerInner, err := header.Header()
 	if err != nil {
-		return Hash{}, err
+		return nil, err
 	}
 	hashView, err := headerInner.PreviousLedgerHash()
 	if err != nil {
-		return Hash{}, err
+		return nil, err
 	}
-	bytes, err := hashView.Value()
-	if err != nil {
-		return Hash{}, err
-	}
-	var h Hash
-	copy(h[:], bytes)
-	return h, nil
+	return hashView.Value()
 }

--- a/xdr/ledger_close_meta_view.go
+++ b/xdr/ledger_close_meta_view.go
@@ -1,0 +1,103 @@
+package xdr
+
+// Convenience helpers on LedgerCloseMetaView that decode just the header
+// fields commonly needed for streaming validation, without the full XDR
+// decode of the body. Mirrors the equivalent methods on LedgerCloseMeta
+// (in ledger_close_meta.go) so callers can switch between decoded and
+// view forms without churn.
+
+func (v LedgerCloseMetaView) ledgerHeaderHistoryEntry() (LedgerHeaderHistoryEntryView, error) {
+	disc, err := v.V()
+	if err != nil {
+		return nil, err
+	}
+	value, err := disc.Value()
+	if err != nil {
+		return nil, err
+	}
+	switch value {
+	case 0:
+		v0, err := v.V0()
+		if err != nil {
+			return nil, err
+		}
+		return v0.LedgerHeader()
+	case 1:
+		v1, err := v.V1()
+		if err != nil {
+			return nil, err
+		}
+		return v1.LedgerHeader()
+	case 2:
+		v2, err := v.V2()
+		if err != nil {
+			return nil, err
+		}
+		return v2.LedgerHeader()
+	default:
+		return nil, viewErrUnknownDiscriminant(0, value)
+	}
+}
+
+// LedgerSequence returns the sequence number of this LedgerCloseMeta.
+func (v LedgerCloseMetaView) LedgerSequence() (uint32, error) {
+	header, err := v.ledgerHeaderHistoryEntry()
+	if err != nil {
+		return 0, err
+	}
+	headerInner, err := header.Header()
+	if err != nil {
+		return 0, err
+	}
+	seqView, err := headerInner.LedgerSeq()
+	if err != nil {
+		return 0, err
+	}
+	seq, err := seqView.Value()
+	if err != nil {
+		return 0, err
+	}
+	return uint32(seq), nil
+}
+
+// LedgerHash returns the hash of the closed ledger.
+func (v LedgerCloseMetaView) LedgerHash() (Hash, error) {
+	header, err := v.ledgerHeaderHistoryEntry()
+	if err != nil {
+		return Hash{}, err
+	}
+	hashView, err := header.Hash()
+	if err != nil {
+		return Hash{}, err
+	}
+	bytes, err := hashView.Value()
+	if err != nil {
+		return Hash{}, err
+	}
+	var h Hash
+	copy(h[:], bytes)
+	return h, nil
+}
+
+// PreviousLedgerHash returns the hash of the parent ledger.
+func (v LedgerCloseMetaView) PreviousLedgerHash() (Hash, error) {
+	header, err := v.ledgerHeaderHistoryEntry()
+	if err != nil {
+		return Hash{}, err
+	}
+	headerInner, err := header.Header()
+	if err != nil {
+		return Hash{}, err
+	}
+	hashView, err := headerInner.PreviousLedgerHash()
+	if err != nil {
+		return Hash{}, err
+	}
+	bytes, err := hashView.Value()
+	if err != nil {
+		return Hash{}, err
+	}
+	var h Hash
+	copy(h[:], bytes)
+	return h, nil
+}


### PR DESCRIPTION
## Summary

Builds on the XDR view types (#5937) by integrating them into BufferedStorageBackend, adding a `GetLedgerRaw` method to the `LedgerBackend` interface, and tuning the BSB pipeline for higher throughput.

### Views integration + GetLedgerRaw

- **BSB rewrite to use views**: Replaces eager full-batch decode (`xdr.LedgerCloseMetaBatch`) with view-based parse (`xdr.LedgerCloseMetaBatchView`). Per-ledger byte slices are extracted once via `metas.All()` and stored on the BSB struct. `GetLedger` decodes a single ledger on demand from the cached bytes; `GetLedgerRaw` returns the raw bytes without decoding.
- **GetLedgerRaw across all backends**: Added to the `LedgerBackend` interface with implementations on every backend:
  - `BufferedStorageBackend`: returns a copy of the per-ledger view slice from the cached batch.
  - `CaptiveStellarCore`: cache changed from a decoded `cachedMeta *xdr.LedgerCloseMeta` to raw frame bytes plus sequence (`cachedRaw []byte` + `cachedSeq uint32`, extracted via view at frame time). `GetLedger` decodes lazily from `cachedRaw`; `GetLedgerRaw` returns a copy. Both share a `fetchSequence` helper. The meta-pipe reader (`bufferedLedgerMetaReader`) now returns raw frame bytes instead of pre-decoding.
  - `RPCLedgerBackend`: buffer changed from `map[uint32]xdr.LedgerCloseMeta` to `map[uint32][]byte` holding the base64-decoded raw bytes. `GetLedger` does the XDR decode on demand from the cached bytes; `GetLedgerRaw` returns a copy.
  - `metricsLedgerBackend`: passthrough that records the same `ledger_fetch_duration_seconds` summary as `GetLedger`.
  - `loadtest.LedgerBackend`: baseline implementation calling `GetLedger` + `MarshalBinary`.
  - `MockDatabaseBackend` and `loadtest`'s `mockLedgerBackend`: testify-mock stubs.
- **`xdr/ledger_close_meta_view.go`** (new): Convenience helpers on `LedgerCloseMetaView` (`LedgerSequence()`, `LedgerHash()`, `PreviousLedgerHash()`) that mirror the equivalents on `LedgerCloseMeta`. Used by BSB and CaptiveCore to extract sequence/hash fields without paying the full XDR decode.
- **Idempotent re-request consistency**: All backends now consistently allow re-requesting the most-recently-served sequence without erroring or advancing state (BSB and RPC previously diverged from CaptiveStellarCore).
- **Per-frame allocation in meta pipe reader**: `bufferedLedgerMetaReader` now allocates a fresh slice per frame (replacing the reusable `frameBuf`). Required for correctness — the raw frame bytes must outlive the reader's read state to be passed through to consumers.
- **`DataStore.GetFile` size return**: Signature changed to `(io.ReadCloser, int64, error)` so `ledger_buffer` can pre-allocate the zstd decompression buffer using the compressed file size, avoiding repeated buffer growth/realloc on each ledger object. Size is `-1` if unknown (chunked transfer). Affects all `DataStore` implementations (`gcs`, `s3`, `filesystem`, `mocks`) and their tests.

### BSB pipeline tuning

- **Default `BufferSize` = 10000** for small-file schemas (was 100). The old default throttled workers via the per-consumer-pull `pushTaskQueue` feedback loop. With the buffer sized to the range cap (`newLedgerBuffer` caps internally), workers see all queued tasks upfront. This change is independent of the views work and benefits upstream too if applied there.
- **Decompression moved from workers to consumer**. Each `zstd.DecodeAll` allocates ~9 MB of internal `sequenceDecs` working memory; with N concurrent workers the GC pressure stole CPU from the pipeline. The consumer now decompresses one batch at a time on a single shared `zstd.Decoder`. The ~100 µs per-batch cost is dwarfed by the consumer's XDR work.
- **Channel-based buffer pools** — `compressedPool` (~14 KB worker download buffers) and `decompressedPool` (~50 KB consumer batch buffers). Sidesteps `sync.Pool`'s GC overhead on hot-path large allocations. Decompression buffer is pre-allocated using `zstd.Header.FrameContentSize` when present.
- **Cancellation safety in `pushTaskQueue` and `storeObject`**: both now `select` on `ctx.Done()` during their `taskQueue` / `ledgerQueue` channel sends. Without this, a worker could hang on a full queue forever after cancellation (and subsequently block `wg.Wait()` in `close()`).
- **Granular `currentLedgerLock` in `storeObject`**: held only for the brief `currentLedger` increment, not across the channel send. Holding it across the send would block `GetLatestLedgerSequence` callers whenever `ledgerQueue` is full.
- **Local `bufferSize` variable in `newLedgerBuffer`**: instead of mutating `bsb.config.BufferSize`. Avoids a latent bug where a second `PrepareRange` with a different range would see the cap from the first call.

### Performance

GCS-backed throughput at `NumWorkers=100, BufferSize=10000` (10-run medians, pubnet, 1000 ledgers):

| | lps | % of network ceiling |
|---|---|---|
| Network ceiling (parallel curl / direct `GetFile`) | 207 | 100% |
| **This branch `GetLedgerRaw`** | 198 | 96% |
| **This branch `GetLedger`** | 167 | 81% |
| Upstream main `GetLedger` (with `BufferSize=10000`) | 165 | 80% |
| Upstream main `GetLedger` (default `BufferSize=100`) | ~80 | 39% |

The `BufferSize` default bump accounts for most of the lift (upstream goes from ~80 → 165 lps with the same change). `GetLedgerRaw` adds another ~19% over `GetLedger` by skipping XDR decoding.

`buffered_storage_backend_bench_test.go` is included for reproducibility — env-driven (`BSB_BENCH_BUCKET` / `_FROM` / `_TO` + GCS application-default credentials), skips silently in CI.

## Test plan

- [x] All existing unit tests pass
- [x] Race detector passes (`go test -race ./ingest/ledgerbackend/...`)
- [x] New tests:
  - `TestBSBGetLedgerRaw_SingleLedgerPerFile`
  - `TestBSBGetLedger_IdempotentReRequest`
  - `TestRPCGetLedgerRaw` (round-trip + idempotent + copy semantics)
  - `TestCaptiveGetLedgerRaw` (round-trip + idempotent + copy semantics)
  - `TestMetricsGetLedgerRaw` (verifies same summary as `GetLedger`)
  - `TestReadLedgerMetaFromPipe` and `TestReadLedgerMetaFromPipeMultipleFrames` now assert raw frame bytes round-trip back to their `LedgerCloseMeta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)