### PR TITLE
rpcclient: add Client.URL() to expose configured RPC server URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Official project releases may be found here: https://github.com/stellar/go-stell
 
 ### New Features
 * xdr: Added `LedgerCloseMetaView.LedgerHeader()`, exposing the version-resolving header accessor that already backs `LedgerSequence`, `LedgerCloseTime`, `LedgerHash`, and `PreviousLedgerHash` ([#5982](https://github.com/stellar/go-stellar-sdk/pull/5982))
+* rpcclient: Add `Client.URL()` to expose the configured RPC server URL ([#5885](https://github.com/stellar/go-stellar-sdk/issues/5885))
 
 ### Bug Fixes
 * processors/token_transfer: Accept a `to_muxed_id` bound to `Void` in V4 event data. CAP-0067 specifies that the key is simply absent when there is no muxed destination, and that form already parsed. `Void` is what a contract emits instead if it publishes its event data as a `#[contracttype]` struct with an `Option` field — the natural way to write it before CAP-0086's sparse maps, which omit the key. Such an event previously failed to parse and was dropped from the event stream entirely, silently ([#5983](https://github.com/stellar/go-stellar-sdk/pull/5983))

--- a/clients/rpcclient/doc.go
+++ b/clients/rpcclient/doc.go
@@ -17,6 +17,9 @@ For custom HTTP settings (timeouts, proxies, etc.), provide your own http.Client
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	client := rpcclient.NewClient("https://soroban-testnet.stellar.org", httpClient)
 
+[Client.URL] returns the RPC server URL the client was configured with, which is
+useful when the client is wrapped in another type.
+
 # Network Information
 
 These methods retrieve information about the RPC server and network:

--- a/clients/rpcclient/examples_test.go
+++ b/clients/rpcclient/examples_test.go
@@ -27,6 +27,15 @@ func ExampleNewClient() {
 	defer clientWithCustomHTTP.Close()
 }
 
+// This example demonstrates retrieving the URL a client is configured with.
+func ExampleClient_URL() {
+	client := rpcclient.NewClient("https://soroban-testnet.stellar.org", nil)
+	defer client.Close()
+
+	fmt.Println(client.URL())
+	// Output: https://soroban-testnet.stellar.org
+}
+
 // This example demonstrates checking the health of an RPC server.
 func ExampleClient_GetHealth() {
 	client := rpcclient.NewClient("https://soroban-testnet.stellar.org", nil)

--- a/clients/rpcclient/main.go
+++ b/clients/rpcclient/main.go
@@ -42,6 +42,11 @@ func NewClient(url string, httpClient *http.Client) *Client {
 	return c
 }
 
+// URL returns the RPC server URL this client is configured to use.
+func (c *Client) URL() string {
+	return c.url
+}
+
 // Close closes the client connection. After Close is called, the client
 // should not be used.
 func (c *Client) Close() error {

--- a/clients/rpcclient/main_test.go
+++ b/clients/rpcclient/main_test.go
@@ -667,3 +667,33 @@ func TestPollTransactionWithOptions_RPCError(t *testing.T) {
 
 	require.Error(t, err)
 }
+
+func TestClient_URL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, nil)
+	defer client.Close()
+
+	assert.Equal(t, server.URL, client.URL())
+}
+
+// TestClient_URL_afterRefresh asserts the URL survives the internal client
+// refresh that callResult performs after a failed call.
+func TestClient_URL_afterRefresh(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not valid json"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, nil)
+	defer client.Close()
+
+	_, err := client.GetHealth(context.Background())
+	require.Error(t, err)
+
+	assert.Equal(t, server.URL, client.URL())
+}


### PR DESCRIPTION
## Motivation
`rpcclient.Client` stores the RPC server URL internally (unexported `url` field) but never exposes it. This forces consumers that wrap `Client` in another type — such as [stellar/friendbot](https://github.com/stellar/friendbot) — to duplicate the URL manually, since there's no way to retrieve it from the client. This is redundant and prone to drift between the duplicated URL and the one actually used by the client. For comparison, `horizonclient.Client` already exposes this via a public `HorizonURL` field.

Resolves #5885

## Behavior
Added the `Client.URL() string` method (`clients/rpcclient/main.go`), which returns the RPC URL the client was configured with.

- Implemented as a getter (`return c.url`) instead of exporting the `url` field directly — preserves encapsulation and allows future flexibility without breaking the public API (the alternative suggested and discarded in the issue itself).
- `c.url` is written only in `NewClient` and never mutated afterward (including during `refreshClient`, which only recreates the internal `jrpc2` connection) — so the getter needs no lock (`c.mx`) and is safe for concurrent use.
- Package documentation (`clients/rpcclient/doc.go`) updated to mention `Client.URL` and its use case (client wrapped in another type).

There is no internal usage in the SDK — this is a public API for external consumers, analogous to `horizonclient`'s `HorizonURL`.

## Tests
Two new tests in `clients/rpcclient/main_test.go`:

- `TestClient_URL`: verifies `URL()` returns exactly the URL passed to `NewClient`.
- `TestClient_URL_afterRefresh`: triggers a `GetHealth` call against a server that returns invalid JSON, forcing `callResult` to internally trigger `refreshClient()` (see `main.go:75-78`), and confirms `URL()` still returns the same URL after that refresh cycle.

Validation performed:
- `go vet ./...` — no warnings
- `go test -race ./...` (`rpcclient` package) — all tests pass, including the two new ones, under the race detector
- `gofmt -l .` — no diffs

## Release Impact
No breaking changes. Pure addition of a public API (`Client.URL()`), with no change to existing method signatures or behavior. No data migration required. Entry added to `CHANGELOG.md` under `## Pending / ### New Features`.

## Checklist

- [x] Public and internal documentation updated to reflect behavior changes.
- [ ] Error messages and failure codes reviewed or updated to cover new scenarios.
- [x] Command examples and tutorials use isolated data or local test environments, adhering to security best practices.
- [ ] Dependencies, lockfiles, and CI/CD workflows are synchronized with the new changes.
- [x] All automated tests and linting checks pass successfully.
