### PR TITLE
protocols/rpc: Add getEvents v2 wire types and request validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Official project releases may be found here: https://github.com/stellar/go-stell
 
 ### New Features
 * protocols/rpc: Add `LatestLedgerCloseTime` and `OldestLedgerCloseTime` to `GetHealthResponse`, exposing the latest and oldest ledgers' close times (unix seconds) on the `getHealth` response ([#5958](https://github.com/stellar/go-stellar-sdk/pull/5958))
+* protocols/rpc: Add getEvents v2 wire types and request validation (`GetEventsV2Request`/`GetEventsV2Response`, `EventFilterV2`, scan statuses, typed `error.data` payloads), transcribed from the [accepted proposal](https://github.com/orgs/stellar/discussions/1872) ([#5971](https://github.com/stellar/go-stellar-sdk/pull/5971))
 
 ## [0.7.0]
 

--- a/protocols/rpc/get_events_v2.go
+++ b/protocols/rpc/get_events_v2.go
@@ -119,16 +119,17 @@ var jsonNull = []byte("null")
 // cursor query (cursor). The two are mutually exclusive; limit and xdrFormat
 // apply to both.
 type GetEventsV2Request struct {
-	MinLedger      uint32          `json:"minLedger,omitempty"`
-	MaxLedger      uint32          `json:"maxLedger,omitempty"`
-	Order          string          `json:"order,omitempty"`
+	MinLedger uint32 `json:"minLedger,omitempty"`
+	MaxLedger uint32 `json:"maxLedger,omitempty"`
+	Order     string `json:"order,omitempty"`
+	// Filters: a JSON null decodes like an omitted member (match all
+	// events), consistent with null topics.
 	Filters        []EventFilterV2 `json:"filters,omitempty"`
 	XDRInputFormat string          `json:"xdrInputFormat,omitempty"`
 	Cursor         string          `json:"cursor,omitempty"`
-	// Limit 0 means unset (the server applies its default). The proposal
-	// rejects limit < 1, but an explicit limit of 0 is indistinguishable
-	// from an omitted one here and is treated as unset.
-	Limit  uint   `json:"limit,omitempty"`
+	// Limit is nil when omitted; the server applies its default. An
+	// explicit limit outside [1, MaxLimitV2] is rejected.
+	Limit  *uint  `json:"limit,omitempty"`
 	Format string `json:"xdrFormat,omitempty"`
 }
 
@@ -204,7 +205,7 @@ func (r *GetEventsV2Request) validShape() error {
 }
 
 func (r *GetEventsV2Request) validLimit() error {
-	if r.Limit > MaxLimitV2 {
+	if r.Limit != nil && (*r.Limit < 1 || *r.Limit > MaxLimitV2) {
 		return invalidParamsf("limit must be between 1 and %d", MaxLimitV2)
 	}
 	return nil

--- a/protocols/rpc/get_events_v2.go
+++ b/protocols/rpc/get_events_v2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -25,7 +26,7 @@ const (
 	// DefaultMaxFiltersV2 is the default cap on the filters list per
 	// request; providers may configure their own, passed to Valid as
 	// maxFilters.
-	DefaultMaxFiltersV2 = 256
+	DefaultMaxFiltersV2 MaxFilters = 256
 
 	// DefaultTermBudgetV2 is the default cap on distinct index terms per
 	// query. Counting terms needs the canonical form of json-format topics,
@@ -64,6 +65,9 @@ const (
 
 // InvalidParamsErrorData is error.data for invalid_params. TermsUsed and
 // TermBudget are present only when the query exceeds the term budget.
+// Unlike the sibling error-data types, Reason is not injected at marshal
+// time: the server fills this struct directly for both plain validation
+// failures (via invalidParamsf) and term-budget rejections.
 type InvalidParamsErrorData struct {
 	Reason     string `json:"reason"`
 	TermsUsed  uint32 `json:"termsUsed,omitempty"`
@@ -78,11 +82,25 @@ type LedgerOutOfRangeErrorData struct {
 	LatestLedger  uint32 `json:"latestLedger"`
 }
 
+// MarshalJSON fills Reason so a wrong reason is unrepresentable on the wire.
+func (d LedgerOutOfRangeErrorData) MarshalJSON() ([]byte, error) {
+	type data LedgerOutOfRangeErrorData
+	d.Reason = ErrorReasonLedgerOutOfRange
+	return json.Marshal(data(d))
+}
+
 // CursorMalformedErrorData is error.data for cursor_malformed.
 type CursorMalformedErrorData struct {
 	Reason       string `json:"reason"`
 	OldestLedger uint32 `json:"oldestLedger"`
 	LatestLedger uint32 `json:"latestLedger"`
+}
+
+// MarshalJSON fills Reason so a wrong reason is unrepresentable on the wire.
+func (d CursorMalformedErrorData) MarshalJSON() ([]byte, error) {
+	type data CursorMalformedErrorData
+	d.Reason = ErrorReasonCursorMalformed
+	return json.Marshal(data(d))
 }
 
 // EventFilterV2 is one filter in a range query. Fields within a filter are
@@ -113,6 +131,20 @@ func (f *EventFilterV2) Topics() [MaxTopicCount]json.RawMessage {
 }
 
 var jsonNull = []byte("null")
+
+// TopicScVal encodes an ScVal view as a topic value for a base64-format
+// request: a JSON string holding the base64 of the view's XDR bytes. It
+// rejects views that do not hold exactly one well-formed ScVal.
+func TopicScVal(v xdr.ScValView) (json.RawMessage, error) {
+	raw, err := v.Raw()
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) != len(v) {
+		return nil, fmt.Errorf("%d trailing bytes after ScVal", len(v)-len(raw))
+	}
+	return json.Marshal(v) // []byte marshals as std base64
+}
 
 // GetEventsV2Request is the union of two request shapes: a
 // range query (minLedger, maxLedger, order, filters, xdrInputFormat) or a
@@ -150,45 +182,52 @@ func invalidParamsf(format string, args ...any) error {
 	}
 }
 
-// Valid checks the request against the proposal's parameter rules and
-// returns the first violation as an *InvalidParamsError. maxFilters is the
-// provider-configured cap on the filters list (DefaultMaxFiltersV2 unless
-// the provider sets its own).
-func (r *GetEventsV2Request) Valid(maxFilters uint) error {
-	if err := r.validFormats(); err != nil {
-		return err
-	}
-	if err := r.validShape(); err != nil {
-		return err
-	}
-	if err := r.validLimit(); err != nil {
-		return err
-	}
-	return r.validFilters(maxFilters)
-}
+// MaxFilters is the provider-configured cap on the filters list. A defined
+// type so a v1-shaped call site (Valid(maxLimit)) cannot compile with the
+// wrong cap.
+type MaxFilters uint
 
-func (r *GetEventsV2Request) validFormats() error {
+// Valid checks the request against the proposal's parameter rules and
+// returns the first violation as an *InvalidParamsError. The request is a
+// cursor query when cursor is set and a range query otherwise; xdrFormat
+// and limit apply to both shapes. maxFilters must be at least 1
+// (DefaultMaxFiltersV2 unless the provider configures its own).
+func (r *GetEventsV2Request) Valid(maxFilters MaxFilters) error {
 	switch r.Format {
 	case "", FormatBase64, FormatJSON:
 	default:
 		return invalidParamsf("xdrFormat must be %q or %q", FormatBase64, FormatJSON)
 	}
-	switch r.XDRInputFormat {
-	case "", FormatBase64, FormatJSON:
-	default:
-		return invalidParamsf("xdrInputFormat must be %q or %q", FormatBase64, FormatJSON)
+	if err := r.validLimit(); err != nil {
+		return err
+	}
+	if r.Cursor != "" {
+		return r.validCursorQuery()
+	}
+	return r.validRangeQuery(maxFilters)
+}
+
+func (r *GetEventsV2Request) validLimit() error {
+	if r.Limit != nil && (*r.Limit < 1 || *r.Limit > MaxLimitV2) {
+		return invalidParamsf("limit must be between 1 and %d", MaxLimitV2)
 	}
 	return nil
 }
 
-func (r *GetEventsV2Request) validShape() error {
-	if r.Cursor != "" {
-		if r.MinLedger != 0 || r.MaxLedger != 0 || r.Order != "" ||
-			r.Filters != nil || r.XDRInputFormat != "" {
-			return invalidParamsf(
-				"cursor is mutually exclusive with minLedger, maxLedger, order, filters, xdrInputFormat")
-		}
-		return nil
+func (r *GetEventsV2Request) validCursorQuery() error {
+	if r.MinLedger != 0 || r.MaxLedger != 0 || r.Order != "" ||
+		r.Filters != nil || r.XDRInputFormat != "" {
+		return invalidParamsf(
+			"cursor is mutually exclusive with minLedger, maxLedger, order, filters, xdrInputFormat")
+	}
+	return nil
+}
+
+func (r *GetEventsV2Request) validRangeQuery(maxFilters MaxFilters) error {
+	switch r.XDRInputFormat {
+	case "", FormatBase64, FormatJSON:
+	default:
+		return invalidParamsf("xdrInputFormat must be %q or %q", FormatBase64, FormatJSON)
 	}
 	switch r.Order {
 	case "", OrderAscending, OrderDescending:
@@ -201,21 +240,7 @@ func (r *GetEventsV2Request) validShape() error {
 	if r.MinLedger != 0 && r.MaxLedger != 0 && r.MinLedger > r.MaxLedger {
 		return invalidParamsf("minLedger must be <= maxLedger")
 	}
-	return nil
-}
-
-func (r *GetEventsV2Request) validLimit() error {
-	if r.Limit != nil && (*r.Limit < 1 || *r.Limit > MaxLimitV2) {
-		return invalidParamsf("limit must be between 1 and %d", MaxLimitV2)
-	}
-	return nil
-}
-
-func (r *GetEventsV2Request) validFilters(maxFilters uint) error {
-	if r.Cursor != "" {
-		return nil // mutual exclusion is validShape's finding
-	}
-	if r.Filters != nil && (len(r.Filters) == 0 || uint(len(r.Filters)) > maxFilters) {
+	if r.Filters != nil && (len(r.Filters) == 0 || len(r.Filters) > int(maxFilters)) {
 		return invalidParamsf("filters must contain 1 to %d filters", maxFilters)
 	}
 	for i := range r.Filters {
@@ -228,13 +253,8 @@ func (r *GetEventsV2Request) validFilters(maxFilters uint) error {
 
 func (f *EventFilterV2) valid(index int, xdrInputFormat string) error {
 	topics := f.Topics()
-	hasTopic := false
-	for _, topic := range topics {
-		if topic != nil {
-			hasTopic = true
-			break
-		}
-	}
+	hasTopic := slices.ContainsFunc(topics[:],
+		func(t json.RawMessage) bool { return t != nil })
 	if f.ContractID == "" && f.EventType == "" && !hasTopic {
 		return invalidParamsf(
 			"filters[%d]: filter must specify type, contractId, or at least one topic position", index)
@@ -246,13 +266,16 @@ func (f *EventFilterV2) valid(index int, xdrInputFormat string) error {
 			index, EventTypeContract, EventTypeSystem)
 	}
 	if f.ContractID != "" {
-		if _, err := strkey.Decode(strkey.VersionByteContract, f.ContractID); err != nil {
+		// strkey.Decode checks version byte and checksum but not payload
+		// length; a contract id is exactly a 32-byte hash.
+		raw, err := strkey.Decode(strkey.VersionByteContract, f.ContractID)
+		if err != nil || len(raw) != 32 {
 			return invalidParamsf("filters[%d]: contractId is invalid", index)
 		}
 	}
 	// The base64 form is decodable here; the JSON form needs the server's
 	// XDR-JSON converter and is validated there. An invalid format is
-	// validFormats's finding, so no topic error is derived from it.
+	// validRangeQuery's finding, so no topic error is derived from it.
 	if xdrInputFormat != "" && xdrInputFormat != FormatBase64 {
 		return nil
 	}
@@ -260,12 +283,14 @@ func (f *EventFilterV2) valid(index int, xdrInputFormat string) error {
 		if topic == nil {
 			continue
 		}
-		var b64 string
-		if err := json.Unmarshal(topic, &b64); err != nil {
+		// Unmarshalling into a view base64-decodes and validates without
+		// building an ScVal tree; the length check rejects trailing bytes.
+		var view xdr.ScValView
+		if err := json.Unmarshal(topic, &view); err != nil {
 			return invalidParamsf("filters[%d].topic%d is not valid base64-encoded XDR", index, pos)
 		}
-		var scVal xdr.ScVal
-		if err := xdr.SafeUnmarshalBase64(b64, &scVal); err != nil {
+		raw, err := view.Raw()
+		if err != nil || len(raw) != len(view) {
 			return invalidParamsf("filters[%d].topic%d is not valid base64-encoded XDR", index, pos)
 		}
 	}

--- a/protocols/rpc/get_events_v2.go
+++ b/protocols/rpc/get_events_v2.go
@@ -1,0 +1,306 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// The getEvents v2 wire types, transcribed from the accepted proposal
+// (https://github.com/orgs/stellar/discussions/1872).
+
+const (
+	// GetEventsV2MethodName is the working method name.
+	GetEventsV2MethodName = "getEventsV2"
+
+	// MaxLimitV2 caps the limit parameter (max events per response). The
+	// proposal fixes it, unlike the provider-configurable defaults below.
+	// (The server's default when limit is unset, 100, is a separate number
+	// this package never applies.)
+	MaxLimitV2 = 1000
+
+	// DefaultMaxFiltersV2 is the default cap on the filters list per
+	// request; providers may configure their own, passed to Valid as
+	// maxFilters.
+	DefaultMaxFiltersV2 = 256
+
+	// DefaultTermBudgetV2 is the default cap on distinct index terms per
+	// query. Counting terms needs the canonical form of json-format topics,
+	// which only the server's XDR-JSON converter can produce, hence the
+	// server enforces it (reporting via InvalidParamsErrorData's TermsUsed
+	// and TermBudget).
+	DefaultTermBudgetV2 = 15
+)
+
+const (
+	OrderAscending  = "asc"
+	OrderDescending = "desc"
+)
+
+// Scan statuses reported by GetEventsV2Response.ScanStatus.
+const (
+	// ScanStatusHasMore: more to scan on this node right now.
+	ScanStatusHasMore = "HAS_MORE"
+	// ScanStatusWaitingForLedgers: the query needs ledgers this node does not
+	// have yet.
+	ScanStatusWaitingForLedgers = "WAITING_FOR_LEDGERS"
+	// ScanStatusOldestReached: the query wants history older than this node
+	// holds.
+	ScanStatusOldestReached = "OLDEST_REACHED"
+	// ScanStatusComplete: the query is finished and will never return more;
+	// the response carries no cursor.
+	ScanStatusComplete = "COMPLETE"
+)
+
+// Machine-readable error reasons carried in error.data.reason.
+const (
+	ErrorReasonInvalidParams    = "invalid_params"
+	ErrorReasonLedgerOutOfRange = "ledger_out_of_range"
+	ErrorReasonCursorMalformed  = "cursor_malformed"
+)
+
+// InvalidParamsErrorData is error.data for invalid_params. TermsUsed and
+// TermBudget are present only when the query exceeds the term budget.
+type InvalidParamsErrorData struct {
+	Reason     string `json:"reason"`
+	TermsUsed  uint32 `json:"termsUsed,omitempty"`
+	TermBudget uint32 `json:"termBudget,omitempty"`
+}
+
+// LedgerOutOfRangeErrorData is error.data for ledger_out_of_range.
+type LedgerOutOfRangeErrorData struct {
+	Reason        string `json:"reason"`
+	MissingLedger uint32 `json:"missingLedger"`
+	OldestLedger  uint32 `json:"oldestLedger"`
+	LatestLedger  uint32 `json:"latestLedger"`
+}
+
+// CursorMalformedErrorData is error.data for cursor_malformed.
+type CursorMalformedErrorData struct {
+	Reason       string `json:"reason"`
+	OldestLedger uint32 `json:"oldestLedger"`
+	LatestLedger uint32 `json:"latestLedger"`
+}
+
+// EventFilterV2 is one filter in a range query. Fields within a filter are
+// AND-ed; filters in the list are OR-ed. At least one field must be set.
+// Topic values are ScVals encoded per the request's xdrInputFormat (base64
+// XDR strings, or JSON objects); an omitted topic position matches any
+// value.
+type EventFilterV2 struct {
+	ContractID string          `json:"contractId,omitempty"`
+	EventType  string          `json:"type,omitempty"`
+	Topic0     json.RawMessage `json:"topic0,omitempty"`
+	Topic1     json.RawMessage `json:"topic1,omitempty"`
+	Topic2     json.RawMessage `json:"topic2,omitempty"`
+	Topic3     json.RawMessage `json:"topic3,omitempty"`
+}
+
+// Topics returns the positional topic values, index i holding topicI. An
+// explicit JSON null is returned as nil: null means the same as omitted
+// (matches any value), and RawMessage stores it as the non-nil bytes "null".
+func (f *EventFilterV2) Topics() [MaxTopicCount]json.RawMessage {
+	topics := [MaxTopicCount]json.RawMessage{f.Topic0, f.Topic1, f.Topic2, f.Topic3}
+	for i, topic := range topics {
+		if bytes.Equal(topic, jsonNull) {
+			topics[i] = nil
+		}
+	}
+	return topics
+}
+
+var jsonNull = []byte("null")
+
+// GetEventsV2Request is the union of two request shapes: a
+// range query (minLedger, maxLedger, order, filters, xdrInputFormat) or a
+// cursor query (cursor). The two are mutually exclusive; limit and xdrFormat
+// apply to both.
+type GetEventsV2Request struct {
+	MinLedger      uint32          `json:"minLedger,omitempty"`
+	MaxLedger      uint32          `json:"maxLedger,omitempty"`
+	Order          string          `json:"order,omitempty"`
+	Filters        []EventFilterV2 `json:"filters,omitempty"`
+	XDRInputFormat string          `json:"xdrInputFormat,omitempty"`
+	Cursor         string          `json:"cursor,omitempty"`
+	// Limit 0 means unset (the server applies its default). The proposal
+	// rejects limit < 1, but an explicit limit of 0 is indistinguishable
+	// from an omitted one here and is treated as unset.
+	Limit  uint   `json:"limit,omitempty"`
+	Format string `json:"xdrFormat,omitempty"`
+}
+
+// InvalidParamsError is a request validation failure: the proposal's
+// invalid_params message plus the error.data payload to return with it. The
+// server serializes Message and Data into the JSON-RPC error.
+type InvalidParamsError struct {
+	Message string
+	Data    InvalidParamsErrorData
+}
+
+func (e *InvalidParamsError) Error() string { return e.Message }
+
+func invalidParamsf(format string, args ...any) error {
+	return &InvalidParamsError{
+		Message: fmt.Sprintf(format, args...),
+		Data:    InvalidParamsErrorData{Reason: ErrorReasonInvalidParams},
+	}
+}
+
+// Valid checks the request against the proposal's parameter rules and
+// returns the first violation as an *InvalidParamsError. maxFilters is the
+// provider-configured cap on the filters list (DefaultMaxFiltersV2 unless
+// the provider sets its own).
+func (r *GetEventsV2Request) Valid(maxFilters uint) error {
+	if err := r.validFormats(); err != nil {
+		return err
+	}
+	if err := r.validShape(); err != nil {
+		return err
+	}
+	if err := r.validLimit(); err != nil {
+		return err
+	}
+	return r.validFilters(maxFilters)
+}
+
+func (r *GetEventsV2Request) validFormats() error {
+	switch r.Format {
+	case "", FormatBase64, FormatJSON:
+	default:
+		return invalidParamsf("xdrFormat must be %q or %q", FormatBase64, FormatJSON)
+	}
+	switch r.XDRInputFormat {
+	case "", FormatBase64, FormatJSON:
+	default:
+		return invalidParamsf("xdrInputFormat must be %q or %q", FormatBase64, FormatJSON)
+	}
+	return nil
+}
+
+func (r *GetEventsV2Request) validShape() error {
+	if r.Cursor != "" {
+		if r.MinLedger != 0 || r.MaxLedger != 0 || r.Order != "" ||
+			r.Filters != nil || r.XDRInputFormat != "" {
+			return invalidParamsf(
+				"cursor is mutually exclusive with minLedger, maxLedger, order, filters, xdrInputFormat")
+		}
+		return nil
+	}
+	switch r.Order {
+	case "", OrderAscending, OrderDescending:
+	default:
+		return invalidParamsf("order must be %q or %q", OrderAscending, OrderDescending)
+	}
+	if r.Order != OrderDescending && r.MinLedger == 0 {
+		return invalidParamsf("minLedger is required for ascending order")
+	}
+	if r.MinLedger != 0 && r.MaxLedger != 0 && r.MinLedger > r.MaxLedger {
+		return invalidParamsf("minLedger must be <= maxLedger")
+	}
+	return nil
+}
+
+func (r *GetEventsV2Request) validLimit() error {
+	if r.Limit > MaxLimitV2 {
+		return invalidParamsf("limit must be between 1 and %d", MaxLimitV2)
+	}
+	return nil
+}
+
+func (r *GetEventsV2Request) validFilters(maxFilters uint) error {
+	if r.Cursor != "" {
+		return nil // mutual exclusion is validShape's finding
+	}
+	if r.Filters != nil && (len(r.Filters) == 0 || uint(len(r.Filters)) > maxFilters) {
+		return invalidParamsf("filters must contain 1 to %d filters", maxFilters)
+	}
+	for i := range r.Filters {
+		if err := r.Filters[i].valid(i, r.XDRInputFormat); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *EventFilterV2) valid(index int, xdrInputFormat string) error {
+	topics := f.Topics()
+	hasTopic := false
+	for _, topic := range topics {
+		if topic != nil {
+			hasTopic = true
+			break
+		}
+	}
+	if f.ContractID == "" && f.EventType == "" && !hasTopic {
+		return invalidParamsf(
+			"filters[%d]: filter must specify type, contractId, or at least one topic position", index)
+	}
+	switch f.EventType {
+	case "", EventTypeContract, EventTypeSystem:
+	default:
+		return invalidParamsf("filters[%d]: type must be %q or %q",
+			index, EventTypeContract, EventTypeSystem)
+	}
+	if f.ContractID != "" {
+		if _, err := strkey.Decode(strkey.VersionByteContract, f.ContractID); err != nil {
+			return invalidParamsf("filters[%d]: contractId is invalid", index)
+		}
+	}
+	// The base64 form is decodable here; the JSON form needs the server's
+	// XDR-JSON converter and is validated there. An invalid format is
+	// validFormats's finding, so no topic error is derived from it.
+	if xdrInputFormat != "" && xdrInputFormat != FormatBase64 {
+		return nil
+	}
+	for pos, topic := range topics {
+		if topic == nil {
+			continue
+		}
+		var b64 string
+		if err := json.Unmarshal(topic, &b64); err != nil {
+			return invalidParamsf("filters[%d].topic%d is not valid base64-encoded XDR", index, pos)
+		}
+		var scVal xdr.ScVal
+		if err := xdr.SafeUnmarshalBase64(b64, &scVal); err != nil {
+			return invalidParamsf("filters[%d].topic%d is not valid base64-encoded XDR", index, pos)
+		}
+	}
+	return nil
+}
+
+// EventInfoV2 is one event in a v2 response. Exactly one of TopicXDR and
+// TopicJSON, and one of ValueXDR and ValueJSON, is present, per the
+// request's xdrFormat.
+type EventInfoV2 struct {
+	EventType       string `json:"type"`
+	Ledger          int32  `json:"ledger"`
+	LedgerClosedAt  string `json:"ledgerClosedAt"`
+	ContractID      string `json:"contractId"`
+	ID              string `json:"id"`
+	OpIndex         uint32 `json:"operationIndex"`
+	TxIndex         uint32 `json:"transactionIndex"`
+	TransactionHash string `json:"txHash"`
+
+	// TopicXDR is a base64-encoded list of ScVals
+	TopicXDR  []string          `json:"topic,omitempty"`
+	TopicJSON []json.RawMessage `json:"topicJson,omitempty"`
+
+	// ValueXDR is a base64-encoded ScVal
+	ValueXDR  string          `json:"value,omitempty"`
+	ValueJSON json.RawMessage `json:"valueJson,omitempty"`
+}
+
+// GetEventsV2Response is the v2 response. Cursor is present on every
+// response except when ScanStatus is COMPLETE: an absent cursor means the
+// query is finished.
+type GetEventsV2Response struct {
+	Events        []EventInfoV2 `json:"events"`
+	Cursor        string        `json:"cursor,omitempty"`
+	ScanStatus    string        `json:"scanStatus"`
+	ScannedLedger uint32        `json:"scannedLedger"`
+	OldestLedger  uint32        `json:"oldestLedger"`
+	LatestLedger  uint32        `json:"latestLedger"`
+}

--- a/protocols/rpc/get_events_v2_test.go
+++ b/protocols/rpc/get_events_v2_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -22,14 +24,26 @@ func testContractIDV2(t *testing.T) string {
 	return id
 }
 
+func shortContractIDV2(t *testing.T) string {
+	t.Helper()
+	id, err := strkey.Encode(strkey.VersionByteContract, bytes.Repeat([]byte{1}, 31))
+	require.NoError(t, err)
+	return id
+}
+
 func testTopicB64V2(t *testing.T) json.RawMessage {
 	t.Helper()
 	sym := xdr.ScSymbol("transfer")
-	b64, err := xdr.MarshalBase64(xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym})
+	bin, err := xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym}.MarshalBinary()
 	require.NoError(t, err)
-	raw, err := json.Marshal(b64)
+	raw, err := TopicScVal(xdr.ScValView(bin))
 	require.NoError(t, err)
 	return raw
+}
+
+func TestTopicScValRejectsMalformed(t *testing.T) {
+	_, err := TopicScVal(xdr.ScValView([]byte{0xff}))
+	assert.Error(t, err)
 }
 
 const (
@@ -212,7 +226,25 @@ func TestGetEventsV2RequestValidCursor(t *testing.T) {
 			request: GetEventsV2Request{Cursor: testOpaqueCursor, XDRInputFormat: FormatBase64},
 			wantErr: errMutuallyExclusiveV2,
 		},
+		{
+			// mutual exclusion is the truer complaint: xdrInputFormat is not
+			// a legal cursor-query field at all, whatever its value.
+			name:    "cursor with invalid xdrInputFormat",
+			request: GetEventsV2Request{Cursor: testOpaqueCursor, XDRInputFormat: "hex"},
+			wantErr: errMutuallyExclusiveV2,
+		},
 	})
+}
+
+// Explicit "filters": null on the wire decodes like an omitted member.
+func TestGetEventsV2FiltersNullJSON(t *testing.T) {
+	var cursorReq GetEventsV2Request
+	require.NoError(t, json.Unmarshal([]byte(`{"cursor":"x","filters":null}`), &cursorReq))
+	assert.NoError(t, cursorReq.Valid(DefaultMaxFiltersV2))
+
+	var rangeReq GetEventsV2Request
+	require.NoError(t, json.Unmarshal([]byte(`{"minLedger":1,"filters":null}`), &rangeReq))
+	assert.NoError(t, rangeReq.Valid(DefaultMaxFiltersV2))
 }
 
 // typeOnlyFiltersV2 builds n filters that each pass the at-least-one-field
@@ -234,12 +266,12 @@ func TestGetEventsV2RequestValidFilters(t *testing.T) {
 		},
 		{
 			name:    "too many filters",
-			request: GetEventsV2Request{MinLedger: 1, Filters: typeOnlyFiltersV2(DefaultMaxFiltersV2 + 1)},
+			request: GetEventsV2Request{MinLedger: 1, Filters: typeOnlyFiltersV2(int(DefaultMaxFiltersV2) + 1)},
 			wantErr: fmt.Sprintf("filters must contain 1 to %d filters", DefaultMaxFiltersV2),
 		},
 		{
 			name:    "exactly max filters accepted",
-			request: GetEventsV2Request{MinLedger: 1, Filters: typeOnlyFiltersV2(DefaultMaxFiltersV2)},
+			request: GetEventsV2Request{MinLedger: 1, Filters: typeOnlyFiltersV2(int(DefaultMaxFiltersV2))},
 		},
 		{
 			name:    "system event type accepted",
@@ -261,6 +293,14 @@ func TestGetEventsV2RequestValidFilters(t *testing.T) {
 			name: "invalid contract ID",
 			request: GetEventsV2Request{
 				MinLedger: 1, Filters: []EventFilterV2{{ContractID: "not-a-contract"}},
+			},
+			wantErr: "filters[0]: contractId is invalid",
+		},
+		{
+			// checksum-valid strkey with a payload that is not 32 bytes
+			name: "contract ID with short payload",
+			request: GetEventsV2Request{
+				MinLedger: 1, Filters: []EventFilterV2{{ContractID: shortContractIDV2(t)}},
 			},
 			wantErr: "filters[0]: contractId is invalid",
 		},
@@ -407,7 +447,7 @@ func TestGetEventsV2RequestJSONRoundTrip(t *testing.T) {
 		require.NoError(t, err)
 		var keys map[string]json.RawMessage
 		require.NoError(t, json.Unmarshal(raw, &keys))
-		assert.Equal(t, []string{"topic1"}, mapKeys(keys))
+		assert.Equal(t, []string{"topic1"}, slices.Collect(maps.Keys(keys)))
 	})
 }
 
@@ -473,17 +513,16 @@ func TestGetEventsV2ResponseJSON(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, `{"reason":"invalid_params"}`, string(raw))
 
+		// Reason is deliberately unset: MarshalJSON injects it.
 		raw, err = json.Marshal(LedgerOutOfRangeErrorData{
-			Reason: ErrorReasonLedgerOutOfRange, MissingLedger: 7, OldestLedger: 1, LatestLedger: 9,
+			MissingLedger: 7, OldestLedger: 1, LatestLedger: 9,
 		})
 		require.NoError(t, err)
 		assert.Equal(t,
 			`{"reason":"ledger_out_of_range","missingLedger":7,"oldestLedger":1,"latestLedger":9}`,
 			string(raw))
 
-		raw, err = json.Marshal(CursorMalformedErrorData{
-			Reason: ErrorReasonCursorMalformed, OldestLedger: 1, LatestLedger: 9,
-		})
+		raw, err = json.Marshal(CursorMalformedErrorData{OldestLedger: 1, LatestLedger: 9})
 		require.NoError(t, err)
 		assert.Equal(t,
 			`{"reason":"cursor_malformed","oldestLedger":1,"latestLedger":9}`,
@@ -513,14 +552,6 @@ func fieldSpecSet(t *testing.T, typ reflect.Type) map[string]string {
 		specs[strings.Split(tag, ",")[0]] = tag + " " + field.Type.String()
 	}
 	return specs
-}
-
-func mapKeys(m map[string]json.RawMessage) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }
 
 func mustJSONV2(t *testing.T, v any) json.RawMessage {

--- a/protocols/rpc/get_events_v2_test.go
+++ b/protocols/rpc/get_events_v2_test.go
@@ -39,6 +39,8 @@ const (
 	errEmptyFilterV2       = "filters[0]: filter must specify type, contractId, or at least one topic position"
 )
 
+func limitV2(v uint) *uint { return &v }
+
 type requestValidCaseV2 struct {
 	name    string
 	request GetEventsV2Request
@@ -54,7 +56,7 @@ func runRequestValidCasesV2(t *testing.T, cases []requestValidCaseV2) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.EqualError(t, err, tc.wantErr)
 				var invalidParams *InvalidParamsError
 				require.ErrorAs(t, err, &invalidParams)
 				assert.Equal(t, ErrorReasonInvalidParams, invalidParams.Data.Reason)
@@ -95,7 +97,7 @@ func TestGetEventsV2RequestValidCustomMaxFilters(t *testing.T) {
 	// does not.
 	assert.Error(t,
 		(&GetEventsV2Request{MinLedger: 1, Filters: typeOnlyFiltersV2(1)}).Valid(0))
-	assert.NoError(t, (&GetEventsV2Request{MinLedger: 1, Limit: 1}).Valid(0))
+	assert.NoError(t, (&GetEventsV2Request{MinLedger: 1, Limit: limitV2(1)}).Valid(0))
 }
 
 func TestGetEventsV2RequestValid(t *testing.T) {
@@ -118,7 +120,7 @@ func TestGetEventsV2RequestValid(t *testing.T) {
 				Filters: []EventFilterV2{
 					{ContractID: contractID, EventType: EventTypeContract, Topic0: topic},
 				},
-				XDRInputFormat: FormatBase64, Limit: 10, Format: FormatJSON,
+				XDRInputFormat: FormatBase64, Limit: limitV2(10), Format: FormatJSON,
 			},
 		},
 		{
@@ -147,7 +149,7 @@ func TestGetEventsV2RequestValid(t *testing.T) {
 		},
 		{
 			name:    "limit exactly at max accepted",
-			request: GetEventsV2Request{MinLedger: 1, Limit: MaxLimitV2},
+			request: GetEventsV2Request{MinLedger: 1, Limit: limitV2(MaxLimitV2)},
 		},
 		{
 			name:    "invalid order",
@@ -156,7 +158,12 @@ func TestGetEventsV2RequestValid(t *testing.T) {
 		},
 		{
 			name:    "limit over max",
-			request: GetEventsV2Request{MinLedger: 1, Limit: MaxLimitV2 + 1},
+			request: GetEventsV2Request{MinLedger: 1, Limit: limitV2(MaxLimitV2 + 1)},
+			wantErr: fmt.Sprintf("limit must be between 1 and %d", MaxLimitV2),
+		},
+		{
+			name:    "explicit zero limit rejected",
+			request: GetEventsV2Request{MinLedger: 1, Limit: limitV2(0)},
 			wantErr: fmt.Sprintf("limit must be between 1 and %d", MaxLimitV2),
 		},
 		{
@@ -176,7 +183,7 @@ func TestGetEventsV2RequestValidCursor(t *testing.T) {
 	runRequestValidCasesV2(t, []requestValidCaseV2{
 		{
 			name:    "cursor query",
-			request: GetEventsV2Request{Cursor: testOpaqueCursor, Limit: 100, Format: FormatBase64},
+			request: GetEventsV2Request{Cursor: testOpaqueCursor, Limit: limitV2(100), Format: FormatBase64},
 		},
 		{
 			name:    "cursor with minLedger",
@@ -360,7 +367,7 @@ func TestGetEventsV2RequestJSONRoundTrip(t *testing.T) {
 			Filters: []EventFilterV2{
 				{ContractID: contractID, EventType: EventTypeSystem, Topic0: topic, Topic3: topic},
 			},
-			XDRInputFormat: FormatBase64, Limit: 5, Format: FormatJSON,
+			XDRInputFormat: FormatBase64, Limit: limitV2(5), Format: FormatJSON,
 		}
 		raw, err := json.Marshal(req)
 		require.NoError(t, err)
@@ -378,7 +385,7 @@ func TestGetEventsV2RequestJSONRoundTrip(t *testing.T) {
 				{ContractID: contractID, EventType: EventTypeContract,
 					Topic0: topic, Topic1: topic, Topic2: topic, Topic3: topic},
 			},
-			XDRInputFormat: FormatBase64, Limit: 5, Format: FormatJSON,
+			XDRInputFormat: FormatBase64, Limit: limitV2(5), Format: FormatJSON,
 		})
 		require.NoError(t, err)
 		golden := `{"minLedger":1,"maxLedger":2,"order":"asc","filters":[` +
@@ -390,7 +397,7 @@ func TestGetEventsV2RequestJSONRoundTrip(t *testing.T) {
 	})
 
 	t.Run("cursor query omits range keys", func(t *testing.T) {
-		raw, err := json.Marshal(GetEventsV2Request{Cursor: "opaque", Limit: 10})
+		raw, err := json.Marshal(GetEventsV2Request{Cursor: "opaque", Limit: limitV2(10)})
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"cursor":"opaque","limit":10}`, string(raw))
 	})

--- a/protocols/rpc/get_events_v2_test.go
+++ b/protocols/rpc/get_events_v2_test.go
@@ -1,0 +1,524 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+func testContractIDV2(t *testing.T) string {
+	t.Helper()
+	id, err := strkey.Encode(strkey.VersionByteContract, bytes.Repeat([]byte{1}, 32))
+	require.NoError(t, err)
+	return id
+}
+
+func testTopicB64V2(t *testing.T) json.RawMessage {
+	t.Helper()
+	sym := xdr.ScSymbol("transfer")
+	b64, err := xdr.MarshalBase64(xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym})
+	require.NoError(t, err)
+	raw, err := json.Marshal(b64)
+	require.NoError(t, err)
+	return raw
+}
+
+const (
+	testOpaqueCursor       = "opaque"
+	testTopicXDRV2         = "AAAA"
+	errMutuallyExclusiveV2 = "cursor is mutually exclusive with minLedger, maxLedger, order, filters, xdrInputFormat"
+	errEmptyFilterV2       = "filters[0]: filter must specify type, contractId, or at least one topic position"
+)
+
+type requestValidCaseV2 struct {
+	name    string
+	request GetEventsV2Request
+	wantErr string // empty means valid
+}
+
+func runRequestValidCasesV2(t *testing.T, cases []requestValidCaseV2) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.request.Valid(DefaultMaxFiltersV2)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				var invalidParams *InvalidParamsError
+				require.ErrorAs(t, err, &invalidParams)
+				assert.Equal(t, ErrorReasonInvalidParams, invalidParams.Data.Reason)
+			}
+		})
+	}
+}
+
+// TestGetEventsV2Constants pins the wire values and spec caps as literals:
+// tests that use the constants on both sides pass a value change in
+// lockstep, these do not.
+func TestGetEventsV2Constants(t *testing.T) {
+	assert.EqualValues(t, 1000, MaxLimitV2)
+	assert.EqualValues(t, 256, DefaultMaxFiltersV2)
+	assert.EqualValues(t, 15, DefaultTermBudgetV2)
+	assert.Equal(t, "getEventsV2", GetEventsV2MethodName)
+	assert.Equal(t, "asc", OrderAscending)
+	assert.Equal(t, "desc", OrderDescending)
+	assert.Equal(t, "HAS_MORE", ScanStatusHasMore)
+	assert.Equal(t, "WAITING_FOR_LEDGERS", ScanStatusWaitingForLedgers)
+	assert.Equal(t, "OLDEST_REACHED", ScanStatusOldestReached)
+	assert.Equal(t, "COMPLETE", ScanStatusComplete)
+	assert.Equal(t, "invalid_params", ErrorReasonInvalidParams)
+	assert.Equal(t, "ledger_out_of_range", ErrorReasonLedgerOutOfRange)
+	assert.Equal(t, "cursor_malformed", ErrorReasonCursorMalformed)
+}
+
+// TestGetEventsV2RequestValidCustomMaxFilters proves Valid enforces the
+// caller's filter cap, not the package default.
+func TestGetEventsV2RequestValidCustomMaxFilters(t *testing.T) {
+	require.NoError(t,
+		(&GetEventsV2Request{MinLedger: 1, Filters: typeOnlyFiltersV2(2)}).Valid(2))
+	assert.EqualError(t,
+		(&GetEventsV2Request{MinLedger: 1, Filters: typeOnlyFiltersV2(3)}).Valid(2),
+		"filters must contain 1 to 2 filters")
+
+	// A zero cap rejects any request that sets filters and passes one that
+	// does not.
+	assert.Error(t,
+		(&GetEventsV2Request{MinLedger: 1, Filters: typeOnlyFiltersV2(1)}).Valid(0))
+	assert.NoError(t, (&GetEventsV2Request{MinLedger: 1, Limit: 1}).Valid(0))
+}
+
+func TestGetEventsV2RequestValid(t *testing.T) {
+	contractID := testContractIDV2(t)
+	topic := testTopicB64V2(t)
+
+	runRequestValidCasesV2(t, []requestValidCaseV2{
+		{
+			name:    "ascending with minLedger only",
+			request: GetEventsV2Request{MinLedger: 100},
+		},
+		{
+			name:    "descending with no bounds",
+			request: GetEventsV2Request{Order: OrderDescending},
+		},
+		{
+			name: "full range query",
+			request: GetEventsV2Request{
+				MinLedger: 1, MaxLedger: 100, Order: OrderAscending,
+				Filters: []EventFilterV2{
+					{ContractID: contractID, EventType: EventTypeContract, Topic0: topic},
+				},
+				XDRInputFormat: FormatBase64, Limit: 10, Format: FormatJSON,
+			},
+		},
+		{
+			name:    "ascending without minLedger",
+			request: GetEventsV2Request{Order: OrderAscending},
+			wantErr: "minLedger is required for ascending order",
+		},
+		{
+			name:    "default order without minLedger",
+			request: GetEventsV2Request{},
+			wantErr: "minLedger is required for ascending order",
+		},
+		{
+			name:    "minLedger greater than maxLedger",
+			request: GetEventsV2Request{MinLedger: 5, MaxLedger: 2},
+			wantErr: "minLedger must be <= maxLedger",
+		},
+		{
+			name:    "inverted bounds rejected for descending too",
+			request: GetEventsV2Request{MinLedger: 5, MaxLedger: 2, Order: OrderDescending},
+			wantErr: "minLedger must be <= maxLedger",
+		},
+		{
+			name:    "equal bounds accepted",
+			request: GetEventsV2Request{MinLedger: 5, MaxLedger: 5},
+		},
+		{
+			name:    "limit exactly at max accepted",
+			request: GetEventsV2Request{MinLedger: 1, Limit: MaxLimitV2},
+		},
+		{
+			name:    "invalid order",
+			request: GetEventsV2Request{MinLedger: 1, Order: "sideways"},
+			wantErr: `order must be "asc" or "desc"`,
+		},
+		{
+			name:    "limit over max",
+			request: GetEventsV2Request{MinLedger: 1, Limit: MaxLimitV2 + 1},
+			wantErr: fmt.Sprintf("limit must be between 1 and %d", MaxLimitV2),
+		},
+		{
+			name:    "invalid xdrFormat",
+			request: GetEventsV2Request{MinLedger: 1, Format: "hex"},
+			wantErr: `xdrFormat must be "base64" or "json"`,
+		},
+		{
+			name:    "invalid xdrInputFormat",
+			request: GetEventsV2Request{MinLedger: 1, XDRInputFormat: "hex"},
+			wantErr: `xdrInputFormat must be "base64" or "json"`,
+		},
+	})
+}
+
+func TestGetEventsV2RequestValidCursor(t *testing.T) {
+	runRequestValidCasesV2(t, []requestValidCaseV2{
+		{
+			name:    "cursor query",
+			request: GetEventsV2Request{Cursor: testOpaqueCursor, Limit: 100, Format: FormatBase64},
+		},
+		{
+			name:    "cursor with minLedger",
+			request: GetEventsV2Request{Cursor: testOpaqueCursor, MinLedger: 1},
+			wantErr: errMutuallyExclusiveV2,
+		},
+		{
+			name:    "cursor with maxLedger",
+			request: GetEventsV2Request{Cursor: testOpaqueCursor, MaxLedger: 5},
+			wantErr: errMutuallyExclusiveV2,
+		},
+		{
+			name:    "cursor with order",
+			request: GetEventsV2Request{Cursor: testOpaqueCursor, Order: OrderDescending},
+			wantErr: errMutuallyExclusiveV2,
+		},
+		{
+			name: "cursor with filters",
+			request: GetEventsV2Request{
+				Cursor: testOpaqueCursor, Filters: []EventFilterV2{{EventType: EventTypeContract}},
+			},
+			wantErr: errMutuallyExclusiveV2,
+		},
+		{
+			name:    "cursor with xdrInputFormat",
+			request: GetEventsV2Request{Cursor: testOpaqueCursor, XDRInputFormat: FormatBase64},
+			wantErr: errMutuallyExclusiveV2,
+		},
+	})
+}
+
+// typeOnlyFiltersV2 builds n filters that each pass the at-least-one-field
+// rule, for exercising the count bounds.
+func typeOnlyFiltersV2(n int) []EventFilterV2 {
+	filters := make([]EventFilterV2, n)
+	for i := range filters {
+		filters[i].EventType = EventTypeContract
+	}
+	return filters
+}
+
+func TestGetEventsV2RequestValidFilters(t *testing.T) {
+	runRequestValidCasesV2(t, []requestValidCaseV2{
+		{
+			name:    "empty filters array",
+			request: GetEventsV2Request{MinLedger: 1, Filters: []EventFilterV2{}},
+			wantErr: fmt.Sprintf("filters must contain 1 to %d filters", DefaultMaxFiltersV2),
+		},
+		{
+			name:    "too many filters",
+			request: GetEventsV2Request{MinLedger: 1, Filters: typeOnlyFiltersV2(DefaultMaxFiltersV2 + 1)},
+			wantErr: fmt.Sprintf("filters must contain 1 to %d filters", DefaultMaxFiltersV2),
+		},
+		{
+			name:    "exactly max filters accepted",
+			request: GetEventsV2Request{MinLedger: 1, Filters: typeOnlyFiltersV2(DefaultMaxFiltersV2)},
+		},
+		{
+			name:    "system event type accepted",
+			request: GetEventsV2Request{MinLedger: 1, Filters: []EventFilterV2{{EventType: EventTypeSystem}}},
+		},
+		{
+			name:    "filter with no fields",
+			request: GetEventsV2Request{MinLedger: 1, Filters: []EventFilterV2{{}}},
+			wantErr: errEmptyFilterV2,
+		},
+		{
+			name: "invalid event type",
+			request: GetEventsV2Request{
+				MinLedger: 1, Filters: []EventFilterV2{{EventType: "diagnostic"}},
+			},
+			wantErr: `filters[0]: type must be "contract" or "system"`,
+		},
+		{
+			name: "invalid contract ID",
+			request: GetEventsV2Request{
+				MinLedger: 1, Filters: []EventFilterV2{{ContractID: "not-a-contract"}},
+			},
+			wantErr: "filters[0]: contractId is invalid",
+		},
+		{
+			name: "topic0 position validated",
+			request: GetEventsV2Request{
+				MinLedger: 1,
+				Filters:   []EventFilterV2{{Topic0: json.RawMessage(`"!!!"`)}},
+			},
+			wantErr: "filters[0].topic0 is not valid base64-encoded XDR",
+		},
+		{
+			name: "topic not base64 XDR under default input format",
+			request: GetEventsV2Request{
+				MinLedger: 1,
+				Filters:   []EventFilterV2{{Topic1: json.RawMessage(`"!!!"`)}},
+			},
+			wantErr: "filters[0].topic1 is not valid base64-encoded XDR",
+		},
+		{
+			name: "topic not a JSON string under base64 input format",
+			request: GetEventsV2Request{
+				MinLedger:      1,
+				XDRInputFormat: FormatBase64,
+				Filters:        []EventFilterV2{{Topic2: json.RawMessage(`{"symbol":"transfer"}`)}},
+			},
+			wantErr: "filters[0].topic2 is not valid base64-encoded XDR",
+		},
+		{
+			name: "JSON topic under json input format",
+			request: GetEventsV2Request{
+				MinLedger:      1,
+				XDRInputFormat: FormatJSON,
+				Filters:        []EventFilterV2{{Topic0: json.RawMessage(`{"symbol":"transfer"}`)}},
+			},
+		},
+		{
+			name: "topic3 position validated",
+			request: GetEventsV2Request{
+				MinLedger: 1,
+				Filters:   []EventFilterV2{{Topic3: json.RawMessage(`"!!!"`)}},
+			},
+			wantErr: "filters[0].topic3 is not valid base64-encoded XDR",
+		},
+		{
+			name: "error names the failing filter index",
+			request: GetEventsV2Request{
+				MinLedger: 1,
+				Filters:   []EventFilterV2{{EventType: EventTypeContract}, {}},
+			},
+			wantErr: "filters[1]: filter must specify type, contractId, or at least one topic position",
+		},
+		{
+			name: "contractId still validated under json input format",
+			request: GetEventsV2Request{
+				MinLedger:      1,
+				XDRInputFormat: FormatJSON,
+				Filters:        []EventFilterV2{{ContractID: "not-a-contract"}},
+			},
+			wantErr: "filters[0]: contractId is invalid",
+		},
+	})
+}
+
+// Explicit JSON null topics mean the same as omitted (matches any value).
+func TestGetEventsV2RequestValidNullTopics(t *testing.T) {
+	runRequestValidCasesV2(t, []requestValidCaseV2{
+		{
+			name: "null topic counts as omitted: empty filter rejected",
+			request: GetEventsV2Request{
+				MinLedger: 1,
+				Filters:   []EventFilterV2{{Topic0: json.RawMessage(`null`)}},
+			},
+			wantErr: errEmptyFilterV2,
+		},
+		{
+			name: "null topic counts as omitted under json input format too",
+			request: GetEventsV2Request{
+				MinLedger:      1,
+				XDRInputFormat: FormatJSON,
+				Filters:        []EventFilterV2{{Topic1: json.RawMessage(`null`)}},
+			},
+			wantErr: errEmptyFilterV2,
+		},
+		{
+			name: "null topic alongside a real constraint is legal",
+			request: GetEventsV2Request{
+				MinLedger: 1,
+				Filters: []EventFilterV2{{
+					EventType: EventTypeContract, Topic0: json.RawMessage(`null`),
+				}},
+			},
+		},
+	})
+}
+
+func TestGetEventsV2RequestJSONRoundTrip(t *testing.T) {
+	contractID := testContractIDV2(t)
+	topic := testTopicB64V2(t)
+
+	t.Run("range query", func(t *testing.T) {
+		req := GetEventsV2Request{
+			MinLedger: 1, MaxLedger: 2, Order: OrderDescending,
+			Filters: []EventFilterV2{
+				{ContractID: contractID, EventType: EventTypeSystem, Topic0: topic, Topic3: topic},
+			},
+			XDRInputFormat: FormatBase64, Limit: 5, Format: FormatJSON,
+		}
+		raw, err := json.Marshal(req)
+		require.NoError(t, err)
+		var got GetEventsV2Request
+		require.NoError(t, json.Unmarshal(raw, &got))
+		assert.Equal(t, req, got)
+	})
+
+	// The tags are the public wire contract; round-trips through the same
+	// struct pass a tag rename in lockstep, the literal does not.
+	t.Run("golden request keys", func(t *testing.T) {
+		raw, err := json.Marshal(GetEventsV2Request{
+			MinLedger: 1, MaxLedger: 2, Order: OrderAscending,
+			Filters: []EventFilterV2{
+				{ContractID: contractID, EventType: EventTypeContract,
+					Topic0: topic, Topic1: topic, Topic2: topic, Topic3: topic},
+			},
+			XDRInputFormat: FormatBase64, Limit: 5, Format: FormatJSON,
+		})
+		require.NoError(t, err)
+		golden := `{"minLedger":1,"maxLedger":2,"order":"asc","filters":[` +
+			`{"contractId":` + string(mustJSONV2(t, contractID)) +
+			`,"type":"contract","topic0":` + string(topic) + `,"topic1":` + string(topic) +
+			`,"topic2":` + string(topic) + `,"topic3":` + string(topic) + `}],` +
+			`"xdrInputFormat":"base64","limit":5,"xdrFormat":"json"}`
+		assert.Equal(t, golden, string(raw))
+	})
+
+	t.Run("cursor query omits range keys", func(t *testing.T) {
+		raw, err := json.Marshal(GetEventsV2Request{Cursor: "opaque", Limit: 10})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"cursor":"opaque","limit":10}`, string(raw))
+	})
+
+	t.Run("unset topics are omitted", func(t *testing.T) {
+		raw, err := json.Marshal(EventFilterV2{Topic1: topic})
+		require.NoError(t, err)
+		var keys map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(raw, &keys))
+		assert.Equal(t, []string{"topic1"}, mapKeys(keys))
+	})
+}
+
+func TestGetEventsV2ResponseJSON(t *testing.T) {
+	t.Run("cursor omitted when empty", func(t *testing.T) {
+		raw, err := json.Marshal(GetEventsV2Response{
+			Events: []EventInfoV2{}, ScanStatus: ScanStatusComplete,
+			ScannedLedger: 5, OldestLedger: 1, LatestLedger: 9,
+		})
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), `"cursor"`)
+		assert.Contains(t, string(raw), `"scanStatus":"COMPLETE"`)
+	})
+
+	t.Run("round trip with cursor", func(t *testing.T) {
+		resp := GetEventsV2Response{
+			Events: []EventInfoV2{{
+				EventType: EventTypeContract, Ledger: 3, LedgerClosedAt: "2026-01-01T00:00:00Z",
+				ContractID: "C...", ID: "0000000000000003-0000000001",
+				OpIndex: 1, TxIndex: 2, TransactionHash: "ab",
+				TopicXDR: []string{testTopicXDRV2}, ValueXDR: testTopicXDRV2,
+			}},
+			Cursor: "opaque", ScanStatus: ScanStatusHasMore,
+			ScannedLedger: 3, OldestLedger: 1, LatestLedger: 9,
+		}
+		raw, err := json.Marshal(resp)
+		require.NoError(t, err)
+		var got GetEventsV2Response
+		require.NoError(t, json.Unmarshal(raw, &got))
+		assert.Equal(t, resp, got)
+	})
+
+	t.Run("golden response and event keys", func(t *testing.T) {
+		raw, err := json.Marshal(GetEventsV2Response{
+			Events: []EventInfoV2{{
+				EventType: EventTypeContract, Ledger: 3, LedgerClosedAt: "2026-01-01T00:00:00Z",
+				ContractID: "C1", ID: "id1", OpIndex: 1, TxIndex: 2, TransactionHash: "ab",
+				TopicXDR: []string{testTopicXDRV2}, ValueXDR: testTopicXDRV2,
+			}},
+			Cursor: "c", ScanStatus: ScanStatusHasMore,
+			ScannedLedger: 3, OldestLedger: 1, LatestLedger: 9,
+		})
+		require.NoError(t, err)
+		golden := `{"events":[{"type":"contract","ledger":3,` +
+			`"ledgerClosedAt":"2026-01-01T00:00:00Z","contractId":"C1","id":"id1",` +
+			`"operationIndex":1,"transactionIndex":2,"txHash":"ab",` +
+			`"topic":["AAAA"],"value":"AAAA"}],` +
+			`"cursor":"c","scanStatus":"HAS_MORE","scannedLedger":3,` +
+			`"oldestLedger":1,"latestLedger":9}`
+		assert.Equal(t, golden, string(raw))
+	})
+
+	t.Run("golden error data keys", func(t *testing.T) {
+		raw, err := json.Marshal(InvalidParamsErrorData{
+			Reason: ErrorReasonInvalidParams, TermsUsed: 18, TermBudget: 15,
+		})
+		require.NoError(t, err)
+		assert.Equal(t,
+			`{"reason":"invalid_params","termsUsed":18,"termBudget":15}`,
+			string(raw))
+
+		raw, err = json.Marshal(InvalidParamsErrorData{Reason: ErrorReasonInvalidParams})
+		require.NoError(t, err)
+		assert.Equal(t, `{"reason":"invalid_params"}`, string(raw))
+
+		raw, err = json.Marshal(LedgerOutOfRangeErrorData{
+			Reason: ErrorReasonLedgerOutOfRange, MissingLedger: 7, OldestLedger: 1, LatestLedger: 9,
+		})
+		require.NoError(t, err)
+		assert.Equal(t,
+			`{"reason":"ledger_out_of_range","missingLedger":7,"oldestLedger":1,"latestLedger":9}`,
+			string(raw))
+
+		raw, err = json.Marshal(CursorMalformedErrorData{
+			Reason: ErrorReasonCursorMalformed, OldestLedger: 1, LatestLedger: 9,
+		})
+		require.NoError(t, err)
+		assert.Equal(t,
+			`{"reason":"cursor_malformed","oldestLedger":1,"latestLedger":9}`,
+			string(raw))
+	})
+}
+
+// TestEventInfoV2MirrorsV1 trips when EventInfo and EventInfoV2 drift apart:
+// v2 is defined as v1 without the deprecated inSuccessfulContractCall field,
+// so a field added to one must be added to the other (or the exception
+// listed here). Compares full tags and Go types, not just key names.
+func TestEventInfoV2MirrorsV1(t *testing.T) {
+	v1 := fieldSpecSet(t, reflect.TypeOf(EventInfo{}))
+	v2 := fieldSpecSet(t, reflect.TypeOf(EventInfoV2{}))
+	delete(v1, "inSuccessfulContractCall")
+	assert.Equal(t, v1, v2)
+}
+
+// fieldSpecSet maps each field's JSON key to its full tag and Go type.
+func fieldSpecSet(t *testing.T, typ reflect.Type) map[string]string {
+	t.Helper()
+	specs := make(map[string]string, typ.NumField())
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		tag := field.Tag.Get("json")
+		require.NotEmpty(t, tag)
+		specs[strings.Split(tag, ",")[0]] = tag + " " + field.Type.String()
+	}
+	return specs
+}
+
+func mapKeys(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func mustJSONV2(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	require.NoError(t, err)
+	return raw
+}


### PR DESCRIPTION
### What

Adds the getEvents v2 wire types to `protocols/rpc`, transcribed from the accepted proposal ([stellar/discussions#1872](https://github.com/orgs/stellar/discussions/1872)): request/response/event structs, scan statuses, error reasons and `error.data` payloads, the spec's caps, and request validation.

The proposal is treated as normative for every field name, enum spelling, error reason, and `invalid_params` message — all are transcribed verbatim and pinned by golden tests.

### Design decisions

- **`Valid(maxFilters MaxFilters)`** checks every rule decidable from the request alone and returns the first violation as a typed `*InvalidParamsError` carrying the proposal's verbatim message plus the ready-to-serialize `error.data` payload. Server-state rules stay with the server: the serving window, unknown-field rejection (needs strict JSON decoding), json-format topic decoding, and the term budget.
- **The three caps take three shapes, matching the proposal's annotations**: the limit cap (`MaxLimitV2 = 1000`) is a flat spec maximum enforced as a constant; the filter cap (256) is a provider-configurable default (`DefaultMaxFiltersV2`) passed to `Valid`; the term budget (15, `DefaultTermBudgetV2`) is provider-configurable and server-enforced — counting terms requires the canonical form of json-format topics, which only the server's XDR-JSON converter can produce (byte-comparing raw JSON would over-count and falsely reject valid queries).
- **Topics are `json.RawMessage`** because their encoding is decided by the sibling `xdrInputFormat` field (base64 string vs XDR-JSON object), so decoding must be deferred to whoever holds the whole request. An explicit JSON `null` topic is normalized to omitted (matches any value) per the proposal.
- **`Limit` is `*uint`**: nil means omitted (the server applies its default of 100); an explicit value outside [1, 1000] is rejected with the spec message, including `"limit": 0`.
- **`"filters": []` is rejected** while an omitted key matches all events — the proposal states "Empty values are invalid: omit `filters` entirely to match all events."

### Notes for the stellar-rpc integration

- Populate `jrpc2.Error.Data` from `InvalidParamsError.Data` — the v1 handler pattern sets only `Code` and `Message`, which would silently drop the proposal's `error.data.reason` contract.
- Enforce the term budget after topic conversion, reporting via `InvalidParamsErrorData`'s `termsUsed`/`termBudget` fields with the proposal's message format.
- Validate the configured filter cap at startup: a zero `maxFilters` rejects any request that sets filters.
- The server owns the default page size (100) applied when `limit` is unset; this package never applies it.

### Testing

Golden JSON assertions for request, response, event, and all three error-data shapes; literal pins for every wire constant, spec cap, and full error message (mutation-tested — value changes fail the suite); a reflection test keeping `EventInfoV2` in lockstep with v1's `EventInfo` minus the deprecated `inSuccessfulContractCall`; validation tables covering every rule including boundary cases for custom and zero filter caps, explicit-null topics, and all four topic positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
