### PR TITLE
txnbuild: validate payload length in contract address decoding

### DIFF
--- a/txnbuild/invoke_host_function.go
+++ b/txnbuild/invoke_host_function.go
@@ -72,6 +72,9 @@ func NewPaymentToContract(params PaymentToContractParams) (InvokeHostFunction, e
 	if err != nil {
 		return InvokeHostFunction{}, err
 	}
+	if len(decoded) != 32 {
+		return InvokeHostFunction{}, errors.New("invalid destination contract address")
+	}
 	var destinationContractID xdr.ContractId
 	copy(destinationContractID[:], decoded)
 

--- a/txnbuild/invoke_host_function_test.go
+++ b/txnbuild/invoke_host_function_test.go
@@ -32,6 +32,11 @@ func TestPaymentToContract(t *testing.T) {
 	_, err = NewPaymentToContract(params)
 	require.Error(t, err)
 
+	oversized := make([]byte, 36)
+	params.Destination = strkey.MustEncode(strkey.VersionByteContract, oversized)
+	_, err = NewPaymentToContract(params)
+	require.EqualError(t, err, "invalid destination contract address")
+
 	contractID := xdr.Hash{1}
 	params.Destination = strkey.MustEncode(strkey.VersionByteContract, contractID[:])
 

--- a/txnbuild/restore_footprint.go
+++ b/txnbuild/restore_footprint.go
@@ -54,6 +54,9 @@ func NewAssetBalanceRestoration(params AssetBalanceRestorationParams) (RestoreFo
 	if err != nil {
 		return RestoreFootprint{}, err
 	}
+	if len(decoded) != 32 {
+		return RestoreFootprint{}, errors.New("invalid contract address")
+	}
 	var contractID xdr.Hash
 	copy(contractID[:], decoded)
 

--- a/txnbuild/restore_footprint_test.go
+++ b/txnbuild/restore_footprint_test.go
@@ -29,6 +29,11 @@ func TestRestoreAssetBalance(t *testing.T) {
 	_, err = NewAssetBalanceRestoration(params)
 	require.Error(t, err)
 
+	oversized := make([]byte, 36)
+	params.Contract = strkey.MustEncode(strkey.VersionByteContract, oversized)
+	_, err = NewAssetBalanceRestoration(params)
+	require.EqualError(t, err, "invalid contract address")
+
 	contractID := xdr.Hash{1}
 	params.Contract = strkey.MustEncode(strkey.VersionByteContract, contractID[:])
 


### PR DESCRIPTION
## Summary

- `strkey.Decode()` accepts payloads of any length with valid checksums. Without an explicit length check at the call site, the `copy(...)` into the fixed-size `xdr.ContractId` / `xdr.Hash` truncates oversized payloads to their first 32 bytes.
- Add an explicit 32-byte length check in `NewPaymentToContract` and `NewAssetBalanceRestoration` to reject malformed contract addresses early.
- Matches the pattern already in place in `keypair/from_address.go:27` and `xdr/account_id.go:110`.

## Test plan

- [x] `go test ./txnbuild/` passes
- [x] Extended `TestPaymentToContract` to cover an oversized destination payload
- [x] Extended `TestRestoreAssetBalance` to cover an oversized contract payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)