### PR TITLE
protocols/rpc: Add LedgerCloseTime to GetHealthResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Official project releases may be found here: https://github.com/stellar/go-stell
 ## Pending
 
 ### New Features
-* protocols/rpc: Add `LatestLedgerCloseTime` to `GetHealthResponse`, exposing the latest ledger's close time (unix seconds) on the `getHealth` response ([#5958](https://github.com/stellar/go-stellar-sdk/pull/5958))
+* protocols/rpc: Add `LatestLedgerCloseTime` and `OldestLedgerCloseTime` to `GetHealthResponse`, exposing the latest and oldest ledgers' close times (unix seconds) on the `getHealth` response ([#5958](https://github.com/stellar/go-stellar-sdk/pull/5958))
 
 ## [0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This monorepo contains a number of sdk's:
 Official project releases may be found here: https://github.com/stellar/go-stellar-sdk/releases
 ## Pending
 
+### New Features
+* protocols/rpc: Add `LatestLedgerCloseTime` to `GetHealthResponse`, exposing the latest ledger's close time (unix seconds) on the `getHealth` response ([#5958](https://github.com/stellar/go-stellar-sdk/pull/5958))
+
 ## [0.3.0]
 
 ### Security Fixes

--- a/clients/rpcclient/main_test.go
+++ b/clients/rpcclient/main_test.go
@@ -37,6 +37,7 @@ func TestClient_GetHealth(t *testing.T) {
 		LatestLedger:          1000,
 		LatestLedgerCloseTime: 1700000000,
 		OldestLedger:          100,
+		OldestLedgerCloseTime: 1699000000,
 		LedgerRetentionWindow: 900,
 	}
 
@@ -66,6 +67,7 @@ func TestClient_GetHealth(t *testing.T) {
 	assert.Equal(t, expectedResponse.LatestLedger, health.LatestLedger)
 	assert.Equal(t, expectedResponse.LatestLedgerCloseTime, health.LatestLedgerCloseTime)
 	assert.Equal(t, expectedResponse.OldestLedger, health.OldestLedger)
+	assert.Equal(t, expectedResponse.OldestLedgerCloseTime, health.OldestLedgerCloseTime)
 	assert.Equal(t, expectedResponse.LedgerRetentionWindow, health.LedgerRetentionWindow)
 }
 

--- a/clients/rpcclient/main_test.go
+++ b/clients/rpcclient/main_test.go
@@ -35,6 +35,7 @@ func TestClient_GetHealth(t *testing.T) {
 	expectedResponse := protocol.GetHealthResponse{
 		Status:                "healthy",
 		LatestLedger:          1000,
+		LatestLedgerCloseTime: 1700000000,
 		OldestLedger:          100,
 		LedgerRetentionWindow: 900,
 	}
@@ -63,6 +64,7 @@ func TestClient_GetHealth(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expectedResponse.Status, health.Status)
 	assert.Equal(t, expectedResponse.LatestLedger, health.LatestLedger)
+	assert.Equal(t, expectedResponse.LatestLedgerCloseTime, health.LatestLedgerCloseTime)
 	assert.Equal(t, expectedResponse.OldestLedger, health.OldestLedger)
 	assert.Equal(t, expectedResponse.LedgerRetentionWindow, health.LedgerRetentionWindow)
 }

--- a/protocols/rpc/get_health.go
+++ b/protocols/rpc/get_health.go
@@ -8,7 +8,9 @@ type GetHealthResponse struct {
 	Status       string `json:"status"`
 	LatestLedger uint32 `json:"latestLedger"`
 	// LatestLedgerCloseTime is the time the latest ledger closed at, as a unix timestamp in seconds.
-	LatestLedgerCloseTime int64  `json:"latestLedgerCloseTime"`
+	LatestLedgerCloseTime int64  `json:"latestLedgerCloseTime,string"`
 	OldestLedger          uint32 `json:"oldestLedger"`
+	// OldestLedgerCloseTime is the time the oldest ledger closed at, as a unix timestamp in seconds.
+	OldestLedgerCloseTime int64  `json:"oldestLedgerCloseTime,string"`
 	LedgerRetentionWindow uint32 `json:"ledgerRetentionWindow"`
 }

--- a/protocols/rpc/get_health.go
+++ b/protocols/rpc/get_health.go
@@ -5,8 +5,10 @@ const GetHealthMethodName = "getHealth"
 type GetHealthRequest struct{}
 
 type GetHealthResponse struct {
-	Status                string `json:"status"`
-	LatestLedger          uint32 `json:"latestLedger"`
+	Status       string `json:"status"`
+	LatestLedger uint32 `json:"latestLedger"`
+	// LatestLedgerCloseTime is the time the latest ledger closed at, as a unix timestamp in seconds.
+	LatestLedgerCloseTime int64  `json:"latestLedgerCloseTime"`
 	OldestLedger          uint32 `json:"oldestLedger"`
 	LedgerRetentionWindow uint32 `json:"ledgerRetentionWindow"`
 }


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex. `services/friendbot`, or `all` or `doc` if the changes are broad or impact many packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes. (N/A — this is a data-only struct field; behavior is exercised in stellar/stellar-rpc.)
* [x] I've updated any docs affected by this change (godoc on the new field).

### Release planning

* [x] I've reviewed the changes in this PR and updated the relevant `CHANGELOG.md`.
* [x] I've decided this is a non-breaking, additive change (minor), targeted at `main`.
</details>

### What

Adds a `LatestLedgerCloseTime` field (unix timestamp, in seconds) to `protocols/rpc.GetHealthResponse`.

### Why

The RPC `getHealth` method already returns `latestLedger`, but not the time at which that ledger closed. Consumers that want to assess ledger freshness from the lightweight health endpoint currently have to additionally call `getLatestLedger`, which always returns the full `headerXdr` + `metadataXdr` of the ledger (multiple MB on active ledgers) — far too heavy for a health/monitoring probe.

The close time is the natural companion to `latestLedger`. Naming and format mirror the existing top-level `latestLedgerCloseTime` field already present in `GetLedgersResponse` (plain `int64` unix seconds).

Server-side population is added in a follow-up PR in stellar/stellar-rpc.

### Known limitations

N/A — additive, backward-compatible field (existing clients ignore the new field).
