### PR TITLE
ingest/ledgerbackend: Update captive-core-pubnet.cfg: swap SP with Obsrvr

### DIFF
--- a/ingest/ledgerbackend/configs/captive-core-pubnet.cfg
+++ b/ingest/ledgerbackend/configs/captive-core-pubnet.cfg
@@ -18,7 +18,7 @@ HOME_DOMAIN="www.franklintempleton.com"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
-HOME_DOMAIN="satoshipay"
+HOME_DOMAIN="stellar.withobsrvr.com"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
@@ -97,25 +97,25 @@ HISTORY="curl -sf https://stellar-history-usw.franklintempleton.com/azuswshf401/
 HOME_DOMAIN="www.franklintempleton.com"
 
 [[VALIDATORS]]
-NAME="satoshipay_de"
-PUBLIC_KEY="GC5SXLNAM3C4NMGK2PXK4R34B5GNZ47FYQ24ZIBFDFOCU6D4KBN4POAE"
-ADDRESS="stellar-de-fra.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-de-fra.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay"
+NAME="OBSRVR Validator 1"
+PUBLIC_KEY="GDRCZ4IPJR7V3HK4GR45CRTE72SDAOZUF2TDBQ5E5IGWC4KM5TSKU2LS"
+ADDRESS="core-live-1.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-1.nodeswithobsrvr.co/obsrvr-core-1/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
 
 [[VALIDATORS]]
-NAME="satoshipay_sg"
-PUBLIC_KEY="GBJQUIXUO4XSNPAUT6ODLZUJRV2NPXYASKUBY4G5MYP3M47PCVI55MNT"
-ADDRESS="stellar-sg-sin.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-sg-sin.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay"
+NAME="OBSRVR Validator 2"
+PUBLIC_KEY="GA2PU4UGMLSFUXGZATHPTDXXX7FOHBAQC57RSJCQUN72WFKTD6CEPQSF"
+ADDRESS="core-live-2.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-2.nodeswithobsrvr.co/obsrvr-core-2/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
 
 [[VALIDATORS]]
-NAME="satoshipay_us"
-PUBLIC_KEY="GAK6Z5UVGUVSEK6PEOCAYJISTT5EJBB34PN3NOLEQG2SUKXRVV2F6HZY"
-ADDRESS="stellar-us-iowa.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-us-iowa.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay"
+NAME="OBSRVR Validator 3"
+PUBLIC_KEY="GACM6GIRMLXBBZIYJXBDTAEYZ2GJP3JJP5G5K4WDPBS6QFHPJNK6S2FB"
+ADDRESS="core-live-3.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-3.nodeswithobsrvr.co/obsrvr-core-3/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
 
 [[VALIDATORS]]
 NAME = "Gamma Node Validator"


### PR DESCRIPTION
This PR replaces SatoshiPay with Obsrvr in the bundled `captive-core-pubnet.cfg` to match the current network. A similar change was merged in stellar/packages#223.