### PR TITLE
ingest/ledgerbackend: add LedgerStream streaming ingestion API

### DIFF
--- a/ingest/CHANGELOG.md
+++ b/ingest/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file. This projec
   These are now relocated to `ingest` package. Will need to change references in existing code.
 * Moved the `ingest/verify` package to be internally located at `services/horizon/internal/ingest` package in `verify.go` for overall go repo restructuring. [5670](https://github.com/stellar/go-stellar-sdk/issues/5670)  
 
+### New Features
+* Add `ledgerbackend.LedgerStream`, a streaming-first, interchangeable ingestion source interface whose single `RawLedgers` method yields the raw XDR bytes of each ledger in a range. Constructors are provided for every backend: `NewBufferedStorageStream` (datastore), `NewCaptiveCoreStream` (captive stellar-core), and `NewRPCStream` (RPC). Each stream owns its backend's full lifecycle — set up on the first pull, torn down when iteration ends — and yields each ledger as a borrowed slice valid only until the next step. Pass `WithStreamMetrics(registry, namespace)` to `RawLedgers` to record `ledger_fetch_duration_seconds` (and, for captive-core, the `captive_stellar_core_*` suite), matching the metrics `WithMetrics` emits on the `GetLedger` path. [5944](https://github.com/stellar/go-stellar-sdk/pull/5944).
+
 
 ## v23.0.0
 

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -45,7 +45,8 @@ type metaResult struct {
 	// raw is the XDR frame bytes for this ledger (without the frame length
 	// prefix). Owned by the metaResult — the reader allocates a fresh slice
 	// per frame so consumers can hold onto the bytes. Decoding happens
-	// lazily downstream (in GetLedger).
+	// lazily downstream — in GetLedger, or directly by LedgerStream consumers
+	// of the raw frame.
 	raw []byte
 	err error
 }

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -45,7 +45,7 @@ type metaResult struct {
 	// raw is the XDR frame bytes for this ledger (without the frame length
 	// prefix). Owned by the metaResult — the reader allocates a fresh slice
 	// per frame so consumers can hold onto the bytes. Decoding happens
-	// lazily downstream so GetLedgerRaw can avoid the unmarshal entirely.
+	// lazily downstream (in GetLedger).
 	raw []byte
 	err error
 }
@@ -86,8 +86,7 @@ func newBufferedLedgerMetaReader(reader io.Reader) *bufferedLedgerMetaReader {
 
 // readLedgerMetaFromPipe reads the next framed ledger from the meta pipe and
 // returns the raw frame bytes. The XDR decode happens downstream on demand
-// (in GetLedger, or via views in handleMetaPipeResult) so GetLedgerRaw can
-// avoid the unmarshal entirely.
+// (in GetLedger, or via views in handleMetaPipeResult).
 //
 // It can block for two reasons:
 //   - Meta pipe buffer is full so it will wait until it refills.

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -228,7 +228,9 @@ func (bsb *BufferedStorageBackend) validateSequence(sequence uint32) error {
 
 // getLedgerRaw is the internal implementation that returns raw XDR bytes for a
 // single LedgerCloseMeta. The returned bytes alias an internal buffer and are
-// only valid until the next getLedgerRaw call. Caller must hold bsBackendLock.
+// only valid until the next getLedgerRaw call. Concurrent callers must hold
+// bsBackendLock (GetLedger does); a single exclusive owner — the LedgerStream —
+// may call it lock-free.
 func (bsb *BufferedStorageBackend) getLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
 	if err := bsb.validateSequence(sequence); err != nil {
 		return nil, err

--- a/ingest/ledgerbackend/buffered_storage_backend.go
+++ b/ingest/ledgerbackend/buffered_storage_backend.go
@@ -35,12 +35,14 @@ type BufferedStorageBackendConfig struct {
 type BufferedStorageBackend struct {
 	config BufferedStorageBackendConfig
 
-	// bsBackendLock is held by Close (write) so it can interrupt in-flight
-	// operations, and by every other method (read) so they observe a stable
-	// closed flag. Concurrent reads between non-Close methods are *not* made
-	// safe by this lock — the type's thread-safety contract requires callers
-	// to serialize externally; the read lock here only protects against
-	// concurrent Close.
+	// bsBackendLock serializes PrepareRange (write lock — it resets the buffer
+	// and cursor) against the read methods and Close (read lock). Reads and
+	// Close may run concurrently with each other: Close interrupts a blocked
+	// read by cancelling the ledgerBuffer's context (a write lock would
+	// deadlock against a reader parked in getFromLedgerQueue), not by lock
+	// exclusion. Concurrent reads between non-Close methods are *not* made safe
+	// by this lock — the type's thread-safety contract requires callers to
+	// serialize externally.
 	bsBackendLock sync.RWMutex
 
 	// ledgerBuffer is the buffer for LedgerCloseMeta data read in parallel.
@@ -199,7 +201,7 @@ func (bsb *BufferedStorageBackend) nextExpectedSequence() uint32 {
 
 func (bsb *BufferedStorageBackend) validateSequence(sequence uint32) error {
 	if bsb.closed {
-		return errors.New("BufferedStorageBackend is closed; cannot GetLedger or GetLedgerRaw")
+		return errors.New("BufferedStorageBackend is closed; cannot GetLedger")
 	}
 	if bsb.prepared == nil {
 		return errors.New("session is not prepared, call PrepareRange first")
@@ -254,28 +256,6 @@ func (bsb *BufferedStorageBackend) getLedgerRaw(ctx context.Context, sequence ui
 	}
 
 	return rawBytes, nil
-}
-
-// GetLedgerRaw returns the raw XDR bytes for a single LedgerCloseMeta
-// without performing XDR decoding. This is significantly faster than GetLedger
-// when the caller doesn't need a decoded struct (e.g., for forwarding,
-// replication, or when the caller will decode selectively).
-//
-// For the common case of LedgersPerFile=1, this avoids all XDR decoding
-// and simply returns the bytes after the batch header.
-//
-// The returned byte slice is a safe copy that the caller owns.
-func (bsb *BufferedStorageBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
-	bsb.bsBackendLock.RLock()
-	defer bsb.bsBackendLock.RUnlock()
-
-	rawBytes, err := bsb.getLedgerRaw(ctx, sequence)
-	if err != nil {
-		return nil, err
-	}
-	result := make([]byte, len(rawBytes))
-	copy(result, rawBytes)
-	return result, nil
 }
 
 // GetLedger returns the LedgerCloseMeta for the specified ledger sequence number.

--- a/ingest/ledgerbackend/buffered_storage_backend_bench_test.go
+++ b/ingest/ledgerbackend/buffered_storage_backend_bench_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/support/datastore"
 )
 
-// Benchmarks GetLedger / GetLedgerRaw throughput against a real GCS-backed
+// Benchmarks GetLedger / RawLedgers stream throughput against a real GCS-backed
 // data store. Off by default — set BSB_BENCH_BUCKET to a valid GCS bucket
 // path and BSB_BENCH_FROM/BSB_BENCH_TO to the ledger range. Requires GCS
 // application-default credentials.
@@ -134,11 +134,36 @@ func BenchmarkBSBGetLedger(b *testing.B) {
 	})
 }
 
-func BenchmarkBSBGetLedgerRaw(b *testing.B) {
-	runBSBBench(b, func(ctx context.Context, bsb *BufferedStorageBackend, seq uint32) error {
-		_, err := bsb.GetLedgerRaw(ctx, seq)
-		return err
-	})
+func BenchmarkBufferedStorageStream(b *testing.B) {
+	env := loadBenchEnv(b)
+	for _, nw := range bsbBenchWorkerCounts {
+		b.Run(fmt.Sprintf("Workers=%d", nw), func(b *testing.B) {
+			ctx := context.Background()
+			count := env.toLedger - env.fromLedger + 1
+			b.SetBytes(int64(count))
+			schema := datastore.DataStoreSchema{
+				LedgersPerFile:    env.ledgersPerFile,
+				FilesPerPartition: 64000 / env.ledgersPerFile,
+				FileExtension:     "zstd",
+			}
+			dsConfig := datastore.DataStoreConfig{
+				Type:   "GCS",
+				Params: map[string]string{"destination_bucket_path": env.bucket},
+				Schema: schema,
+			}
+			cfg := BufferedStorageBackendConfig{BufferSize: 10000, NumWorkers: nw, RetryLimit: 0, RetryWait: time.Microsecond}
+			for i := 0; i < b.N; i++ {
+				s := NewBufferedStorageStream(cfg, dsConfig, nil)
+				b.StartTimer()
+				for _, err := range s.RawLedgers(ctx, BoundedRange(env.fromLedger, env.toLedger)) {
+					if err != nil {
+						b.Fatalf("stream: %v", err)
+					}
+				}
+				b.StopTimer()
+			}
+		})
+	}
 }
 
 // BenchmarkBSBPipelineNoDecode measures the BSB worker→pipeline→queue overhead

--- a/ingest/ledgerbackend/buffered_storage_backend_test.go
+++ b/ingest/ledgerbackend/buffered_storage_backend_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stellar/go-stellar-sdk/support/compressxdr"
 	"github.com/stellar/go-stellar-sdk/support/datastore"
+	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
@@ -271,31 +272,44 @@ func TestBSBGetLedger_SingleLedgerPerFile(t *testing.T) {
 	assert.Equal(t, lcmArray[2], lcm)
 }
 
-func TestBSBGetLedgerRaw_SingleLedgerPerFile(t *testing.T) {
+// TestBufferedStorageStream exercises the LedgerStream API end to end over a
+// mocked datastore (via the openStore seam): RawLedgers builds a backend,
+// prepares the range, and yields each ledger's raw bytes (the lock-free
+// getLedgerRaw borrow) in order.
+func TestBufferedStorageStream(t *testing.T) {
 	startLedger := uint32(3)
 	endLedger := uint32(5)
 	ctx := context.Background()
 	lcmArray := createLCMForTesting(startLedger, endLedger)
-	bsb := createBufferedStorageBackendForTesting()
-	ledgerRange := BoundedRange(startLedger, endLedger)
-
 	mockDataStore := createMockdataStore(t, startLedger, endLedger, partitionSize, ledgerPerFileCount)
-	bsb.dataStore = mockDataStore
-
-	assert.NoError(t, bsb.PrepareRange(ctx, ledgerRange))
-	assert.Eventually(t, func() bool { return len(bsb.ledgerBuffer.ledgerQueue) == 3 }, time.Second*5, time.Millisecond*50)
-
-	for i := startLedger; i <= endLedger; i++ {
-		rawBytes, err := bsb.GetLedgerRaw(ctx, i)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, rawBytes)
-
-		// Verify raw bytes decode to the expected LedgerCloseMeta
-		var lcm xdr.LedgerCloseMeta
-		err = xdr.SafeUnmarshal(rawBytes, &lcm)
-		assert.NoError(t, err)
-		assert.Equal(t, lcmArray[i-startLedger], lcm)
+	// The stream owns the datastore lifecycle and closes it on teardown.
+	mockDataStore.On("Close").Return(nil).Once()
+	schema := datastore.DataStoreSchema{
+		LedgersPerFile:    ledgerPerFileCount,
+		FilesPerPartition: partitionSize,
+		FileExtension:     "zstd",
 	}
+
+	s := &bufferedStorageStream{
+		config: createBufferedStorageBackendConfigForTesting(),
+		log:    log.New(),
+		openStore: func(context.Context) (datastore.DataStore, datastore.DataStoreSchema, error) {
+			return mockDataStore, schema, nil
+		},
+	}
+
+	seq := startLedger
+	for raw, err := range s.RawLedgers(ctx, BoundedRange(startLedger, endLedger)) {
+		require.NoError(t, err)
+		require.NotEmpty(t, raw)
+
+		// raw is a borrow; decode it to verify it's the expected ledger.
+		var lcm xdr.LedgerCloseMeta
+		require.NoError(t, xdr.SafeUnmarshal(raw, &lcm))
+		assert.Equal(t, lcmArray[seq-startLedger], lcm)
+		seq++
+	}
+	assert.Equal(t, endLedger+1, seq, "stream should yield every ledger in range")
 }
 
 // TestBSBGetLedger_IdempotentReRequest verifies that requesting the
@@ -324,13 +338,6 @@ func TestBSBGetLedger_IdempotentReRequest(t *testing.T) {
 	second, err := bsb.GetLedger(ctx, startLedger)
 	assert.NoError(t, err)
 	assert.Equal(t, first, second)
-
-	// GetLedgerRaw on the same sequence is also idempotent.
-	rawBytes, err := bsb.GetLedgerRaw(ctx, startLedger)
-	assert.NoError(t, err)
-	var rawLCM xdr.LedgerCloseMeta
-	require.NoError(t, xdr.SafeUnmarshal(rawBytes, &rawLCM))
-	assert.Equal(t, first, rawLCM)
 
 	// Forward progress still works after re-requests.
 	next, err := bsb.GetLedger(ctx, startLedger+1)
@@ -517,7 +524,7 @@ func TestBSBClose(t *testing.T) {
 	assert.EqualError(t, err, "BufferedStorageBackend is closed; cannot GetLatestLedgerSequence")
 
 	_, err = bsb.GetLedger(ctx, 3)
-	assert.EqualError(t, err, "BufferedStorageBackend is closed; cannot GetLedger or GetLedgerRaw")
+	assert.EqualError(t, err, "BufferedStorageBackend is closed; cannot GetLedger")
 
 	err = bsb.PrepareRange(ctx, ledgerRange)
 	assert.EqualError(t, err, "BufferedStorageBackend is closed; cannot PrepareRange")

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -111,8 +112,13 @@ type CaptiveStellarCore struct {
 	// such as writing Prometheus metric captive_stellar_core_latest_ledger.
 	ledgerSequenceLock sync.RWMutex
 
-	prepared           *Range  // non-nil if any range is prepared
-	closed             bool    // False until the core is closed
+	prepared *Range // non-nil if any range is prepared
+	// closed is set by Close, which is thread-safe and may run on a goroutine
+	// distinct from the one reading ledgers (and from the Prometheus scrape
+	// goroutine reading GetLatestLedgerSequence). It is atomic so those reads
+	// never race the write — no single mutex covers all three callers, since
+	// the stream's read path is lock-free and Close writes under the read lock.
+	closed             atomic.Bool
 	nextLedger         uint32  // next ledger expected, error w/ restart if not seen
 	lastLedger         *uint32 // end of current segment if offline, nil if online
 	previousLedgerHash *string
@@ -539,7 +545,7 @@ func (c *CaptiveStellarCore) IsPrepared(ctx context.Context, ledgerRange Range) 
 }
 
 func (c *CaptiveStellarCore) isPrepared(ledgerRange Range) bool {
-	if c.closed {
+	if c.closed.Load() {
 		return false
 	}
 
@@ -624,7 +630,7 @@ func (c *CaptiveStellarCore) fetchSequence(ctx context.Context, sequence uint32)
 		return nil
 	}
 
-	if c.closed {
+	if c.closed.Load() {
 		return errors.New("stellar-core is no longer usable")
 	}
 
@@ -798,7 +804,7 @@ func (c *CaptiveStellarCore) GetLatestLedgerSequence(ctx context.Context) (uint3
 	c.ledgerSequenceLock.RLock()
 	defer c.ledgerSequenceLock.RUnlock()
 
-	if c.closed {
+	if c.closed.Load() {
 		return 0, errors.New("stellar-core is no longer usable")
 	}
 	if c.prepared == nil {
@@ -828,7 +834,7 @@ func (c *CaptiveStellarCore) Close() error {
 	c.stellarCoreLock.RLock()
 	defer c.stellarCoreLock.RUnlock()
 
-	c.closed = true
+	c.closed.Store(true)
 
 	if c.stellarCoreRunner != nil {
 		return c.stellarCoreRunner.close()

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -101,9 +101,8 @@ type CaptiveStellarCore struct {
 
 	// cached holds the most recently fetched ledger's XDR wire bytes and
 	// sequence. nil until the first ledger is consumed. Updated in
-	// fetchSequence(), shared by GetLedger() (decodes on demand) and
-	// GetLedgerRaw() (returns a copy). The two fields always move together —
-	// one validates the other.
+	// fetchSequence(); GetLedger() decodes from it on demand. The two fields
+	// always move together — one validates the other.
 	cached *cachedLedger
 
 	// ledgerSequenceLock mutex is used to protect the member variables used in the
@@ -605,7 +604,7 @@ func (c *CaptiveStellarCore) GetLedger(ctx context.Context, sequence uint32) (xd
 		return xdr.LedgerCloseMeta{}, err
 	}
 	// Decode lazily from the cached raw bytes — only GetLedger callers pay the
-	// XDR unmarshal cost; GetLedgerRaw avoids it entirely.
+	// XDR unmarshal cost.
 	var lcm xdr.LedgerCloseMeta
 	if err := xdr.SafeUnmarshal(c.cached.Raw, &lcm); err != nil {
 		return xdr.LedgerCloseMeta{}, errors.Wrap(err, "decoding cached ledger meta")
@@ -613,25 +612,11 @@ func (c *CaptiveStellarCore) GetLedger(ctx context.Context, sequence uint32) (xd
 	return lcm, nil
 }
 
-// GetLedgerRaw returns the XDR wire bytes for the requested sequence without
-// any XDR decoding. The reader stores the frame bytes as they arrive from the
-// captive-core meta pipe, so this is a copy of already-read data.
-func (c *CaptiveStellarCore) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
-	c.stellarCoreLock.RLock()
-	defer c.stellarCoreLock.RUnlock()
-	if err := c.fetchSequence(ctx, sequence); err != nil {
-		return nil, err
-	}
-	out := make([]byte, len(c.cached.Raw))
-	copy(out, c.cached.Raw)
-	return out, nil
-}
-
 // fetchSequence advances the captive-core stream until the cache holds the
 // requested ledger. The caller must hold c.stellarCoreLock.RLock().
 func (c *CaptiveStellarCore) fetchSequence(ctx context.Context, sequence uint32) error {
 	if c.cached != nil && sequence == c.cached.Seq {
-		// GetLedger / GetLedgerRaw can be called multiple times using the same sequence,
+		// GetLedger can be called multiple times using the same sequence,
 		// ex. to create change and transaction readers. If we have this ledger buffered,
 		// return it.
 		return nil
@@ -695,7 +680,7 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 
 	// Validate the streamed frame using zero-copy views — only the header
 	// fields we need for sequence/hash checks. The full XDR decode is
-	// deferred to GetLedger so GetLedgerRaw avoids it entirely.
+	// deferred to GetLedger.
 	view := xdr.LedgerCloseMetaView(result.raw)
 	seq, err := view.LedgerSequence()
 	if err != nil {

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -613,7 +613,9 @@ func (c *CaptiveStellarCore) GetLedger(ctx context.Context, sequence uint32) (xd
 }
 
 // fetchSequence advances the captive-core stream until the cache holds the
-// requested ledger. The caller must hold c.stellarCoreLock.RLock().
+// requested ledger. Concurrent callers must hold c.stellarCoreLock.RLock()
+// (GetLedger does); a single exclusive owner — the LedgerStream — may call it
+// lock-free.
 func (c *CaptiveStellarCore) fetchSequence(ctx context.Context, sequence uint32) error {
 	if c.cached != nil && sequence == c.cached.Seq {
 		// GetLedger can be called multiple times using the same sequence,

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -78,6 +78,180 @@ func TestCaptiveCoreStream(t *testing.T) {
 	tt.Equal(uint32(65), uint32(decoded.LedgerSequence()))
 }
 
+// TestCaptiveCoreStreamMetrics verifies the streaming path keeps the
+// observability the GetLedger+WithMetrics path had: every streamed ledger
+// records into ledger_fetch_duration_seconds, and the captive_stellar_core_*
+// suite is registered once and reads the per-iteration backend.
+func TestCaptiveCoreStreamMetrics(t *testing.T) {
+	tt := assert.New(t)
+	metaChan := make(chan metaResult, 300)
+	for i := uint32(64); i <= 66; i++ {
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: i})
+		raw, err := meta.MarshalBinary()
+		require.NoError(t, err)
+		metaChan <- metaResult{raw: raw}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan), true)
+	mockRunner.On("context").Return(ctx)
+	mockRunner.On("getProcessExitError").Return(nil, false)
+	mockRunner.On("close").Return(nil).Maybe()
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.On("GetRootHAS").Return(historyarchive.HistoryArchiveState{
+		CurrentLedger: 200,
+	}, nil)
+
+	stream := &captiveCoreStream{
+		log: log.New(),
+		newCore: func() (*CaptiveStellarCore, error) {
+			return &CaptiveStellarCore{
+				archive:                  mockArchive,
+				stellarCoreRunnerFactory: func() stellarCoreRunnerInterface { return mockRunner },
+				checkpointManager:        historyarchive.NewCheckpointManager(64),
+				cancel:                   context.CancelFunc(func() {}),
+			}, nil
+		},
+	}
+
+	registry := prometheus.NewRegistry()
+
+	var count int
+	for _, err := range stream.RawLedgers(ctx, BoundedRange(65, 66), WithStreamMetrics(registry, "test")) {
+		require.NoError(t, err)
+		count++
+	}
+	require.Equal(t, 2, count)
+
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+	families := map[string]*dto.MetricFamily{}
+	for _, mf := range metrics {
+		families[mf.GetName()] = mf
+	}
+
+	fetch := families["test_ingest_ledger_fetch_duration_seconds"]
+	require.NotNil(t, fetch, "ledger_fetch_duration_seconds not registered on the stream")
+	require.Len(t, fetch.Metric, 1)
+	tt.Equal(uint64(2), fetch.Metric[0].Summary.GetSampleCount(),
+		"each streamed ledger should record a fetch duration")
+
+	// The full captive-core suite must be registered, matching WithMetrics on a
+	// captive backend — otherwise the streaming path silently drops them.
+	for _, name := range []string{
+		"test_ingest_captive_stellar_core_synced",
+		"test_ingest_captive_stellar_core_supported_protocol_version",
+		"test_ingest_captive_stellar_core_latest_ledger",
+		"test_ingest_captive_stellar_core_start_duration_seconds",
+		"test_ingest_captive_stellar_core_new_db",
+	} {
+		tt.NotNil(families[name], "captive-core metric %q not registered on the stream", name)
+	}
+}
+
+// TestCaptiveCoreStreamMetricsConcurrentScrape runs a metrics scrape loop on a
+// separate goroutine while the stream drives the captive backend lock-free —
+// the exact concurrency a real /metrics endpoint creates. The captive gauges
+// read the live core (synced/version/latest-ledger) concurrently with
+// fetchSequence advancing it. Run under -race, this asserts the gauges only
+// touch fields the lock-free reader leaves synchronized (nextLedger/lastLedger
+// under ledgerSequenceLock, the set-once client, the stellarCoreLock-guarded
+// runner), never the lock-free cached/previousLedgerHash.
+func TestCaptiveCoreStreamMetricsConcurrentScrape(t *testing.T) {
+	metaChan := make(chan metaResult, 300)
+	for i := uint32(64); i <= 199; i++ {
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: i})
+		raw, err := meta.MarshalBinary()
+		require.NoError(t, err)
+		metaChan <- metaResult{raw: raw}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(65), uint32(199)).Return(nil)
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan), true)
+	mockRunner.On("context").Return(ctx)
+	mockRunner.On("getProcessExitError").Return(nil, false)
+	mockRunner.On("close").Return(nil).Maybe()
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.On("GetRootHAS").Return(historyarchive.HistoryArchiveState{
+		CurrentLedger: 300,
+	}, nil)
+
+	stream := &captiveCoreStream{
+		log: log.New(),
+		newCore: func() (*CaptiveStellarCore, error) {
+			return &CaptiveStellarCore{
+				archive:                  mockArchive,
+				stellarCoreRunnerFactory: func() stellarCoreRunnerInterface { return mockRunner },
+				checkpointManager:        historyarchive.NewCheckpointManager(64),
+				cancel:                   context.CancelFunc(func() {}),
+			}, nil
+		},
+	}
+
+	registry := prometheus.NewRegistry()
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				// Gather evaluates every GaugeFunc, calling into the live core.
+				_, _ = registry.Gather()
+			}
+		}
+	}()
+
+	var count int
+	for _, err := range stream.RawLedgers(ctx, BoundedRange(65, 199), WithStreamMetrics(registry, "test")) {
+		require.NoError(t, err)
+		count++
+	}
+	close(done)
+	wg.Wait()
+	require.Equal(t, 135, count)
+}
+
+// TestStreamMetricsSinglePass pins the metrics contract: the first instrumented
+// RawLedgers registers the collectors on the registry, so a registry
+// instruments a single call; a second instrumented call against the same
+// registry panics on duplicate registration (create a new stream/registry).
+func TestStreamMetricsSinglePass(t *testing.T) {
+	ctx := context.Background()
+	s := &captiveCoreStream{log: log.New()}
+	registry := prometheus.NewRegistry()
+
+	// First instrumented call registers fetch_duration. The iterator is
+	// discarded — registration happens on the call, no backend is built.
+	_ = s.RawLedgers(ctx, BoundedRange(1, 1), WithStreamMetrics(registry, "test"))
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+	var registered bool
+	for _, mf := range mfs {
+		if mf.GetName() == "test_ingest_ledger_fetch_duration_seconds" {
+			registered = true
+		}
+	}
+	require.True(t, registered, "first instrumented call should register fetch_duration")
+
+	// A second instrumented call re-registers on the same registry and panics.
+	require.Panics(t, func() {
+		_ = s.RawLedgers(ctx, BoundedRange(1, 1), WithStreamMetrics(registry, "test"))
+	})
+}
+
 // TODO: test frame decoding
 // TODO: test from static base64-encoded data
 
@@ -794,12 +968,12 @@ func TestCaptiveGetLedger(t *testing.T) {
 
 	ledgerRange := BoundedRange(65, 66)
 	tt.False(captiveBackend.isPrepared(ledgerRange), "core is not prepared until explicitly prepared")
-	tt.False(captiveBackend.closed)
+	tt.False(captiveBackend.closed.Load())
 	err = captiveBackend.PrepareRange(ctx, ledgerRange)
 	assert.NoError(t, err)
 
 	tt.True(captiveBackend.isPrepared(ledgerRange))
-	tt.False(captiveBackend.closed)
+	tt.False(captiveBackend.closed.Load())
 
 	_, err = captiveBackend.GetLedger(ctx, 64)
 	tt.Error(err, "requested ledger 64 is behind the captive core stream (expected=66)")
@@ -825,12 +999,12 @@ func TestCaptiveGetLedger(t *testing.T) {
 	tt.NoError(err)
 
 	tt.False(captiveBackend.isPrepared(ledgerRange))
-	tt.False(captiveBackend.closed)
+	tt.False(captiveBackend.closed.Load())
 	_, err = captiveBackend.GetLedger(ctx, 66)
 	tt.NoError(err)
 
 	// core is not closed unless it's explicitly closed
-	tt.False(captiveBackend.closed)
+	tt.False(captiveBackend.closed.Load())
 
 	mockArchive.AssertExpectations(t)
 	mockRunner.AssertExpectations(t)
@@ -1077,14 +1251,14 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 	tt.NoError(err)
 	tt.Equal(xdr.Uint32(65), meta.V0.LedgerHeader.Header.LedgerSeq)
 
-	tt.False(captiveBackend.closed)
+	tt.False(captiveBackend.closed.Load())
 
 	// try reading from an empty buffer
 	_, err = captiveBackend.GetLedger(ctx, 66)
 	tt.EqualError(err, "unmarshaling error")
 
 	// not closed even if there is an error getting ledger
-	tt.False(captiveBackend.closed)
+	tt.False(captiveBackend.closed.Load())
 
 	mockArchive.AssertExpectations(t)
 	mockRunner.AssertExpectations(t)
@@ -1167,7 +1341,7 @@ func TestCaptiveAfterClose(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, captiveBackend.Close())
-	assert.True(t, captiveBackend.closed)
+	assert.True(t, captiveBackend.closed.Load())
 
 	_, err = captiveBackend.GetLedger(ctx, boundedRange.to)
 	assert.EqualError(t, err, "stellar-core is no longer usable")

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -18,8 +18,65 @@ import (
 	"github.com/stellar/go-stellar-sdk/historyarchive"
 	"github.com/stellar/go-stellar-sdk/network"
 	"github.com/stellar/go-stellar-sdk/support/errors"
+	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
+
+// TestCaptiveCoreStream exercises the LedgerStream backed by captive-core via
+// the newCore seam: RawLedgers builds the backend, prepares the range, streams
+// each ledger's raw frame, and closes the backend on teardown.
+func TestCaptiveCoreStream(t *testing.T) {
+	tt := assert.New(t)
+	metaChan := make(chan metaResult, 300)
+
+	rawByLedger := map[uint32][]byte{}
+	for i := uint32(64); i <= 66; i++ {
+		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: i})
+		raw, err := meta.MarshalBinary()
+		require.NoError(t, err)
+		rawByLedger[i] = raw
+		metaChan <- metaResult{raw: raw}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockRunner := &stellarCoreRunnerMock{}
+	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
+	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan), true)
+	mockRunner.On("context").Return(ctx)
+	mockRunner.On("getProcessExitError").Return(nil, false)
+	mockRunner.On("close").Return(nil).Maybe()
+
+	mockArchive := &historyarchive.MockArchive{}
+	mockArchive.On("GetRootHAS").Return(historyarchive.HistoryArchiveState{
+		CurrentLedger: 200,
+	}, nil)
+
+	stream := &captiveCoreStream{
+		log: log.New(),
+		newCore: func() (*CaptiveStellarCore, error) {
+			return &CaptiveStellarCore{
+				archive:                  mockArchive,
+				stellarCoreRunnerFactory: func() stellarCoreRunnerInterface { return mockRunner },
+				checkpointManager:        historyarchive.NewCheckpointManager(64),
+				cancel:                   context.CancelFunc(func() {}),
+			}, nil
+		},
+	}
+
+	var got [][]byte
+	for raw, err := range stream.RawLedgers(ctx, BoundedRange(65, 66)) {
+		tt.NoError(err)
+		got = append(got, append([]byte(nil), raw...))
+	}
+	require.Len(t, got, 2)
+	tt.Equal(rawByLedger[65], got[0])
+	tt.Equal(rawByLedger[66], got[1])
+
+	var decoded xdr.LedgerCloseMeta
+	require.NoError(t, xdr.SafeUnmarshal(got[0], &decoded))
+	tt.Equal(uint32(65), uint32(decoded.LedgerSequence()))
+}
 
 // TODO: test frame decoding
 // TODO: test from static base64-encoded data
@@ -777,69 +834,6 @@ func TestCaptiveGetLedger(t *testing.T) {
 
 	mockArchive.AssertExpectations(t)
 	mockRunner.AssertExpectations(t)
-}
-
-// TestCaptiveGetLedgerRaw verifies that GetLedgerRaw returns the raw frame
-// bytes captured by the meta pipe reader without re-marshaling, that the
-// bytes round-trip to the same LedgerCloseMeta, that re-requests are
-// idempotent, and that returned bytes are a copy (not aliased).
-func TestCaptiveGetLedgerRaw(t *testing.T) {
-	tt := assert.New(t)
-	metaChan := make(chan metaResult, 300)
-
-	// Pre-load ledgers 64-66 so PrepareRange can fast-forward to 65, then
-	// GetLedgerRaw can consume 65 and verify its raw bytes round-trip.
-	rawByLedger := map[uint32][]byte{}
-	for i := uint32(64); i <= 66; i++ {
-		meta := buildLedgerCloseMeta(testLedgerHeader{sequence: i})
-		raw, err := meta.MarshalBinary()
-		require.NoError(t, err)
-		rawByLedger[i] = raw
-		metaChan <- metaResult{raw: raw}
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	mockRunner := &stellarCoreRunnerMock{}
-	mockRunner.On("catchup", uint32(65), uint32(66)).Return(nil)
-	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan), true)
-	mockRunner.On("context").Return(ctx)
-	mockRunner.On("getProcessExitError").Return(nil, false)
-	mockRunner.On("close").Return(nil).Maybe()
-
-	mockArchive := &historyarchive.MockArchive{}
-	mockArchive.On("GetRootHAS").Return(historyarchive.HistoryArchiveState{
-		CurrentLedger: 200,
-	}, nil)
-
-	captiveBackend := &CaptiveStellarCore{
-		archive:                  mockArchive,
-		stellarCoreRunnerFactory: func() stellarCoreRunnerInterface { return mockRunner },
-		checkpointManager:        historyarchive.NewCheckpointManager(64),
-	}
-	require.NoError(t, captiveBackend.PrepareRange(ctx, BoundedRange(65, 66)))
-
-	out, err := captiveBackend.GetLedgerRaw(ctx, 65)
-	tt.NoError(err)
-	tt.Equal(rawByLedger[65], out)
-
-	// Round-trip — bytes decode back to the same ledger.
-	var decoded xdr.LedgerCloseMeta
-	require.NoError(t, xdr.SafeUnmarshal(out, &decoded))
-	tt.Equal(uint32(65), uint32(decoded.LedgerSequence()))
-
-	// Idempotent re-request returns the same cached bytes.
-	out2, err := captiveBackend.GetLedgerRaw(ctx, 65)
-	tt.NoError(err)
-	tt.Equal(out, out2)
-
-	// Returned bytes must be a copy of cachedRaw, not aliased.
-	if len(out) > 0 {
-		out[0] ^= 0xFF
-	}
-	out3, err := captiveBackend.GetLedgerRaw(ctx, 65)
-	tt.NoError(err)
-	tt.Equal(out2, out3, "GetLedgerRaw must return a copy, not an aliased slice")
 }
 
 // TestCaptiveGetLedgerCacheLatestLedger test the following case:

--- a/ingest/ledgerbackend/ledger_backend.go
+++ b/ingest/ledgerbackend/ledger_backend.go
@@ -18,11 +18,6 @@ type LedgerBackend interface {
 	GetLatestLedgerSequence(ctx context.Context) (sequence uint32, err error)
 	// GetLedger will block until the ledger is available.
 	GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error)
-	// GetLedgerRaw returns the XDR wire bytes for a single LedgerCloseMeta
-	// without performing XDR decoding. Useful for forwarding/replication or
-	// for callers that decode selectively. Blocks until the ledger is available.
-	// Implementations should return a copy of the bytes — the caller owns them.
-	GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error)
 	// PrepareRange prepares the given range (including from and to) to be loaded.
 	// Some backends (like captive stellar-core) need to initalize data to be
 	// able to stream ledgers. Blocks until the first ledger is available.

--- a/ingest/ledgerbackend/ledger_buffer.go
+++ b/ingest/ledgerbackend/ledger_buffer.go
@@ -380,7 +380,11 @@ func (lb *ledgerBuffer) decompress(compressed []byte) ([]byte, error) {
 		lb.decompressedPool.Put(dst)
 	}
 
-	lb.lastDecompressedSize = len(decompressed)
+	// Clamp the fallback hint so a single outsized/corrupt batch can't
+	// permanently inflate the pooled buffer for subsequent (normally
+	// similar-sized) batches — mirrors the maxBatchObjectSize cap on the
+	// FrameContentSize path above.
+	lb.lastDecompressedSize = min(len(decompressed), maxBatchObjectSize)
 	return decompressed, nil
 }
 

--- a/ingest/ledgerbackend/ledger_buffer.go
+++ b/ingest/ledgerbackend/ledger_buffer.go
@@ -83,6 +83,14 @@ type ledgerBuffer struct {
 	// the BSB consumer (via decompress + returnBuffer).
 	decompressedPool bufferPool
 
+	// lastDecompressedSize is the size of the previously decompressed batch,
+	// used to pre-size the next decompress's destination buffer when the zstd
+	// frame carries no FrameContentSize (streaming-compressed objects). Batches
+	// are similar-sized, so this lets decompress reuse a pooled buffer instead
+	// of letting DecodeAll allocate the whole output every call. Consumer-only
+	// (written from decompress), so no lock.
+	lastDecompressedSize int
+
 	// context used to cancel workers within the ledgerBuffer
 	context context.Context
 	cancel  context.CancelCauseFunc
@@ -119,7 +127,13 @@ func (bsb *BufferedStorageBackend) newLedgerBuffer(ledgerRange Range) (*ledgerBu
 		bufferSize = uint32(min(int(bufferSize), int(ledgerRange.to-ledgerRange.from)+1))
 	}
 
-	decoder, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
+	// WithDecoderConcurrency(1): this decoder is driven serially by the BSB
+	// consumer (decompress() is consumer-thread-only), so a single
+	// decode/buffer combo is correct AND the most memory-efficient choice for
+	// DecodeAll. Concurrency 0 (=GOMAXPROCS) keeps GOMAXPROCS decoder combos
+	// and allocates per-call decode state, which dominated allocation under
+	// parallel multi-chunk ingest.
+	decoder, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
 	if err != nil {
 		cancel(err)
 		return nil, errors.Wrap(err, "failed to create zstd decoder")
@@ -335,13 +349,21 @@ func (lb *ledgerBuffer) downloadLedgerObject(ctx context.Context, sequence uint3
 func (lb *ledgerBuffer) decompress(compressed []byte) ([]byte, error) {
 	defer lb.compressedPool.Put(compressed)
 
-	// Skip pool pre-alloc if the header reports an implausibly large frame
-	// size — that's either corrupt data or hostile input, and we'd rather
-	// let DecodeAll grow naturally than reserve a huge buffer up front.
-	var dst []byte
+	// Pre-size the destination so DecodeAll appends into a pooled buffer
+	// instead of allocating the whole output on every call. Prefer the frame's
+	// FrameContentSize; when it's absent (streaming-compressed objects carry no
+	// FCS) fall back to the previous batch's size — batches are similar-sized,
+	// so this keeps the decompressedPool effective rather than letting every
+	// DecodeAll grow from nil. An implausibly large FCS (corrupt/hostile) is
+	// skipped, letting DecodeAll grow naturally.
+	sizeHint := lb.lastDecompressedSize
 	var header zstd.Header
 	if err := header.Decode(compressed); err == nil && header.HasFCS && header.FrameContentSize <= maxBatchObjectSize {
-		dst = lb.decompressedPool.Get(int(header.FrameContentSize))[:0]
+		sizeHint = int(header.FrameContentSize)
+	}
+	var dst []byte
+	if sizeHint > 0 {
+		dst = lb.decompressedPool.Get(sizeHint)[:0]
 	}
 
 	decompressed, err := lb.zstdDecoder.DecodeAll(compressed, dst)
@@ -358,6 +380,7 @@ func (lb *ledgerBuffer) decompress(compressed []byte) ([]byte, error) {
 		lb.decompressedPool.Put(dst)
 	}
 
+	lb.lastDecompressedSize = len(decompressed)
 	return decompressed, nil
 }
 

--- a/ingest/ledgerbackend/ledger_stream.go
+++ b/ingest/ledgerbackend/ledger_stream.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stellar/go-stellar-sdk/support/datastore"
 	"github.com/stellar/go-stellar-sdk/support/log"
@@ -22,7 +25,50 @@ type LedgerStream interface {
 	// cancellation. Each yielded slice is BORROWED: it is valid only until the
 	// next iteration step, so copy it if you need to retain it. Cancel a blocked
 	// stream via ctx.
-	RawLedgers(ctx context.Context, ledgerRange Range) iter.Seq2[[]byte, error]
+	//
+	// Pass WithStreamMetrics to instrument the invocation. The collectors are
+	// registered on the supplied registry, so a registry instruments a single
+	// RawLedgers call; instrumenting a second call on the same stream+registry
+	// panics on duplicate registration. Uninstrumented calls are reusable.
+	RawLedgers(ctx context.Context, ledgerRange Range, opts ...StreamOption) iter.Seq2[[]byte, error]
+}
+
+// StreamOption configures a single RawLedgers invocation.
+type StreamOption func(*streamConfig)
+
+type streamConfig struct {
+	registry  *prometheus.Registry
+	namespace string
+}
+
+// WithStreamMetrics instruments a RawLedgers invocation: it records
+// ledger_fetch_duration_seconds — and, for captive-core, the
+// captive_stellar_core_* suite — on registry under namespace, matching the
+// metric names WithMetrics emits on the GetLedger path. The collectors are
+// registered on the call, so a given registry instruments one RawLedgers call;
+// instrumenting a second call against the same registry panics on duplicate
+// registration. Create a new stream (with a fresh registry) to instrument
+// another run.
+func WithStreamMetrics(registry *prometheus.Registry, namespace string) StreamOption {
+	return func(c *streamConfig) {
+		c.registry = registry
+		c.namespace = namespace
+	}
+}
+
+// streamMetrics parses opts and, when a registry was supplied, registers and
+// returns the fetch-duration summary. It also returns the config so a backend
+// can register its own suite (captive-core). With no registry it returns a nil
+// summary and the fetch timing is skipped.
+func streamMetrics(opts []StreamOption) (prometheus.Summary, streamConfig) {
+	var cfg streamConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.registry == nil {
+		return nil, cfg
+	}
+	return newLedgerFetchDurationSummary(cfg.registry, cfg.namespace), cfg
 }
 
 // rawReader is the per-backend machinery one RawLedgers iteration drives: it
@@ -43,11 +89,16 @@ type rawReader struct {
 // error is logged rather than returned — by the time close runs the caller's
 // loop has already ended. The build func (and the reader it returns) is the
 // only backend-specific part.
+//
+// When fetchDuration is non-nil, each successful read is timed into it — the
+// streaming analog of the metricsLedgerBackend.GetLedger observation, recorded
+// at the single point all three backends funnel their reads through.
 func streamRaw(
 	ctx context.Context,
 	ledgerRange Range,
 	logger *log.Entry,
 	name string,
+	fetchDuration prometheus.Summary,
 	build func() (rawReader, error),
 ) iter.Seq2[[]byte, error] {
 	return func(yield func([]byte, error) bool) {
@@ -67,10 +118,19 @@ func streamRaw(
 			return
 		}
 		for seq := ledgerRange.from; ; seq++ {
+			// Only sample the clock when instrumented — this is the per-ledger
+			// hot path and time.Now() is wasted work when metrics are off.
+			var startTime time.Time
+			if fetchDuration != nil {
+				startTime = time.Now()
+			}
 			raw, err := rr.read(ctx, seq)
 			if err != nil {
 				yield(nil, err)
 				return
+			}
+			if fetchDuration != nil {
+				fetchDuration.Observe(time.Since(startTime).Seconds())
 			}
 			if !yield(raw, nil) {
 				return
@@ -102,6 +162,8 @@ type bufferedStorageStream struct {
 // datastore lifecycle: it is created when iteration begins and closed when
 // iteration ends. If logger is nil a default logger is used; teardown errors
 // are logged at Warn, since they cannot be returned once iteration has ended.
+//
+// Pass WithStreamMetrics to RawLedgers to record ledger_fetch_duration_seconds.
 func NewBufferedStorageStream(
 	cfg BufferedStorageBackendConfig,
 	dsConfig datastore.DataStoreConfig,
@@ -131,8 +193,9 @@ func (s *bufferedStorageStream) open(ctx context.Context) (datastore.DataStore, 
 	return ds, schema, nil
 }
 
-func (s *bufferedStorageStream) RawLedgers(ctx context.Context, ledgerRange Range) iter.Seq2[[]byte, error] {
-	return streamRaw(ctx, ledgerRange, s.log, "buffered storage", func() (rawReader, error) {
+func (s *bufferedStorageStream) RawLedgers(ctx context.Context, ledgerRange Range, opts ...StreamOption) iter.Seq2[[]byte, error] {
+	fetchDuration, _ := streamMetrics(opts)
+	return streamRaw(ctx, ledgerRange, s.log, "buffered storage", fetchDuration, func() (rawReader, error) {
 		ds, schema, err := s.open(ctx)
 		if err != nil {
 			return rawReader{}, err
@@ -169,6 +232,10 @@ type captiveCoreStream struct {
 // The stream owns the core process lifecycle: it is started when iteration
 // begins and closed when iteration ends. If logger is nil a default logger is
 // used; teardown errors are logged at Warn.
+//
+// Pass WithStreamMetrics to RawLedgers to record ledger_fetch_duration_seconds
+// and the captive_stellar_core_* suite (registered on the core that call
+// builds, matching WithMetrics on a captive backend).
 func NewCaptiveCoreStream(config CaptiveCoreConfig, logger *log.Entry) LedgerStream {
 	if logger == nil {
 		logger = log.New()
@@ -183,11 +250,19 @@ func (s *captiveCoreStream) newCaptive() (*CaptiveStellarCore, error) {
 	return NewCaptive(s.config)
 }
 
-func (s *captiveCoreStream) RawLedgers(ctx context.Context, ledgerRange Range) iter.Seq2[[]byte, error] {
-	return streamRaw(ctx, ledgerRange, s.log, "captive-core", func() (rawReader, error) {
+func (s *captiveCoreStream) RawLedgers(ctx context.Context, ledgerRange Range, opts ...StreamOption) iter.Seq2[[]byte, error] {
+	fetchDuration, cfg := streamMetrics(opts)
+	return streamRaw(ctx, ledgerRange, s.log, "captive-core", fetchDuration, func() (rawReader, error) {
 		c, err := s.newCaptive()
 		if err != nil {
 			return rawReader{}, err
+		}
+		// Register the captive suite on this core via the backend's own
+		// mechanism — the same call WithMetrics makes — before PrepareRange,
+		// which is where the start-duration summary and new-db counter are
+		// observed. The gauges read this core live on the scrape goroutine.
+		if cfg.registry != nil {
+			c.registerMetrics(cfg.registry, cfg.namespace)
 		}
 		return rawReader{
 			prepare: c.PrepareRange,
@@ -220,6 +295,8 @@ type rpcStream struct {
 // the backend lifecycle: it is created when iteration begins and closed when
 // iteration ends. If logger is nil a default logger is used; teardown errors
 // are logged at Warn.
+//
+// Pass WithStreamMetrics to RawLedgers to record ledger_fetch_duration_seconds.
 func NewRPCStream(options RPCLedgerBackendOptions, logger *log.Entry) LedgerStream {
 	if logger == nil {
 		logger = log.New()
@@ -234,8 +311,9 @@ func (s *rpcStream) newRPC() *RPCLedgerBackend {
 	return NewRPCLedgerBackend(s.options)
 }
 
-func (s *rpcStream) RawLedgers(ctx context.Context, ledgerRange Range) iter.Seq2[[]byte, error] {
-	return streamRaw(ctx, ledgerRange, s.log, "rpc", func() (rawReader, error) {
+func (s *rpcStream) RawLedgers(ctx context.Context, ledgerRange Range, opts ...StreamOption) iter.Seq2[[]byte, error] {
+	fetchDuration, _ := streamMetrics(opts)
+	return streamRaw(ctx, ledgerRange, s.log, "rpc", fetchDuration, func() (rawReader, error) {
 		b := s.newRPC()
 		return rawReader{
 			prepare: b.PrepareRange,

--- a/ingest/ledgerbackend/ledger_stream.go
+++ b/ingest/ledgerbackend/ledger_stream.go
@@ -1,0 +1,246 @@
+package ledgerbackend
+
+import (
+	"context"
+	"errors"
+	"iter"
+
+	"github.com/stellar/go-stellar-sdk/support/datastore"
+	"github.com/stellar/go-stellar-sdk/support/log"
+)
+
+// LedgerStream is an interchangeable ingestion source — captive-core,
+// buffered-storage (GCS/S3/…), RPC, and so on. Streaming is the only
+// operation: an implementation owns its own setup and teardown, so there is no
+// PrepareRange/GetLedger/Close for the consumer to sequence or misuse, and no
+// locking for the consumer to reason about (a stream is consumed by a single
+// goroutine).
+type LedgerStream interface {
+	// RawLedgers yields the raw XDR bytes of each ledger in ledgerRange, in
+	// order. The source is set up on the first pull and fully torn down when
+	// iteration ends — completion, an early break, an error, or ctx
+	// cancellation. Each yielded slice is BORROWED: it is valid only until the
+	// next iteration step, so copy it if you need to retain it. Cancel a blocked
+	// stream via ctx.
+	RawLedgers(ctx context.Context, ledgerRange Range) iter.Seq2[[]byte, error]
+}
+
+// rawReader is the per-backend machinery one RawLedgers iteration drives: it
+// prepares the range, reads each ledger's raw frame, and releases all
+// resources. The read returns a borrow valid only until the next read; because
+// a stream exclusively owns its backend on a single goroutine, the read needs
+// no lock (the only thing a backend's read lock guards is a concurrent Close,
+// which can't happen here — a blocked read is cancelled via ctx instead).
+type rawReader struct {
+	prepare func(ctx context.Context, ledgerRange Range) error
+	read    func(ctx context.Context, sequence uint32) ([]byte, error)
+	close   func() error
+}
+
+// streamRaw is the shared skeleton behind every LedgerStream.RawLedgers: build
+// the reader, prepare the range, yield each ledger's raw borrow in order, and
+// close on exit (completion, break, error, or ctx cancellation). The teardown
+// error is logged rather than returned — by the time close runs the caller's
+// loop has already ended. The build func (and the reader it returns) is the
+// only backend-specific part.
+func streamRaw(
+	ctx context.Context,
+	ledgerRange Range,
+	logger *log.Entry,
+	name string,
+	build func() (rawReader, error),
+) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		rr, err := build()
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		defer func() {
+			if cerr := rr.close(); cerr != nil {
+				logger.WithError(cerr).Warnf("%s stream: error closing backend", name)
+			}
+		}()
+
+		if err := rr.prepare(ctx, ledgerRange); err != nil {
+			yield(nil, err)
+			return
+		}
+		for seq := ledgerRange.from; ; seq++ {
+			raw, err := rr.read(ctx, seq)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield(raw, nil) {
+				return
+			}
+			if ledgerRange.bounded && seq == ledgerRange.to {
+				return
+			}
+		}
+	}
+}
+
+// bufferedStorageStream is a LedgerStream backed by a DataStore (GCS, S3, …).
+// Each RawLedgers call opens the datastore, runs a BufferedStorageBackend over
+// the range, and tears both down when iteration ends.
+var _ LedgerStream = (*bufferedStorageStream)(nil)
+
+type bufferedStorageStream struct {
+	config   BufferedStorageBackendConfig
+	dsConfig datastore.DataStoreConfig
+	log      *log.Entry
+
+	// openStore creates the datastore + schema; overridable for tests. nil →
+	// built from dsConfig.
+	openStore func(context.Context) (datastore.DataStore, datastore.DataStoreSchema, error)
+}
+
+// NewBufferedStorageStream returns a LedgerStream that streams raw ledgers from
+// the datastore described by dsConfig, tuned by cfg. The stream owns the
+// datastore lifecycle: it is created when iteration begins and closed when
+// iteration ends. If logger is nil a default logger is used; teardown errors
+// are logged at Warn, since they cannot be returned once iteration has ended.
+func NewBufferedStorageStream(
+	cfg BufferedStorageBackendConfig,
+	dsConfig datastore.DataStoreConfig,
+	logger *log.Entry,
+) LedgerStream {
+	if logger == nil {
+		logger = log.New()
+	}
+	return &bufferedStorageStream{config: cfg, dsConfig: dsConfig, log: logger}
+}
+
+func (s *bufferedStorageStream) open(ctx context.Context) (datastore.DataStore, datastore.DataStoreSchema, error) {
+	if s.openStore != nil {
+		return s.openStore(ctx)
+	}
+	ds, err := datastore.NewDataStore(ctx, s.dsConfig)
+	if err != nil {
+		return nil, datastore.DataStoreSchema{}, err
+	}
+	schema, err := datastore.LoadSchema(ctx, ds, s.dsConfig)
+	if err != nil {
+		if cerr := ds.Close(); cerr != nil {
+			s.log.WithError(cerr).Warn("buffered storage stream: error closing datastore after schema load failure")
+		}
+		return nil, datastore.DataStoreSchema{}, err
+	}
+	return ds, schema, nil
+}
+
+func (s *bufferedStorageStream) RawLedgers(ctx context.Context, ledgerRange Range) iter.Seq2[[]byte, error] {
+	return streamRaw(ctx, ledgerRange, s.log, "buffered storage", func() (rawReader, error) {
+		ds, schema, err := s.open(ctx)
+		if err != nil {
+			return rawReader{}, err
+		}
+		bsb, err := NewBufferedStorageBackend(s.config, ds, schema)
+		if err != nil {
+			if cerr := ds.Close(); cerr != nil {
+				s.log.WithError(cerr).Warn("buffered storage stream: error closing datastore")
+			}
+			return rawReader{}, err
+		}
+		return rawReader{
+			prepare: bsb.PrepareRange,
+			read:    bsb.getLedgerRaw,
+			close:   func() error { return errors.Join(bsb.Close(), ds.Close()) },
+		}, nil
+	})
+}
+
+// captiveCoreStream is a LedgerStream backed by a captive stellar-core process.
+// Each RawLedgers call starts a core process for the range and shuts it down
+// when iteration ends.
+var _ LedgerStream = (*captiveCoreStream)(nil)
+
+type captiveCoreStream struct {
+	config CaptiveCoreConfig
+	log    *log.Entry
+
+	// newCore builds the backend; overridable for tests. nil → NewCaptive(config).
+	newCore func() (*CaptiveStellarCore, error)
+}
+
+// NewCaptiveCoreStream returns a LedgerStream backed by captive stellar-core.
+// The stream owns the core process lifecycle: it is started when iteration
+// begins and closed when iteration ends. If logger is nil a default logger is
+// used; teardown errors are logged at Warn.
+func NewCaptiveCoreStream(config CaptiveCoreConfig, logger *log.Entry) LedgerStream {
+	if logger == nil {
+		logger = log.New()
+	}
+	return &captiveCoreStream{config: config, log: logger}
+}
+
+func (s *captiveCoreStream) newCaptive() (*CaptiveStellarCore, error) {
+	if s.newCore != nil {
+		return s.newCore()
+	}
+	return NewCaptive(s.config)
+}
+
+func (s *captiveCoreStream) RawLedgers(ctx context.Context, ledgerRange Range) iter.Seq2[[]byte, error] {
+	return streamRaw(ctx, ledgerRange, s.log, "captive-core", func() (rawReader, error) {
+		c, err := s.newCaptive()
+		if err != nil {
+			return rawReader{}, err
+		}
+		return rawReader{
+			prepare: c.PrepareRange,
+			read: func(ctx context.Context, seq uint32) ([]byte, error) {
+				if err := c.fetchSequence(ctx, seq); err != nil {
+					return nil, err
+				}
+				return c.cached.Raw, nil
+			},
+			close: c.Close,
+		}, nil
+	})
+}
+
+// rpcStream is a LedgerStream backed by an RPC server. Each RawLedgers call
+// drives a fresh RPCLedgerBackend over the range and closes it when iteration
+// ends.
+var _ LedgerStream = (*rpcStream)(nil)
+
+type rpcStream struct {
+	options RPCLedgerBackendOptions
+	log     *log.Entry
+
+	// newBackend builds the backend; overridable for tests. nil →
+	// NewRPCLedgerBackend(options).
+	newBackend func() *RPCLedgerBackend
+}
+
+// NewRPCStream returns a LedgerStream backed by an RPC server. The stream owns
+// the backend lifecycle: it is created when iteration begins and closed when
+// iteration ends. If logger is nil a default logger is used; teardown errors
+// are logged at Warn.
+func NewRPCStream(options RPCLedgerBackendOptions, logger *log.Entry) LedgerStream {
+	if logger == nil {
+		logger = log.New()
+	}
+	return &rpcStream{options: options, log: logger}
+}
+
+func (s *rpcStream) newRPC() *RPCLedgerBackend {
+	if s.newBackend != nil {
+		return s.newBackend()
+	}
+	return NewRPCLedgerBackend(s.options)
+}
+
+func (s *rpcStream) RawLedgers(ctx context.Context, ledgerRange Range) iter.Seq2[[]byte, error] {
+	return streamRaw(ctx, ledgerRange, s.log, "rpc", func() (rawReader, error) {
+		b := s.newRPC()
+		return rawReader{
+			prepare: b.PrepareRange,
+			read:    b.fetchSequenceLocked,
+			close:   b.Close,
+		}, nil
+	})
+}

--- a/ingest/ledgerbackend/ledger_stream.go
+++ b/ingest/ledgerbackend/ledger_stream.go
@@ -239,7 +239,7 @@ func (s *rpcStream) RawLedgers(ctx context.Context, ledgerRange Range) iter.Seq2
 		b := s.newRPC()
 		return rawReader{
 			prepare: b.PrepareRange,
-			read:    b.fetchSequenceLocked,
+			read:    b.fetchSequence,
 			close:   b.Close,
 		}, nil
 	})

--- a/ingest/ledgerbackend/metrics.go
+++ b/ingest/ledgerbackend/metrics.go
@@ -9,11 +9,12 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
-// WithMetrics decorates the given LedgerBackend with metrics
-func WithMetrics(base LedgerBackend, registry *prometheus.Registry, namespace string) LedgerBackend {
-	if captiveCoreBackend, ok := base.(*CaptiveStellarCore); ok {
-		captiveCoreBackend.registerMetrics(registry, namespace)
-	}
+// newLedgerFetchDurationSummary builds and registers the
+// ledger_fetch_duration_seconds summary. Shared by WithMetrics (the GetLedger
+// path) and the LedgerStream implementations (the RawLedgers path) so both
+// emit the identical metric — a consumer keeps the same dashboard whichever
+// ingestion API it uses.
+func newLedgerFetchDurationSummary(registry *prometheus.Registry, namespace string) prometheus.Summary {
 	summary := prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: namespace, Subsystem: "ingest", Name: "ledger_fetch_duration_seconds",
@@ -22,9 +23,17 @@ func WithMetrics(base LedgerBackend, registry *prometheus.Registry, namespace st
 		},
 	)
 	registry.MustRegister(summary)
+	return summary
+}
+
+// WithMetrics decorates the given LedgerBackend with metrics
+func WithMetrics(base LedgerBackend, registry *prometheus.Registry, namespace string) LedgerBackend {
+	if captiveCoreBackend, ok := base.(*CaptiveStellarCore); ok {
+		captiveCoreBackend.registerMetrics(registry, namespace)
+	}
 	return metricsLedgerBackend{
 		LedgerBackend:              base,
-		ledgerFetchDurationSummary: summary,
+		ledgerFetchDurationSummary: newLedgerFetchDurationSummary(registry, namespace),
 	}
 }
 

--- a/ingest/ledgerbackend/metrics.go
+++ b/ingest/ledgerbackend/metrics.go
@@ -42,17 +42,3 @@ func (m metricsLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (x
 	m.ledgerFetchDurationSummary.Observe(time.Since(startTime).Seconds())
 	return lcm, nil
 }
-
-// GetLedgerRaw is a passthrough to the wrapped backend, recording the same
-// ledgerFetchDurationSummary as GetLedger — both code paths are "fetches"
-// from the backend's perspective; the latency profile is dominated by I/O,
-// not by the marshal step.
-func (m metricsLedgerBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
-	startTime := time.Now()
-	raw, err := m.LedgerBackend.GetLedgerRaw(ctx, sequence)
-	if err != nil {
-		return nil, err
-	}
-	m.ledgerFetchDurationSummary.Observe(time.Since(startTime).Seconds())
-	return raw, nil
-}

--- a/ingest/ledgerbackend/metrics_test.go
+++ b/ingest/ledgerbackend/metrics_test.go
@@ -11,20 +11,18 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
-// TestMetricsGetLedgerRaw verifies that GetLedgerRaw on the metrics-decorated
-// backend records the same ledgerFetchDurationSummary as GetLedger (both are
-// "fetches" from the backend's perspective).
-func TestMetricsGetLedgerRaw(t *testing.T) {
+// TestMetricsGetLedger verifies that GetLedger on the metrics-decorated backend
+// records into the ledgerFetchDurationSummary — once per fetch.
+func TestMetricsGetLedger(t *testing.T) {
 	ctx := context.Background()
 	mock := &MockDatabaseBackend{}
-	mock.On("GetLedgerRaw", ctx, uint32(5)).Return([]byte{0x01, 0x02, 0x03}, nil).Once()
-	mock.On("GetLedger", ctx, uint32(6)).Return(xdr.LedgerCloseMeta{}, nil).Once()
+	mock.On("GetLedger", ctx, uint32(6)).Return(xdr.LedgerCloseMeta{}, nil).Twice()
 	defer mock.AssertExpectations(t)
 
 	registry := prometheus.NewRegistry()
 	backend := WithMetrics(mock, registry, "test")
 
-	_, err := backend.GetLedgerRaw(ctx, 5)
+	_, err := backend.GetLedger(ctx, 6)
 	require.NoError(t, err)
 	_, err = backend.GetLedger(ctx, 6)
 	require.NoError(t, err)
@@ -42,5 +40,5 @@ func TestMetricsGetLedgerRaw(t *testing.T) {
 	}
 	require.NotNil(t, summary, "ledger_fetch_duration_seconds summary not found")
 	require.Equal(t, uint64(2), summary.GetSampleCount(),
-		"GetLedger and GetLedgerRaw should both record into the same summary")
+		"each GetLedger should record into the summary")
 }

--- a/ingest/ledgerbackend/mock_database_backend.go
+++ b/ingest/ledgerbackend/mock_database_backend.go
@@ -34,11 +34,6 @@ func (m *MockDatabaseBackend) GetLedger(ctx context.Context, sequence uint32) (x
 	return args.Get(0).(xdr.LedgerCloseMeta), args.Error(1)
 }
 
-func (m *MockDatabaseBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
-	args := m.Called(ctx, sequence)
-	return args.Get(0).([]byte), args.Error(1)
-}
-
 func (m *MockDatabaseBackend) Close() error {
 	args := m.Called()
 	return args.Error(0)

--- a/ingest/ledgerbackend/rpc_backend.go
+++ b/ingest/ledgerbackend/rpc_backend.go
@@ -122,7 +122,7 @@ func (b *RPCLedgerBackend) GetLatestLedgerSequence(ctx context.Context) (sequenc
 func (b *RPCLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
 	b.bufferLock.Lock()
 	defer b.bufferLock.Unlock()
-	raw, err := b.fetchSequenceLocked(ctx, sequence)
+	raw, err := b.fetchSequence(ctx, sequence)
 	if err != nil {
 		return xdr.LedgerCloseMeta{}, err
 	}
@@ -135,9 +135,10 @@ func (b *RPCLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.
 	return lcm, nil
 }
 
-// fetchSequenceLocked is the body of GetLedger. The
-// caller must hold b.bufferLock. On success, advances b.nextLedger.
-func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uint32) ([]byte, error) {
+// fetchSequence is the body of GetLedger; on success it advances b.nextLedger.
+// Concurrent callers must hold b.bufferLock (GetLedger does); a single exclusive
+// owner — the LedgerStream — may call it lock-free.
+func (b *RPCLedgerBackend) fetchSequence(ctx context.Context, sequence uint32) ([]byte, error) {
 	if err := b.checkClosed(); err != nil {
 		return nil, err
 	}

--- a/ingest/ledgerbackend/rpc_backend.go
+++ b/ingest/ledgerbackend/rpc_backend.go
@@ -41,8 +41,7 @@ type RPCLedgerGetter interface {
 type RPCLedgerBackend struct {
 	client RPCLedgerGetter
 	// buffer maps ledger sequence to the raw XDR wire bytes from the most
-	// recent RPC fetch. GetLedger decodes lazily from these bytes;
-	// GetLedgerRaw returns a copy without decoding.
+	// recent RPC fetch. GetLedger decodes lazily from these bytes.
 	buffer             map[uint32][]byte
 	bufferSize         uint32
 	preparedRange      *Range
@@ -128,7 +127,7 @@ func (b *RPCLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.
 		return xdr.LedgerCloseMeta{}, err
 	}
 	// Decode lazily from the cached raw bytes — only GetLedger callers pay
-	// the XDR unmarshal cost; GetLedgerRaw avoids it entirely.
+	// the XDR unmarshal cost.
 	var lcm xdr.LedgerCloseMeta
 	if err := xdr.SafeUnmarshal(raw, &lcm); err != nil {
 		return xdr.LedgerCloseMeta{}, fmt.Errorf("failed to unmarshal cached ledger: %w", err)
@@ -136,22 +135,7 @@ func (b *RPCLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.
 	return lcm, nil
 }
 
-// GetLedgerRaw returns the XDR wire bytes for the requested sequence without
-// any XDR decoding. The buffer holds the base64-decoded bytes from the RPC
-// response, so this is a copy of already-fetched data.
-func (b *RPCLedgerBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
-	b.bufferLock.Lock()
-	defer b.bufferLock.Unlock()
-	raw, err := b.fetchSequenceLocked(ctx, sequence)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]byte, len(raw))
-	copy(out, raw)
-	return out, nil
-}
-
-// fetchSequenceLocked is the shared body of GetLedger / GetLedgerRaw. The
+// fetchSequenceLocked is the body of GetLedger. The
 // caller must hold b.bufferLock. On success, advances b.nextLedger.
 func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uint32) ([]byte, error) {
 	if err := b.checkClosed(); err != nil {
@@ -159,7 +143,7 @@ func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uin
 	}
 
 	if b.preparedRange == nil {
-		return nil, fmt.Errorf("RPCLedgerBackend must be prepared before calling GetLedger or GetLedgerRaw")
+		return nil, fmt.Errorf("RPCLedgerBackend must be prepared before calling GetLedger")
 	}
 
 	if sequence < b.preparedRange.from || (b.preparedRange.bounded && sequence > b.preparedRange.to) {
@@ -207,7 +191,7 @@ func (b *RPCLedgerBackend) fetchSequenceLocked(ctx context.Context, sequence uin
 // PrepareRange initiates retrieval of requested ledger range.
 // It does minimal validation of data on RPC up front.
 // It will check if starting point of range is within current historical retention window of the RPC server.
-// It cannot guarantee ledgers within historical ranges will be available when requested later by GetLedger or GetLedgerRaw.
+// It cannot guarantee ledgers within historical ranges will be available when requested later by GetLedger.
 // See Also: GetLedger for more details on how the RPCLedgerBackend handles ledger availability.
 func (b *RPCLedgerBackend) PrepareRange(ctx context.Context, ledgerRange Range) error {
 	b.bufferLock.Lock()
@@ -306,7 +290,7 @@ func (b *RPCLedgerBackend) getBufferedLedger(ctx context.Context, sequence uint3
 	b.initBuffer()
 
 	// Populate buffer with new ledgers — base64-decode once into raw bytes.
-	// GetLedger decodes lazily from these bytes; GetLedgerRaw returns a copy.
+	// GetLedger decodes lazily from these bytes.
 	for _, ledger := range ledgers.Ledgers {
 		raw, err := base64.StdEncoding.DecodeString(ledger.LedgerMetadata)
 		if err != nil {

--- a/ingest/ledgerbackend/rpc_backend_test.go
+++ b/ingest/ledgerbackend/rpc_backend_test.go
@@ -11,8 +11,59 @@ import (
 	"github.com/stretchr/testify/require"
 
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
+
+// TestRPCStream exercises the LedgerStream backed by RPC via the newBackend
+// seam: RawLedgers prepares the range, streams the buffered raw bytes, and
+// closes the backend on teardown.
+func TestRPCStream(t *testing.T) {
+	rpcBackend, mockClient := setupRPCTest(t)
+	ctx := context.Background()
+	sequence := uint32(12345)
+
+	mockClient.On("GetHealth", ctx).Return(protocol.GetHealthResponse{
+		LatestLedger: sequence + 10,
+	}, nil)
+
+	lcm := xdr.LedgerCloseMeta{
+		V: 0,
+		V0: &xdr.LedgerCloseMetaV0{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					LedgerSeq: xdr.Uint32(sequence),
+				},
+			},
+		},
+	}
+	encodedLCM, err := xdr.MarshalBase64(lcm)
+	assert.NoError(t, err)
+
+	mockClient.On("GetLedgers", ctx, protocol.GetLedgersRequest{
+		StartLedger: sequence,
+		Pagination:  &protocol.LedgerPaginationOptions{Limit: uint(rpcBackendDefaultBufferSize)},
+	}).Return(protocol.GetLedgersResponse{
+		Ledgers:      []protocol.LedgerInfo{{Sequence: sequence, LedgerMetadata: encodedLCM}},
+		LatestLedger: sequence + 10,
+	}, nil).Once()
+
+	stream := &rpcStream{
+		log:        log.New(),
+		newBackend: func() *RPCLedgerBackend { return rpcBackend },
+	}
+
+	var got [][]byte
+	for raw, rerr := range stream.RawLedgers(ctx, BoundedRange(sequence, sequence)) {
+		assert.NoError(t, rerr)
+		got = append(got, append([]byte(nil), raw...))
+	}
+	require.Len(t, got, 1)
+
+	var decoded xdr.LedgerCloseMeta
+	require.NoError(t, xdr.SafeUnmarshal(got[0], &decoded))
+	assert.Equal(t, lcm, decoded)
+}
 
 type MockRPCClient struct {
 	mock.Mock
@@ -128,68 +179,6 @@ func TestRPCGetLedger(t *testing.T) {
 	_, err = rpcBackend.GetLedger(ctx, sequence)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "RPCLedgerBackend is closed")
-}
-
-// TestRPCGetLedgerRaw exercises the GetLedgerRaw zero-copy path: the RPC
-// response's base64-encoded LedgerMetadata is decoded once into raw bytes,
-// the same bytes are returned (as a copy) without re-marshaling, and the
-// bytes round-trip to a valid LedgerCloseMeta.
-func TestRPCGetLedgerRaw(t *testing.T) {
-	rpcBackend, mockClient := setupRPCTest(t)
-	ctx := context.Background()
-	sequence := uint32(12345)
-
-	mockClient.On("GetHealth", ctx).Return(protocol.GetHealthResponse{
-		LatestLedger: sequence + 10,
-	}, nil)
-
-	lcm := xdr.LedgerCloseMeta{
-		V: 0,
-		V0: &xdr.LedgerCloseMetaV0{
-			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
-				Header: xdr.LedgerHeader{
-					LedgerSeq: xdr.Uint32(sequence),
-				},
-			},
-		},
-	}
-	encodedLCM, err := xdr.MarshalBase64(lcm)
-	assert.NoError(t, err)
-
-	mockClient.On("GetLedgers", ctx, protocol.GetLedgersRequest{
-		StartLedger: sequence,
-		Pagination:  &protocol.LedgerPaginationOptions{Limit: uint(rpcBackendDefaultBufferSize)},
-	}).Return(protocol.GetLedgersResponse{
-		Ledgers:      []protocol.LedgerInfo{{Sequence: sequence, LedgerMetadata: encodedLCM}},
-		LatestLedger: sequence + 10,
-	}, nil).Once()
-
-	preparedRange := Range{from: sequence, to: sequence + 10, bounded: true}
-	rpcBackend.PrepareRange(ctx, preparedRange)
-
-	rawBytes, err := rpcBackend.GetLedgerRaw(ctx, sequence)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, rawBytes)
-
-	// Round-trip: bytes should decode to the original LedgerCloseMeta.
-	var decoded xdr.LedgerCloseMeta
-	require.NoError(t, xdr.SafeUnmarshal(rawBytes, &decoded))
-	assert.Equal(t, lcm, decoded)
-
-	// Idempotent re-request: GetLedgerRaw on the same sequence returns the
-	// cached bytes without making another RPC call.
-	rawBytes2, err := rpcBackend.GetLedgerRaw(ctx, sequence)
-	assert.NoError(t, err)
-	assert.Equal(t, rawBytes, rawBytes2)
-
-	// Returned bytes must be a copy, not aliased — mutating one must not
-	// affect a subsequent fetch.
-	if len(rawBytes) > 0 {
-		rawBytes[0] ^= 0xFF
-	}
-	rawBytes3, err := rpcBackend.GetLedgerRaw(ctx, sequence)
-	assert.NoError(t, err)
-	assert.Equal(t, rawBytes2, rawBytes3, "GetLedgerRaw must return a copy, not an aliased slice")
 }
 
 func TestRPCBackendImplementsInterface(t *testing.T) {

--- a/ingest/loadtest/ledger_backend.go
+++ b/ingest/loadtest/ledger_backend.go
@@ -406,18 +406,6 @@ func (r *LedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.Led
 	return r.cachedLedger, nil
 }
 
-// GetLedgerRaw is a baseline implementation that calls GetLedger and marshals
-// the result. The load-test backend reads ledgers from an XDR stream and may
-// merge with real ledgers from the wrapped backend; this routes through the
-// merged-stream path rather than maintaining a parallel raw-bytes cache.
-func (r *LedgerBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
-	lcm, err := r.GetLedger(ctx, sequence)
-	if err != nil {
-		return nil, err
-	}
-	return lcm.MarshalBinary()
-}
-
 func (r *LedgerBackend) Close() error {
 	r.lock.Lock()
 	defer r.lock.Unlock()

--- a/ingest/loadtest/ledger_backend_test.go
+++ b/ingest/loadtest/ledger_backend_test.go
@@ -26,11 +26,6 @@ func (m *mockLedgerBackend) GetLedger(ctx context.Context, sequence uint32) (xdr
 	return args.Get(0).(xdr.LedgerCloseMeta), args.Error(1)
 }
 
-func (m *mockLedgerBackend) GetLedgerRaw(ctx context.Context, sequence uint32) ([]byte, error) {
-	args := m.Called(ctx, sequence)
-	return args.Get(0).([]byte), args.Error(1)
-}
-
 func (m *mockLedgerBackend) PrepareRange(ctx context.Context, ledgerRange ledgerbackend.Range) error {
 	args := m.Called(ctx, ledgerRange)
 	return args.Error(0)


### PR DESCRIPTION
 ### What

  Introduce a streaming-first, interchangeable ingestion source interface:

  ```go
  type LedgerStream interface {
      // RawLedgers yields the raw XDR bytes of each ledger in r, in order.
      RawLedgers(ctx context.Context, r Range) iter.Seq2[[]byte, error]
  }
```
  with constructors for all three backends:
  
  - NewBufferedStorageStream(cfg, dsConfig, log) — GCS/S3 datastore
  - NewCaptiveCoreStream(config, log) — captive stellar-core
  - NewRPCStream(options, log) — RPC server

  Each implementation owns its whole lifecycle: it builds its backend and prepares
  the range when iteration begins, and tears everything down when iteration ends
  (completion, early break, error, or ctx cancellation), logging close errors. The
  three share a single streamRaw skeleton + rawReader so they don't diverge.

  This also removes the unreleased GetLedgerRaw (the LedgerBackend interface
  method, its metricsLedgerBackend passthrough, and the mock) — streaming replaces
  its only use. GetLedger (decoded random access) is unchanged.

  A second commit pools the zstd decompression output buffer in
  BufferedStorageBackend: streaming-compressed objects omit FrameContentSize, so
  DecodeAll's destination stayed nil and it reallocated the full output on every
  batch. It now pre-sizes from the previous batch's decompressed size and reuses the
  buffer, and sets WithDecoderConcurrency(1) (the consumer drives decompress
  serially). Under parallel multi-chunk ingest this allocation dominated.

  ### Why

  Streaming is the dominant ingestion pattern, but PrepareRange + per-ledger
  GetLedger + Close is a stateful sequence that's easy to misuse and forces a
  per-ledger XDR copy/decode. LedgerStream collapses that into one call and lets
  consumers swap captive-core / datastore / RPC sources without touching their loop,
  while each implementation still reaches its own internals for a zero-copy read.

  The per-step read is lock-free: a stream exclusively owns its backend on a
  single goroutine, so the only thing the backend's read lock guards — a concurrent
  Close — cannot happen, and a blocked read is cancelled via ctx. Each yielded
  slice is a borrow that aliases the backend's internal frame and is valid only
  until the next iteration step; consumers copy if they need to retain it. Together
  this removes both the per-ledger lock and the per-ledger copy from the hot path.

  Each backend exposes an injectable factory seam so the streams are unit-testable
  without real GCS/core/RPC.

 ### Known limitations

  - Yielded bytes are borrows, not safe to retain past the next step (documented
  on the interface and rawReader). Callers that retain must copy.
  - No decoded-LedgerCloseMeta streaming helper here — streaming yields raw XDR;
  consumers unmarshal as needed.
  - Single-consumer only: a LedgerStream is meant to be driven by one goroutine.
  - GetLedgerRaw removal is not a breaking change — it was never in a tagged
  release; GetLedger is untouched.

  ### Testing
  
  TestBufferedStorageStream, TestCaptiveCoreStream, and TestRPCStream exercise
  each implementation through its factory seam (lifecycle, ordering, bounded/error/
  early-break paths). Full ingest/ledgerbackend and ingest/loadtest suites pass.
