### PR TITLE
historyarchive: bound the cache writer and cache only completed downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Official project releases may be found here: https://github.com/stellar/go-stell
 
 ### New Features
 * protocols/rpc: Add `LatestLedgerCloseTime` and `OldestLedgerCloseTime` to `GetHealthResponse`, exposing the latest and oldest ledgers' close times (unix seconds) on the `getHealth` response ([#5958](https://github.com/stellar/go-stellar-sdk/pull/5958))
+* historyarchive: Added `ArchiveOptions.MaxCacheFileSize`, capping the size of any single file written to the on-disk cache (default 8 GiB); larger files are served in full, just not cached ([#5975](https://github.com/stellar/go-stellar-sdk/pull/5975))
 
 ### Breaking Changes
 * xdr: `Asset.LessThan` now orders assets the way the protocol does — by the raw 32-byte issuer key — instead of by base32 strkey text, and `xdr.NewPoolId` requires strictly `a < b`, rejecting reversed and identical pairs ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974))
@@ -21,6 +22,10 @@ Official project releases may be found here: https://github.com/stellar/go-stell
 
 ### Bug Fixes
 * processors/token_transfer: trustline revocation now compares liquidity pool assets by value instead of pointer identity, fixing wrong-leg selection when burning pool shares ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974))
+* historyarchive: closing an archive stream now stops its underlying download — an abandoned download no longer keeps writing to the on-disk cache without bound — and the cache's 10 GiB budget is enforced while downloads run, not only between them ([#5975](https://github.com/stellar/go-stellar-sdk/pull/5975))
+* historyarchive: only fully downloaded files are cached — a download that fails mid-copy can no longer leave a truncated cache entry that readers consume as a complete file ([#5975](https://github.com/stellar/go-stellar-sdk/pull/5975))
+* historyarchive: an archive pool shares one cache across its members instead of each building its own over the same directory, which multiplied the size budget and hid each member's files from the others' eviction ([#5975](https://github.com/stellar/go-stellar-sdk/pull/5975))
+* historyarchive: `Scan` and `Mirror` workers return errors instead of panicking on a failed request ([#5975](https://github.com/stellar/go-stellar-sdk/pull/5975))
 
 ## [0.7.0]
 

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -80,6 +80,11 @@ type ArchiveOptions struct {
 	// written to the on-disk cache. A download that grows past it is abandoned
 	// and the partial file is discarded. Zero selects defaultMaxCacheFileSize.
 	MaxCacheFileSize int64
+
+	// sharedCache, when set, is used instead of building a new cache. Set by
+	// NewArchivePool so that every archive in a pool shares one cache over the
+	// one CachePath, rather than each building its own over the same directory.
+	sharedCache *archiveBucketCache
 }
 
 type Ledger struct {
@@ -689,44 +694,54 @@ func Connect(u string, opts ArchiveOptions) (*Archive, error) {
 		return &arch, err
 	}
 
-	if opts.CachePath != "" {
-		// Set up a <= ~10GiB LRU cache for history archives files
-		haunter := fscache.NewLRUHaunterStrategy(
-			fscache.NewLRUHaunter(0, cacheTotalSizeBudget, time.Minute /* frequency check */),
-		)
-
-		maxFileSize := opts.MaxCacheFileSize
-		if maxFileSize == 0 {
-			maxFileSize = defaultMaxCacheFileSize
-		}
-
-		// Wipe any existing cache on startup
-		os.RemoveAll(opts.CachePath)
-		fs, err := fscache.NewFs(opts.CachePath, 0755 /* drwxr-xr-x */)
-
+	switch {
+	case opts.sharedCache != nil:
+		arch.cache = opts.sharedCache
+	case opts.CachePath != "":
+		arch.cache, err = newArchiveBucketCache(opts)
 		if err != nil {
-			return &arch, errors.Wrapf(err,
-				"creating cache at '%s' with mode 0755 failed",
-				opts.CachePath)
-		}
-
-		cache, err := fscache.NewCacheWithHaunter(fs, haunter)
-		if err != nil {
-			return &arch, errors.Wrapf(err,
-				"creating cache at '%s' failed",
-				opts.CachePath)
-		}
-
-		arch.cache = &archiveBucketCache{
-			Cache:        cache,
-			path:         opts.CachePath,
-			maxTotalSize: cacheTotalSizeBudget,
-			maxFileSize:  maxFileSize,
+			return &arch, err
 		}
 	}
 
 	arch.stats = archiveStats{backendName: u}
 	return &arch, nil
+}
+
+func newArchiveBucketCache(opts ArchiveOptions) (*archiveBucketCache, error) {
+	// Set up a <= ~10GiB LRU cache for history archives files
+	haunter := fscache.NewLRUHaunterStrategy(
+		fscache.NewLRUHaunter(0, cacheTotalSizeBudget, time.Minute /* frequency check */),
+	)
+
+	maxFileSize := opts.MaxCacheFileSize
+	if maxFileSize == 0 {
+		maxFileSize = defaultMaxCacheFileSize
+	}
+
+	// Wipe any existing cache on startup
+	os.RemoveAll(opts.CachePath)
+	fs, err := fscache.NewFs(opts.CachePath, 0755 /* drwxr-xr-x */)
+
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"creating cache at '%s' with mode 0755 failed",
+			opts.CachePath)
+	}
+
+	cache, err := fscache.NewCacheWithHaunter(fs, haunter)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"creating cache at '%s' failed",
+			opts.CachePath)
+	}
+
+	return &archiveBucketCache{
+		Cache:        cache,
+		path:         opts.CachePath,
+		maxTotalSize: cacheTotalSizeBudget,
+		maxFileSize:  maxFileSize,
+	}, nil
 }
 
 func ConnectBackend(u string, opts storage.ConnectOptions) (storage.Storage, error) {

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -35,19 +35,16 @@ const rootHASPath = ".well-known/stellar-history.json"
 const maxHASSize = 10 * 1024 * 1024 // 10 MB
 
 const (
-	// cacheTotalSizeBudget is the hard ceiling on the cache directory's size.
-	// A download that would push the directory past it stops being written to
-	// the cache; the caller still receives the whole file.
+	// Hard ceiling on the cache directory's size. A download that would push
+	// the directory past it stops being cached; the caller still receives the
+	// whole file.
 	cacheTotalSizeBudget = 10 << 30 // 10 GiB
 
-	// cacheEvictionTarget is the size the once-a-minute LRU eviction pass
-	// trims the cache directory down to. It sits well below
-	// cacheTotalSizeBudget on purpose: the eviction pass measures the
-	// directory differently than the budget check does (it skips files that
-	// are open, and its own metadata files), so if the two limits shared one
-	// number, a cache sitting at the budget could look small enough to the
-	// eviction pass that it never evicts anything — and then no download
-	// would ever be cached again.
+	// What the once-a-minute LRU eviction pass trims the directory down to.
+	// Deliberately below cacheTotalSizeBudget: eviction measures the
+	// directory differently than the budget check (it skips open files and
+	// its own metadata), so with one shared number a full cache could look
+	// small enough to never evict anything.
 	cacheEvictionTarget = 8 << 30 // 8 GiB
 
 	// The biggest bucket the pubnet archive serves today is around 2.2GiB, so
@@ -55,14 +52,13 @@ const (
 	// cacheTotalSizeBudget, which remains the binding limit.
 	defaultMaxCacheFileSize = 8 << 30 // 8 GiB
 
-	// How many bytes a fill writes to the cache between two checks of
-	// cacheTotalSizeBudget.
+	// How many bytes a fill writes between two checks of the total budget.
 	cacheCopyChunkSize = 4 << 20 // 4 MiB
 
 	cacheUsageScanInterval = time.Second
 
-	// How long the probe read in cacheFillingReader.Close may block before
-	// the upstream is closed under it.
+	// How long the probe read in Close may block before the upstream is
+	// closed under it.
 	cacheCommitProbeTimeout = time.Second
 )
 
@@ -123,9 +119,9 @@ type ArchiveInterface interface {
 	ListBucket(dp DirPrefix) (chan string, chan error)
 	ListAllBuckets() (chan string, chan error)
 	ListAllBucketHashes() (chan Hash, chan error)
-	ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error)
+	ListCategoryCheckpoints(cat string, subpath string) (chan uint32, chan error)
 	GetXdrStreamForHash(hash Hash) (*xdr.Stream, error)
-	GetXdrStream(pth string) (*xdr.Stream, error)
+	GetXdrStream(path string) (*xdr.Stream, error)
 	GetCheckpointManager() CheckpointManager
 	GetStats() []ArchiveStats
 }
@@ -170,33 +166,27 @@ type archiveBucketCache struct {
 	maxFileSize  int64
 	usage        cacheUsage
 
-	// filling holds the paths whose cache entries are being written right
-	// now. Only completed entries are ever served from the cache; see acquire.
+	// Paths whose entries are being written right now. Only completed entries
+	// are ever served; see acquire.
 	fillMu  sync.Mutex
 	filling map[string]struct{}
 }
 
-// acquire routes a request for pth to one of three outcomes: a reader over a
-// fully cached file (rdr != nil), a writer the caller must fill with the
-// upstream's bytes (wrtr != nil), or inFlight=true, meaning another goroutine
-// is filling pth right now and this request should bypass the cache and
-// download directly.
-//
-// The bypass is what keeps concurrent readers safe. The cache library would
-// happily hand out a reader over the half-written file, but if the fill is
-// then abandoned (size limits, upstream error, the filling caller closing
-// early), that reader sees the file end with a clean EOF — silently truncated
-// data, with no error. Serving only completed files makes an abandoned fill
-// invisible to everyone but the caller that started it.
-func (c *archiveBucketCache) acquire(pth string) (rdr io.ReadCloser, wrtr io.WriteCloser, inFlight bool, err error) {
+// acquire returns a reader when path is fully cached, a writer the caller
+// must fill when it isn't, or inFlight=true when another goroutine is filling
+// it — in which case the caller must bypass the cache and download directly.
+// Half-written entries are never handed out: the cache library cannot signal
+// an error to their readers, so an abandoned fill would read as a shorter,
+// complete file.
+func (c *archiveBucketCache) acquire(path string) (rdr io.ReadCloser, wrtr io.WriteCloser, inFlight bool, err error) {
 	c.fillMu.Lock()
 	defer c.fillMu.Unlock()
 
-	if _, filling := c.filling[pth]; filling {
+	if _, filling := c.filling[path]; filling {
 		return nil, nil, true, nil
 	}
 
-	rdr, wrtr, err = c.Get(pth)
+	rdr, wrtr, err = c.Get(path)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -204,51 +194,39 @@ func (c *archiveBucketCache) acquire(pth string) (rdr io.ReadCloser, wrtr io.Wri
 		return rdr, nil, false, nil
 	}
 
-	// A new entry: the caller fills it through wrtr while streaming the
-	// upstream to its own consumer. The reader half is unused — nothing reads
-	// the cache file until the fill completes.
+	// Nothing reads the cache entry until the fill completes.
 	rdr.Close()
-	c.filling[pth] = struct{}{}
+	c.filling[path] = struct{}{}
 	return nil, wrtr, false, nil
 }
 
-// finishFill closes the writer of a fill started by acquire and, unless the
-// fill completed cleanly, deletes the cache entry. Only after both steps does
-// pth leave the in-flight set, so no other caller can observe the entry
-// half-written or mid-removal.
-func (c *archiveBucketCache) finishFill(pth string, wrtr io.WriteCloser, complete bool) (closeErr, removeErr error) {
+// finishFill closes a fill's writer and, unless the fill completed cleanly,
+// deletes the entry. path leaves the in-flight set only after both steps, so
+// no other caller can observe the entry half-written or mid-removal.
+func (c *archiveBucketCache) finishFill(path string, wrtr io.WriteCloser, complete bool) (closeErr, removeErr error) {
 	closeErr = wrtr.Close()
 	if !complete || closeErr != nil {
-		removeErr = c.Remove(pth)
+		removeErr = c.Remove(path)
 	}
 
 	c.fillMu.Lock()
-	delete(c.filling, pth)
+	delete(c.filling, path)
 	c.fillMu.Unlock()
 	return closeErr, removeErr
 }
 
-func (c *archiveBucketCache) hasCompleted(pth string) bool {
+func (c *archiveBucketCache) hasCompleted(path string) bool {
 	c.fillMu.Lock()
-	_, filling := c.filling[pth]
+	_, filling := c.filling[path]
 	c.fillMu.Unlock()
-	return !filling && c.Exists(pth)
+	return !filling && c.Exists(path)
 }
 
-// cacheUsage answers "how many bytes does the cache directory hold right now?".
-//
-// The underlying cache library keeps its own running total, but it leaves out
-// any file that is still open, which is exactly what a download in progress is.
-// So the number is measured here instead, by adding up the files in the cache
-// directory.
-//
-// Measuring means a stat per file, which is too slow to repeat on every write,
-// so the directory is only re-measured once every cacheUsageScanInterval, by
-// whichever caller of total() finds the last measurement expired — and that
-// caller walks the directory without holding a lock, so concurrent downloads
-// are never stalled behind the walk. In between measurements, the copies that
-// are running hand the bytes they write to add(), and those are added to the
-// last measurement.
+// cacheUsage tracks how many bytes the cache directory holds. The cache
+// library's own total leaves out files that are still open — exactly what a
+// download in progress is — so the directory is measured here instead: a full
+// walk at most once per cacheUsageScanInterval, done without holding the
+// lock, plus the bytes the running fills report to add() in between.
 type cacheUsage struct {
 	scanned atomic.Int64
 	written atomic.Int64
@@ -295,20 +273,15 @@ func dirSize(dir string) int64 {
 }
 
 // cacheFillingReader streams a file from the upstream archive to the caller
-// and, as a side effect, writes the same bytes into a cache entry. The caller
-// always receives exactly what the upstream sent: when caching has to stop —
-// the file outgrows the per-file limit, the cache directory hits its budget,
-// or a cache write fails — the half-written entry is deleted and this reader
-// keeps streaming; it just stops caching.
-//
-// A fill is committed once the upstream reports EOF — either during a Read,
-// or by the probe read in Close for callers that consume the whole file
-// without ever seeing the EOF themselves. A caller that closes mid-file gets
-// its incomplete entry deleted instead.
+// and writes the same bytes into a cache entry on the side. The caller always
+// receives exactly what the upstream sent: when caching has to stop — size
+// limits, a failed cache write — the half-written entry is deleted and the
+// reader keeps streaming. A fill is kept only if it reached the upstream's
+// EOF, seen either during a Read or by the probe in Close.
 type cacheFillingReader struct {
 	upstream io.ReadCloser
 	cache    *archiveBucketCache
-	pth      string
+	path     string
 	log      *log.Entry
 
 	wrtr      io.WriteCloser // nil once the fill has been committed or abandoned
@@ -368,7 +341,7 @@ func (r *cacheFillingReader) commit() {
 	wrtr := r.wrtr
 	r.wrtr = nil
 
-	closeErr, removeErr := r.cache.finishFill(r.pth, wrtr, true)
+	closeErr, removeErr := r.cache.finishFill(r.path, wrtr, true)
 	if closeErr != nil {
 		r.log.WithError(closeErr).WithField("cache-rm", removeErr).
 			Warn("Committing cached file failed")
@@ -376,9 +349,8 @@ func (r *cacheFillingReader) commit() {
 	}
 	r.log.Infof("Cached %dKiB file", r.written/1024)
 
-	// Track how much bandwidth we've saved from caching by saving
-	// the size of the file we just downloaded.
-	r.cache.sizes.Store(r.pth, r.written)
+	// Replayed into the bandwidth-saved stat when this path is later a hit.
+	r.cache.sizes.Store(r.path, r.written)
 }
 
 func (r *cacheFillingReader) abandon(reason error) {
@@ -388,19 +360,17 @@ func (r *cacheFillingReader) abandon(reason error) {
 	wrtr := r.wrtr
 	r.wrtr = nil
 
-	closeErr, removeErr := r.cache.finishFill(r.pth, wrtr, false)
+	closeErr, removeErr := r.cache.finishFill(r.path, wrtr, false)
 	r.log.WithError(reason).WithFields(log.Fields{
 		"wr-close": closeErr,
 		"cache-rm": removeErr,
 	}).Warn("Stopped caching file")
 }
 
-// Close can be called more than once. If the fill is still running, one probe
-// read decides its fate: gzip consumers stop reading right after the gzip
-// trailer, without the extra Read that would report io.EOF, so a Close does
-// not necessarily mean the download is incomplete. An immediate EOF from the
-// probe means the whole file was consumed, and the fill is committed;
-// anything else discards it.
+// Close can be called more than once. If the fill is still active, one probe
+// read decides whether it commits: gzip consumers stop reading right after
+// the gzip trailer without ever seeing the raw io.EOF, so a Close does not
+// necessarily mean the download is incomplete.
 func (r *cacheFillingReader) Close() error {
 	r.closeOnce.Do(func() {
 		if r.wrtr != nil {
@@ -412,9 +382,8 @@ func (r *cacheFillingReader) Close() error {
 }
 
 func (r *cacheFillingReader) settleFillOnClose() {
-	// The probe must not block forever on a stalled connection: closing the
-	// upstream is what unblocks a pending read, so a timer does exactly that
-	// if the probe outlives cacheCommitProbeTimeout.
+	// Closing the upstream is what unblocks a stalled probe read, so a timer
+	// does exactly that if the probe outlives cacheCommitProbeTimeout.
 	timer := time.AfterFunc(cacheCommitProbeTimeout, func() { r.closeUpstream() })
 	defer timer.Stop()
 
@@ -434,9 +403,8 @@ func (r *cacheFillingReader) closeUpstream() error {
 	return r.upstreamCloseErr
 }
 
-// closeOnceReader makes Close safe to call more than once. The cache reader
-// underneath panics on a second Close, because its handle count goes negative,
-// and a reader handed out to callers has no business being that fragile.
+// closeOnceReader makes Close safe to call more than once; the fscache reader
+// underneath panics on a second Close.
 type closeOnceReader struct {
 	io.ReadCloser
 	once     sync.Once
@@ -689,12 +657,12 @@ func (a *Archive) ListAllBucketHashes() (chan Hash, chan error) {
 	return ch, errs
 }
 
-func (a *Archive) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
+func (a *Archive) ListCategoryCheckpoints(cat string, subpath string) (chan uint32, chan error) {
 	ext := categoryExt(cat)
 	rx := regexp.MustCompile(cat + hexPrefixPat + cat +
 		"-([0-9a-f]{8})\\." + regexp.QuoteMeta(ext) + "$")
 	a.stats.incrementRequests()
-	sch, errs := a.backend.ListFiles(path.Join(cat, pth))
+	sch, errs := a.backend.ListFiles(path.Join(cat, subpath))
 	ch := make(chan uint32)
 	errs = makeErrorPump(errs)
 
@@ -727,48 +695,47 @@ func (a *Archive) GetXdrStreamForHash(hash Hash) (*xdr.Stream, error) {
 	return a.GetXdrStream(a.GetBucketPathForHash(hash))
 }
 
-func (a *Archive) GetXdrStream(pth string) (*xdr.Stream, error) {
-	if !strings.HasSuffix(pth, ".xdr.gz") {
-		return nil, errors.New("File has non-.xdr.gz suffix: " + pth)
+func (a *Archive) GetXdrStream(path string) (*xdr.Stream, error) {
+	if !strings.HasSuffix(path, ".xdr.gz") {
+		return nil, errors.New("File has non-.xdr.gz suffix: " + path)
 	}
-	rdr, err := a.cachedGet(pth)
+	rdr, err := a.cachedGet(path)
 	if err != nil {
 		return nil, err
 	}
 	return xdr.NewGzStream(rdr)
 }
 
-func (a *Archive) cachedGet(pth string) (io.ReadCloser, error) {
+func (a *Archive) cachedGet(path string) (io.ReadCloser, error) {
 	if a.cache == nil {
 		a.stats.incrementDownloads()
-		return a.backend.GetFile(pth)
+		return a.backend.GetFile(path)
 	}
 
-	L := log.WithField("path", pth).WithField("cache", a.cache.path)
+	L := log.WithField("path", path).WithField("cache", a.cache.path)
 
-	rdr, wrtr, inFlight, err := a.cache.acquire(pth)
+	rdr, wrtr, inFlight, err := a.cache.acquire(path)
 	if err != nil {
 		L.WithError(err).
-			WithField("remove", a.cache.Remove(pth)).
+			WithField("remove", a.cache.Remove(path)).
 			Warn("On-disk cache retrieval failed")
 		a.stats.incrementDownloads()
-		return a.backend.GetFile(pth)
+		return a.backend.GetFile(path)
 	}
 
-	// Another goroutine is filling the cache entry for pth right now. Only
-	// completed entries are ever served from the cache (see acquire), so this
-	// request downloads its own copy instead of waiting.
+	// Another goroutine is filling this entry — download independently
+	// rather than read a file that may be abandoned mid-write (see acquire).
 	if inFlight {
 		a.stats.incrementDownloads()
-		return a.backend.GetFile(pth)
+		return a.backend.GetFile(path)
 	}
 
 	if wrtr != nil {
 		L.Info("Caching file...")
 		a.stats.incrementDownloads()
-		upstream, err := a.backend.GetFile(pth)
+		upstream, err := a.backend.GetFile(path)
 		if err != nil {
-			closeErr, removeErr := a.cache.finishFill(pth, wrtr, false)
+			closeErr, removeErr := a.cache.finishFill(path, wrtr, false)
 			L.WithError(err).WithFields(log.Fields{
 				"write-close": closeErr,
 				"cache-rm":    removeErr,
@@ -779,14 +746,14 @@ func (a *Archive) cachedGet(pth string) (io.ReadCloser, error) {
 		return &cacheFillingReader{
 			upstream: upstream,
 			cache:    a.cache,
-			pth:      pth,
+			path:     path,
 			log:      L,
 			wrtr:     wrtr,
 		}, nil
 	}
 
 	// Best-effort check to track bandwidth metrics
-	if written, found := a.cache.sizes.Load(pth); found {
+	if written, found := a.cache.sizes.Load(path); found {
 		a.stats.incrementCacheBandwidth(written.(int64))
 	}
 	a.stats.incrementCacheHits()
@@ -794,13 +761,13 @@ func (a *Archive) cachedGet(pth string) (io.ReadCloser, error) {
 	return &closeOnceReader{ReadCloser: rdr}, nil
 }
 
-func (a *Archive) cachedExists(pth string) (bool, error) {
-	if a.cache != nil && a.cache.hasCompleted(pth) {
+func (a *Archive) cachedExists(path string) (bool, error) {
+	if a.cache != nil && a.cache.hasCompleted(path) {
 		return true, nil
 	}
 
 	a.stats.incrementRequests()
-	return a.backend.Exists(pth)
+	return a.backend.Exists(path)
 }
 
 func Connect(u string, opts ArchiveOptions) (*Archive, error) {

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -31,6 +32,26 @@ import (
 const hexPrefixPat = "/[0-9a-f]{2}/[0-9a-f]{2}/[0-9a-f]{2}/"
 const rootHASPath = ".well-known/stellar-history.json"
 const maxHASSize = 10 * 1024 * 1024 // 10 MB
+
+const (
+	cacheTotalSizeBudget = 10 << 30 // 10 GiB
+
+	// The biggest bucket the pubnet archive serves today is around 2.2GiB, so
+	// this leaves plenty of room for state growth while staying below
+	// cacheTotalSizeBudget, which remains the binding limit.
+	defaultMaxCacheFileSize = 8 << 30 // 8 GiB
+
+	// How much is copied between two checks of the size limits and of the
+	// cancellation signal.
+	cacheCopyChunkSize = 4 << 20 // 4 MiB
+
+	cacheUsageScanInterval = time.Second
+)
+
+var (
+	errCacheFileTooLarge = errors.New("file is larger than the per-file cache limit")
+	errCacheBudgetSpent  = errors.New("cache has no room left within its size budget")
+)
 
 type CommandOptions struct {
 	Concurrency  int
@@ -55,6 +76,10 @@ type ArchiveOptions struct {
 	CheckpointFrequency uint32
 	// CachePath controls where/if bucket files are cached on the disk.
 	CachePath string
+	// MaxCacheFileSize is the largest single file, in bytes, that will be
+	// written to the on-disk cache. A download that grows past it is abandoned
+	// and the partial file is discarded. Zero selects defaultMaxCacheFileSize.
+	MaxCacheFileSize int64
 }
 
 type Ledger struct {
@@ -114,6 +139,7 @@ type Archive struct {
 	backend storage.Storage
 	stats   archiveStats
 	cache   *archiveBucketCache
+	ctx     context.Context
 }
 
 type archiveBucketCache struct {
@@ -121,6 +147,116 @@ type archiveBucketCache struct {
 
 	path  string
 	sizes sync.Map
+
+	maxTotalSize int64
+	maxFileSize  int64
+	usage        cacheUsage
+}
+
+// cacheUsage answers "how many bytes does the cache directory hold right now?".
+//
+// The underlying cache library keeps its own running total, but it leaves out
+// any file that is still open, which is exactly what a download in progress is.
+// So the number is measured here instead, by adding up the files in the cache
+// directory.
+//
+// Measuring means a stat per file, which is too slow to repeat on every write,
+// so the directory is only re-measured once every cacheUsageScanInterval. In
+// between, the copies that are running hand the bytes they write to add(), and
+// those are added to the last measurement.
+type cacheUsage struct {
+	mu      sync.Mutex
+	scanned int64
+	written int64
+	at      time.Time
+}
+
+func (u *cacheUsage) total(dir string) int64 {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if time.Since(u.at) >= cacheUsageScanInterval {
+		u.scanned = dirSize(dir)
+		u.written = 0
+		u.at = time.Now()
+	}
+	return u.scanned + u.written
+}
+
+func (u *cacheUsage) add(n int64) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.written += n
+}
+
+func dirSize(dir string) int64 {
+	var total int64
+	filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// copyToCache copies src into the cache file dst, and stops early if ctx is
+// cancelled, if this one file grows past maxFileSize, or if the cache directory
+// as a whole reaches maxTotalSize. Stopping early returns an error so that the
+// caller discards the partial file rather than keeping it as a complete cache
+// entry.
+func (c *archiveBucketCache) copyToCache(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
+	buf := make([]byte, cacheCopyChunkSize)
+	var written int64
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+		if c.maxFileSize > 0 && written >= c.maxFileSize {
+			return written, errCacheFileTooLarge
+		}
+		if c.maxTotalSize > 0 && c.usage.total(c.path) >= c.maxTotalSize {
+			return written, errCacheBudgetSpent
+		}
+
+		n, readErr := src.Read(buf)
+		if n > 0 {
+			w, writeErr := dst.Write(buf[:n])
+			written += int64(w)
+			c.usage.add(int64(w))
+			if writeErr != nil {
+				return written, writeErr
+			}
+		}
+		if readErr == io.EOF {
+			return written, nil
+		}
+		if readErr != nil {
+			return written, readErr
+		}
+	}
+}
+
+// cancelOnCloseReader is the reader handed to a caller of cachedGet. Closing it
+// also stops the copy that is filling the cache file behind it, so a download
+// nobody is reading any more does not keep running.
+type cancelOnCloseReader struct {
+	io.ReadCloser
+	cancel   context.CancelFunc
+	once     sync.Once
+	closeErr error
+}
+
+// Close can be called more than once. The reader underneath panics if it is,
+// because its handle count goes negative, and a reader handed out to callers
+// has no business being that fragile.
+func (c *cancelOnCloseReader) Close() error {
+	c.once.Do(func() {
+		c.cancel()
+		c.closeErr = c.ReadCloser.Close()
+	})
+	return c.closeErr
 }
 
 func (arch *Archive) GetStats() []ArchiveStats {
@@ -449,12 +585,38 @@ func (a *Archive) cachedGet(pth string) (io.ReadCloser, error) {
 			return nil, err
 		}
 
+		ctx, cancel := context.WithCancel(a.ctx)
+
+		// A Read that is already waiting on the socket will not notice the
+		// context being cancelled. Closing the body is what makes it return.
+		// Both this watchdog and the copy itself want to close the body, so
+		// whichever gets there first does it.
+		var closeUpstreamOnce sync.Once
+		var upstreamCloseErr error
+		closeUpstream := func() {
+			closeUpstreamOnce.Do(func() { upstreamCloseErr = upstreamReader.Close() })
+		}
+
 		// Start a goroutine to slurp up the upstream and feed
 		// it directly to the cache.
 		go func() {
-			written, err := io.Copy(wrtr, upstreamReader)
+			defer cancel()
+
+			copyDone := make(chan struct{})
+			go func() {
+				select {
+				case <-ctx.Done():
+					closeUpstream()
+				case <-copyDone:
+				}
+			}()
+
+			written, err := a.cache.copyToCache(ctx, wrtr, upstreamReader)
+			close(copyDone)
+
 			writeErr := wrtr.Close()
-			readErr := upstreamReader.Close()
+			closeUpstream()
+			readErr := upstreamCloseErr
 			fields := log.Fields{
 				"wr-close": writeErr,
 				"rd-close": readErr,
@@ -476,13 +638,15 @@ func (a *Archive) cachedGet(pth string) (io.ReadCloser, error) {
 				a.cache.sizes.Store(pth, written)
 			}
 		}()
-	} else {
-		// Best-effort check to track bandwidth metrics
-		if written, found := a.cache.sizes.Load(pth); found {
-			a.stats.incrementCacheBandwidth(written.(int64))
-		}
-		a.stats.incrementCacheHits()
+
+		return &cancelOnCloseReader{ReadCloser: rdr, cancel: cancel}, nil
 	}
+
+	// Best-effort check to track bandwidth metrics
+	if written, found := a.cache.sizes.Load(pth); found {
+		a.stats.incrementCacheBandwidth(written.(int64))
+	}
+	a.stats.incrementCacheHits()
 
 	return rdr, nil
 }
@@ -517,6 +681,7 @@ func Connect(u string, opts ArchiveOptions) (*Archive, error) {
 	if opts.ConnectOptions.Context == nil {
 		opts.ConnectOptions.Context = context.Background()
 	}
+	arch.ctx = opts.ConnectOptions.Context
 
 	var err error
 	arch.backend, err = ConnectBackend(u, opts.ConnectOptions)
@@ -527,8 +692,13 @@ func Connect(u string, opts ArchiveOptions) (*Archive, error) {
 	if opts.CachePath != "" {
 		// Set up a <= ~10GiB LRU cache for history archives files
 		haunter := fscache.NewLRUHaunterStrategy(
-			fscache.NewLRUHaunter(0, 10<<30, time.Minute /* frequency check */),
+			fscache.NewLRUHaunter(0, cacheTotalSizeBudget, time.Minute /* frequency check */),
 		)
+
+		maxFileSize := opts.MaxCacheFileSize
+		if maxFileSize == 0 {
+			maxFileSize = defaultMaxCacheFileSize
+		}
 
 		// Wipe any existing cache on startup
 		os.RemoveAll(opts.CachePath)
@@ -547,7 +717,12 @@ func Connect(u string, opts ArchiveOptions) (*Archive, error) {
 				opts.CachePath)
 		}
 
-		arch.cache = &archiveBucketCache{cache, opts.CachePath, sync.Map{}}
+		arch.cache = &archiveBucketCache{
+			Cache:        cache,
+			path:         opts.CachePath,
+			maxTotalSize: cacheTotalSizeBudget,
+			maxFileSize:  maxFileSize,
+		}
 	}
 
 	arch.stats = archiveStats{backendName: u}

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	fscache "github.com/djherbis/fscache"
@@ -34,18 +35,35 @@ const rootHASPath = ".well-known/stellar-history.json"
 const maxHASSize = 10 * 1024 * 1024 // 10 MB
 
 const (
+	// cacheTotalSizeBudget is the hard ceiling on the cache directory's size.
+	// A download that would push the directory past it stops being written to
+	// the cache; the caller still receives the whole file.
 	cacheTotalSizeBudget = 10 << 30 // 10 GiB
+
+	// cacheEvictionTarget is the size the once-a-minute LRU eviction pass
+	// trims the cache directory down to. It sits well below
+	// cacheTotalSizeBudget on purpose: the eviction pass measures the
+	// directory differently than the budget check does (it skips files that
+	// are open, and its own metadata files), so if the two limits shared one
+	// number, a cache sitting at the budget could look small enough to the
+	// eviction pass that it never evicts anything — and then no download
+	// would ever be cached again.
+	cacheEvictionTarget = 8 << 30 // 8 GiB
 
 	// The biggest bucket the pubnet archive serves today is around 2.2GiB, so
 	// this leaves plenty of room for state growth while staying below
 	// cacheTotalSizeBudget, which remains the binding limit.
 	defaultMaxCacheFileSize = 8 << 30 // 8 GiB
 
-	// How much is copied between two checks of the size limits and of the
-	// cancellation signal.
+	// How many bytes a fill writes to the cache between two checks of
+	// cacheTotalSizeBudget.
 	cacheCopyChunkSize = 4 << 20 // 4 MiB
 
 	cacheUsageScanInterval = time.Second
+
+	// How long the probe read in cacheFillingReader.Close may block before
+	// the upstream is closed under it.
+	cacheCommitProbeTimeout = time.Second
 )
 
 var (
@@ -77,14 +95,10 @@ type ArchiveOptions struct {
 	// CachePath controls where/if bucket files are cached on the disk.
 	CachePath string
 	// MaxCacheFileSize is the largest single file, in bytes, that will be
-	// written to the on-disk cache. A download that grows past it is abandoned
-	// and the partial file is discarded. Zero selects defaultMaxCacheFileSize.
+	// written to the on-disk cache. A larger file is still downloaded and
+	// served in full; it just isn't cached. Zero selects
+	// defaultMaxCacheFileSize.
 	MaxCacheFileSize int64
-
-	// sharedCache, when set, is used instead of building a new cache. Set by
-	// NewArchivePool so that every archive in a pool shares one cache over the
-	// one CachePath, rather than each building its own over the same directory.
-	sharedCache *archiveBucketCache
 }
 
 type Ledger struct {
@@ -144,7 +158,6 @@ type Archive struct {
 	backend storage.Storage
 	stats   archiveStats
 	cache   *archiveBucketCache
-	ctx     context.Context
 }
 
 type archiveBucketCache struct {
@@ -156,6 +169,70 @@ type archiveBucketCache struct {
 	maxTotalSize int64
 	maxFileSize  int64
 	usage        cacheUsage
+
+	// filling holds the paths whose cache entries are being written right
+	// now. Only completed entries are ever served from the cache; see acquire.
+	fillMu  sync.Mutex
+	filling map[string]struct{}
+}
+
+// acquire routes a request for pth to one of three outcomes: a reader over a
+// fully cached file (rdr != nil), a writer the caller must fill with the
+// upstream's bytes (wrtr != nil), or inFlight=true, meaning another goroutine
+// is filling pth right now and this request should bypass the cache and
+// download directly.
+//
+// The bypass is what keeps concurrent readers safe. The cache library would
+// happily hand out a reader over the half-written file, but if the fill is
+// then abandoned (size limits, upstream error, the filling caller closing
+// early), that reader sees the file end with a clean EOF — silently truncated
+// data, with no error. Serving only completed files makes an abandoned fill
+// invisible to everyone but the caller that started it.
+func (c *archiveBucketCache) acquire(pth string) (rdr io.ReadCloser, wrtr io.WriteCloser, inFlight bool, err error) {
+	c.fillMu.Lock()
+	defer c.fillMu.Unlock()
+
+	if _, filling := c.filling[pth]; filling {
+		return nil, nil, true, nil
+	}
+
+	rdr, wrtr, err = c.Get(pth)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if wrtr == nil {
+		return rdr, nil, false, nil
+	}
+
+	// A new entry: the caller fills it through wrtr while streaming the
+	// upstream to its own consumer. The reader half is unused — nothing reads
+	// the cache file until the fill completes.
+	rdr.Close()
+	c.filling[pth] = struct{}{}
+	return nil, wrtr, false, nil
+}
+
+// finishFill closes the writer of a fill started by acquire and, unless the
+// fill completed cleanly, deletes the cache entry. Only after both steps does
+// pth leave the in-flight set, so no other caller can observe the entry
+// half-written or mid-removal.
+func (c *archiveBucketCache) finishFill(pth string, wrtr io.WriteCloser, complete bool) (closeErr, removeErr error) {
+	closeErr = wrtr.Close()
+	if !complete || closeErr != nil {
+		removeErr = c.Remove(pth)
+	}
+
+	c.fillMu.Lock()
+	delete(c.filling, pth)
+	c.fillMu.Unlock()
+	return closeErr, removeErr
+}
+
+func (c *archiveBucketCache) hasCompleted(pth string) bool {
+	c.fillMu.Lock()
+	_, filling := c.filling[pth]
+	c.fillMu.Unlock()
+	return !filling && c.Exists(pth)
 }
 
 // cacheUsage answers "how many bytes does the cache directory hold right now?".
@@ -166,32 +243,44 @@ type archiveBucketCache struct {
 // directory.
 //
 // Measuring means a stat per file, which is too slow to repeat on every write,
-// so the directory is only re-measured once every cacheUsageScanInterval. In
-// between, the copies that are running hand the bytes they write to add(), and
-// those are added to the last measurement.
+// so the directory is only re-measured once every cacheUsageScanInterval, by
+// whichever caller of total() finds the last measurement expired — and that
+// caller walks the directory without holding a lock, so concurrent downloads
+// are never stalled behind the walk. In between measurements, the copies that
+// are running hand the bytes they write to add(), and those are added to the
+// last measurement.
 type cacheUsage struct {
-	mu      sync.Mutex
-	scanned int64
-	written int64
-	at      time.Time
+	scanned atomic.Int64
+	written atomic.Int64
+
+	mu       sync.Mutex
+	scanning bool
+	at       time.Time
 }
 
 func (u *cacheUsage) total(dir string) int64 {
 	u.mu.Lock()
-	defer u.mu.Unlock()
-
-	if time.Since(u.at) >= cacheUsageScanInterval {
-		u.scanned = dirSize(dir)
-		u.written = 0
-		u.at = time.Now()
+	rescan := !u.scanning && time.Since(u.at) >= cacheUsageScanInterval
+	if rescan {
+		u.scanning = true
 	}
-	return u.scanned + u.written
+	u.mu.Unlock()
+
+	if rescan {
+		n := dirSize(dir)
+		u.mu.Lock()
+		u.scanned.Store(n)
+		u.written.Store(0)
+		u.at = time.Now()
+		u.scanning = false
+		u.mu.Unlock()
+	}
+
+	return u.scanned.Load() + u.written.Load()
 }
 
 func (u *cacheUsage) add(n int64) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	u.written += n
+	u.written.Add(n)
 }
 
 func dirSize(dir string) int64 {
@@ -205,60 +294,157 @@ func dirSize(dir string) int64 {
 	return total
 }
 
-// copyToCache copies src into the cache file dst, and stops early if ctx is
-// cancelled, if this one file grows past maxFileSize, or if the cache directory
-// as a whole reaches maxTotalSize. Stopping early returns an error so that the
-// caller discards the partial file rather than keeping it as a complete cache
-// entry.
-func (c *archiveBucketCache) copyToCache(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
-	buf := make([]byte, cacheCopyChunkSize)
-	var written int64
+// cacheFillingReader streams a file from the upstream archive to the caller
+// and, as a side effect, writes the same bytes into a cache entry. The caller
+// always receives exactly what the upstream sent: when caching has to stop —
+// the file outgrows the per-file limit, the cache directory hits its budget,
+// or a cache write fails — the half-written entry is deleted and this reader
+// keeps streaming; it just stops caching.
+//
+// A fill is committed once the upstream reports EOF — either during a Read,
+// or by the probe read in Close for callers that consume the whole file
+// without ever seeing the EOF themselves. A caller that closes mid-file gets
+// its incomplete entry deleted instead.
+type cacheFillingReader struct {
+	upstream io.ReadCloser
+	cache    *archiveBucketCache
+	pth      string
+	log      *log.Entry
 
-	for {
-		if err := ctx.Err(); err != nil {
-			return written, err
-		}
-		if c.maxFileSize > 0 && written >= c.maxFileSize {
-			return written, errCacheFileTooLarge
-		}
-		if c.maxTotalSize > 0 && c.usage.total(c.path) >= c.maxTotalSize {
-			return written, errCacheBudgetSpent
-		}
+	wrtr      io.WriteCloser // nil once the fill has been committed or abandoned
+	written   int64
+	lastCheck int64
 
-		n, readErr := src.Read(buf)
-		if n > 0 {
-			w, writeErr := dst.Write(buf[:n])
-			written += int64(w)
-			c.usage.add(int64(w))
-			if writeErr != nil {
-				return written, writeErr
-			}
+	closeOnce sync.Once
+	closeErr  error
+
+	upstreamCloseOnce sync.Once
+	upstreamCloseErr  error
+}
+
+func (r *cacheFillingReader) Read(p []byte) (int, error) {
+	n, err := r.upstream.Read(p)
+	if n > 0 {
+		r.fill(p[:n])
+	}
+	if err == io.EOF {
+		r.commit()
+	} else if err != nil {
+		r.abandon(err)
+	}
+	return n, err
+}
+
+func (r *cacheFillingReader) fill(b []byte) {
+	if r.wrtr == nil {
+		return
+	}
+	if r.cache.maxFileSize > 0 && r.written+int64(len(b)) > r.cache.maxFileSize {
+		r.abandon(errCacheFileTooLarge)
+		return
+	}
+	if r.written == 0 || r.written-r.lastCheck >= cacheCopyChunkSize {
+		r.lastCheck = r.written
+		if r.cache.maxTotalSize > 0 && r.cache.usage.total(r.cache.path) >= r.cache.maxTotalSize {
+			r.abandon(errCacheBudgetSpent)
+			return
 		}
-		if readErr == io.EOF {
-			return written, nil
-		}
-		if readErr != nil {
-			return written, readErr
-		}
+	}
+
+	w, err := r.wrtr.Write(b)
+	r.written += int64(w)
+	r.cache.usage.add(int64(w))
+	if err != nil {
+		r.abandon(err)
+	} else if w < len(b) {
+		r.abandon(io.ErrShortWrite)
 	}
 }
 
-// cancelOnCloseReader is the reader handed to a caller of cachedGet. Closing it
-// also stops the copy that is filling the cache file behind it, so a download
-// nobody is reading any more does not keep running.
-type cancelOnCloseReader struct {
+func (r *cacheFillingReader) commit() {
+	if r.wrtr == nil {
+		return
+	}
+	wrtr := r.wrtr
+	r.wrtr = nil
+
+	closeErr, removeErr := r.cache.finishFill(r.pth, wrtr, true)
+	if closeErr != nil {
+		r.log.WithError(closeErr).WithField("cache-rm", removeErr).
+			Warn("Committing cached file failed")
+		return
+	}
+	r.log.Infof("Cached %dKiB file", r.written/1024)
+
+	// Track how much bandwidth we've saved from caching by saving
+	// the size of the file we just downloaded.
+	r.cache.sizes.Store(r.pth, r.written)
+}
+
+func (r *cacheFillingReader) abandon(reason error) {
+	if r.wrtr == nil {
+		return
+	}
+	wrtr := r.wrtr
+	r.wrtr = nil
+
+	closeErr, removeErr := r.cache.finishFill(r.pth, wrtr, false)
+	r.log.WithError(reason).WithFields(log.Fields{
+		"wr-close": closeErr,
+		"cache-rm": removeErr,
+	}).Warn("Stopped caching file")
+}
+
+// Close can be called more than once. If the fill is still running, one probe
+// read decides its fate: gzip consumers stop reading right after the gzip
+// trailer, without the extra Read that would report io.EOF, so a Close does
+// not necessarily mean the download is incomplete. An immediate EOF from the
+// probe means the whole file was consumed, and the fill is committed;
+// anything else discards it.
+func (r *cacheFillingReader) Close() error {
+	r.closeOnce.Do(func() {
+		if r.wrtr != nil {
+			r.settleFillOnClose()
+		}
+		r.closeErr = r.closeUpstream()
+	})
+	return r.closeErr
+}
+
+func (r *cacheFillingReader) settleFillOnClose() {
+	// The probe must not block forever on a stalled connection: closing the
+	// upstream is what unblocks a pending read, so a timer does exactly that
+	// if the probe outlives cacheCommitProbeTimeout.
+	timer := time.AfterFunc(cacheCommitProbeTimeout, func() { r.closeUpstream() })
+	defer timer.Stop()
+
+	var buf [1]byte
+	n, err := r.upstream.Read(buf[:])
+	if n == 0 && err == io.EOF {
+		r.commit()
+		return
+	}
+	r.abandon(errors.New("reader closed before EOF"))
+}
+
+func (r *cacheFillingReader) closeUpstream() error {
+	r.upstreamCloseOnce.Do(func() {
+		r.upstreamCloseErr = r.upstream.Close()
+	})
+	return r.upstreamCloseErr
+}
+
+// closeOnceReader makes Close safe to call more than once. The cache reader
+// underneath panics on a second Close, because its handle count goes negative,
+// and a reader handed out to callers has no business being that fragile.
+type closeOnceReader struct {
 	io.ReadCloser
-	cancel   context.CancelFunc
 	once     sync.Once
 	closeErr error
 }
 
-// Close can be called more than once. The reader underneath panics if it is,
-// because its handle count goes negative, and a reader handed out to callers
-// has no business being that fragile.
-func (c *cancelOnCloseReader) Close() error {
+func (c *closeOnceReader) Close() error {
 	c.once.Do(func() {
-		c.cancel()
 		c.closeErr = c.ReadCloser.Close()
 	})
 	return c.closeErr
@@ -560,7 +746,7 @@ func (a *Archive) cachedGet(pth string) (io.ReadCloser, error) {
 
 	L := log.WithField("path", pth).WithField("cache", a.cache.path)
 
-	rdr, wrtr, err := a.cache.Get(pth)
+	rdr, wrtr, inFlight, err := a.cache.acquire(pth)
 	if err != nil {
 		L.WithError(err).
 			WithField("remove", a.cache.Remove(pth)).
@@ -569,82 +755,34 @@ func (a *Archive) cachedGet(pth string) (io.ReadCloser, error) {
 		return a.backend.GetFile(pth)
 	}
 
-	// If a NEW key is being retrieved, it returns a writer to which
-	// you're expected to write your upstream as well as a reader that
-	// will read directly from it.
-	if wrtr != nil {
-		log.WithField("path", pth).Info("Caching file...")
+	// Another goroutine is filling the cache entry for pth right now. Only
+	// completed entries are ever served from the cache (see acquire), so this
+	// request downloads its own copy instead of waiting.
+	if inFlight {
 		a.stats.incrementDownloads()
-		upstreamReader, err := a.backend.GetFile(pth)
+		return a.backend.GetFile(pth)
+	}
+
+	if wrtr != nil {
+		L.Info("Caching file...")
+		a.stats.incrementDownloads()
+		upstream, err := a.backend.GetFile(pth)
 		if err != nil {
-			writeErr := wrtr.Close()
-			readErr := rdr.Close()
-			removeErr := a.cache.Remove(pth)
-			// Execution order isn't guaranteed w/in a function call expression
-			// so we close them with explicit order first.
+			closeErr, removeErr := a.cache.finishFill(pth, wrtr, false)
 			L.WithError(err).WithFields(log.Fields{
-				"write-close": writeErr,
-				"read-close":  readErr,
+				"write-close": closeErr,
 				"cache-rm":    removeErr,
 			}).Warn("Download failed, purging from cache")
 			return nil, err
 		}
 
-		ctx, cancel := context.WithCancel(a.ctx)
-
-		// A Read that is already waiting on the socket will not notice the
-		// context being cancelled. Closing the body is what makes it return.
-		// Both this watchdog and the copy itself want to close the body, so
-		// whichever gets there first does it.
-		var closeUpstreamOnce sync.Once
-		var upstreamCloseErr error
-		closeUpstream := func() {
-			closeUpstreamOnce.Do(func() { upstreamCloseErr = upstreamReader.Close() })
-		}
-
-		// Start a goroutine to slurp up the upstream and feed
-		// it directly to the cache.
-		go func() {
-			defer cancel()
-
-			copyDone := make(chan struct{})
-			go func() {
-				select {
-				case <-ctx.Done():
-					closeUpstream()
-				case <-copyDone:
-				}
-			}()
-
-			written, err := a.cache.copyToCache(ctx, wrtr, upstreamReader)
-			close(copyDone)
-
-			writeErr := wrtr.Close()
-			closeUpstream()
-			readErr := upstreamCloseErr
-			fields := log.Fields{
-				"wr-close": writeErr,
-				"rd-close": readErr,
-			}
-
-			if err != nil {
-				L.WithFields(fields).WithError(err).
-					Warn("Failed to download and cache file")
-
-				// Removal must happen *after* handles close.
-				if removalErr := a.cache.Remove(pth); removalErr != nil {
-					L.WithError(removalErr).Warn("Removing cached file failed")
-				}
-			} else {
-				L.WithFields(fields).Infof("Cached %dKiB file", written/1024)
-
-				// Track how much bandwidth we've saved from caching by saving
-				// the size of the file we just downloaded.
-				a.cache.sizes.Store(pth, written)
-			}
-		}()
-
-		return &cancelOnCloseReader{ReadCloser: rdr, cancel: cancel}, nil
+		return &cacheFillingReader{
+			upstream: upstream,
+			cache:    a.cache,
+			pth:      pth,
+			log:      L,
+			wrtr:     wrtr,
+		}, nil
 	}
 
 	// Best-effort check to track bandwidth metrics
@@ -653,11 +791,11 @@ func (a *Archive) cachedGet(pth string) (io.ReadCloser, error) {
 	}
 	a.stats.incrementCacheHits()
 
-	return rdr, nil
+	return &closeOnceReader{ReadCloser: rdr}, nil
 }
 
 func (a *Archive) cachedExists(pth string) (bool, error) {
-	if a.cache != nil && a.cache.Exists(pth) {
+	if a.cache != nil && a.cache.hasCompleted(pth) {
 		return true, nil
 	}
 
@@ -686,7 +824,6 @@ func Connect(u string, opts ArchiveOptions) (*Archive, error) {
 	if opts.ConnectOptions.Context == nil {
 		opts.ConnectOptions.Context = context.Background()
 	}
-	arch.ctx = opts.ConnectOptions.Context
 
 	var err error
 	arch.backend, err = ConnectBackend(u, opts.ConnectOptions)
@@ -694,10 +831,7 @@ func Connect(u string, opts ArchiveOptions) (*Archive, error) {
 		return &arch, err
 	}
 
-	switch {
-	case opts.sharedCache != nil:
-		arch.cache = opts.sharedCache
-	case opts.CachePath != "":
+	if opts.CachePath != "" {
 		arch.cache, err = newArchiveBucketCache(opts)
 		if err != nil {
 			return &arch, err
@@ -709,9 +843,9 @@ func Connect(u string, opts ArchiveOptions) (*Archive, error) {
 }
 
 func newArchiveBucketCache(opts ArchiveOptions) (*archiveBucketCache, error) {
-	// Set up a <= ~10GiB LRU cache for history archives files
+	// Set up an LRU cache for history archive files
 	haunter := fscache.NewLRUHaunterStrategy(
-		fscache.NewLRUHaunter(0, cacheTotalSizeBudget, time.Minute /* frequency check */),
+		fscache.NewLRUHaunter(0, cacheEvictionTarget, time.Minute /* frequency check */),
 	)
 
 	maxFileSize := opts.MaxCacheFileSize
@@ -741,6 +875,7 @@ func newArchiveBucketCache(opts ArchiveOptions) (*archiveBucketCache, error) {
 		path:         opts.CachePath,
 		maxTotalSize: cacheTotalSizeBudget,
 		maxFileSize:  maxFileSize,
+		filling:      make(map[string]struct{}),
 	}, nil
 }
 

--- a/historyarchive/archive_cache_test.go
+++ b/historyarchive/archive_cache_test.go
@@ -1,0 +1,173 @@
+package historyarchive
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Serves a body that never ends, so the test controls when copying stops.
+func endlessServer(t *testing.T, served *atomic.Int64) *httptest.Server {
+	t.Helper()
+	stop := make(chan struct{})
+	chunk := make([]byte, 256*1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not-a-gzip-header-xx"))
+		w.(http.Flusher).Flush()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			n, err := w.Write(chunk)
+			if served != nil {
+				served.Add(int64(n))
+			}
+			if err != nil {
+				return
+			}
+			w.(http.Flusher).Flush()
+			time.Sleep(4 * time.Millisecond) // keep the test off the developer's disk
+		}
+	}))
+	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { close(stop) })
+	return srv
+}
+
+func cacheDirSize(t *testing.T, dir string) int64 {
+	t.Helper()
+	var total int64
+	filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+func TestGetXdrStreamStopsCachingWhenStreamIsRejected(t *testing.T) {
+	srv := endlessServer(t, nil)
+	cachePath := t.TempDir()
+
+	arch, err := Connect(srv.URL, ArchiveOptions{CachePath: cachePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
+	if _, err := arch.GetXdrStreamForHash(hash); err == nil {
+		t.Fatal("expected the malformed payload to be rejected")
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	settled := cacheDirSize(t, cachePath)
+	time.Sleep(1 * time.Second)
+
+	if grew := cacheDirSize(t, cachePath) - settled; grew > 0 {
+		t.Fatalf("cache kept growing by %d bytes after the stream was rejected", grew)
+	}
+}
+
+func TestCachedGetStopsWritingWhenReaderIsClosed(t *testing.T) {
+	srv := endlessServer(t, nil)
+	cachePath := t.TempDir()
+
+	arch, err := Connect(srv.URL, ArchiveOptions{CachePath: cachePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
+	rdr, err := arch.cachedGet(arch.GetBucketPathForHash(hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	rdr.Close()
+
+	time.Sleep(300 * time.Millisecond)
+	settled := cacheDirSize(t, cachePath)
+	time.Sleep(1 * time.Second)
+
+	if grew := cacheDirSize(t, cachePath) - settled; grew > 0 {
+		t.Fatalf("cache kept growing by %d bytes after the reader was closed", grew)
+	}
+}
+
+func TestCachedGetReaderCloseIsIdempotent(t *testing.T) {
+	srv := endlessServer(t, nil)
+	cachePath := t.TempDir()
+
+	arch, err := Connect(srv.URL, ArchiveOptions{CachePath: cachePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
+	rdr, err := arch.cachedGet(arch.GetBucketPathForHash(hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rdr.Close()
+	rdr.Close()
+	rdr.Close()
+}
+
+func TestCachedGetHonoursPerFileSizeLimit(t *testing.T) {
+	srv := endlessServer(t, nil)
+	cachePath := t.TempDir()
+
+	const limit = 8 << 20
+	arch, err := Connect(srv.URL, ArchiveOptions{CachePath: cachePath, MaxCacheFileSize: limit})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
+	rdr, err := arch.cachedGet(arch.GetBucketPathForHash(hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, rdr)
+	rdr.Close()
+
+	// Allow slack for the chunk in flight when the limit tripped.
+	if got := cacheDirSize(t, cachePath); got > limit+(8<<20) {
+		t.Fatalf("wrote %d bytes past a %d byte limit", got, limit)
+	}
+}
+
+func TestCachedGetHonoursTotalCacheSizeLimit(t *testing.T) {
+	srv := endlessServer(t, nil)
+	cachePath := t.TempDir()
+
+	const budget = 8 << 20
+	arch, err := Connect(srv.URL, ArchiveOptions{CachePath: cachePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	arch.cache.maxTotalSize = budget
+
+	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
+	rdr, err := arch.cachedGet(arch.GetBucketPathForHash(hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, rdr)
+	rdr.Close()
+
+	// Allow slack for the chunk in flight when the budget was reached.
+	if got := cacheDirSize(t, cachePath); got > budget+(8<<20) {
+		t.Fatalf("wrote %d bytes past a %d byte budget", got, budget)
+	}
+}

--- a/historyarchive/archive_cache_test.go
+++ b/historyarchive/archive_cache_test.go
@@ -1,6 +1,7 @@
 package historyarchive
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -121,6 +122,41 @@ func TestCachedGetReaderCloseIsIdempotent(t *testing.T) {
 	rdr.Close()
 	rdr.Close()
 	rdr.Close()
+}
+
+func TestArchivePoolCachesEachFileOnce(t *testing.T) {
+	var upstreamRequests atomic.Int64
+	body := bytes.Repeat([]byte("payload"), 1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamRequests.Add(1)
+		w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	cachePath := t.TempDir()
+	pool, err := NewArchivePool([]string{srv.URL, srv.URL, srv.URL}, ArchiveOptions{CachePath: cachePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	members := pool.(*ArchivePool).pool
+	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
+
+	for _, member := range members {
+		arch := member.(*Archive)
+		rdr, err := arch.cachedGet(arch.GetBucketPathForHash(hash))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(io.Discard, rdr); err != nil {
+			t.Fatal(err)
+		}
+		rdr.Close()
+	}
+
+	if got := upstreamRequests.Load(); got != 1 {
+		t.Fatalf("fetched the same path %d times through a pool of 3", got)
+	}
 }
 
 func TestCachedGetHonoursPerFileSizeLimit(t *testing.T) {

--- a/historyarchive/archive_cache_test.go
+++ b/historyarchive/archive_cache_test.go
@@ -134,9 +134,9 @@ func TestCachedGetHitReaderCloseIsIdempotent(t *testing.T) {
 	}
 
 	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
-	pth := arch.GetBucketPathForHash(hash)
+	path := arch.GetBucketPathForHash(hash)
 
-	rdr, err := arch.cachedGet(pth)
+	rdr, err := arch.cachedGet(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestCachedGetHitReaderCloseIsIdempotent(t *testing.T) {
 	}
 	rdr.Close()
 
-	hit, err := arch.cachedGet(pth)
+	hit, err := arch.cachedGet(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,8 +270,7 @@ func TestCachedGetServesFullFileWhenCacheIsFull(t *testing.T) {
 	}
 	arch.cache.maxTotalSize = 1 << 20
 
-	// Fill the directory past the budget. Retrying cannot help: until eviction
-	// runs, every download must degrade to an uncached passthrough.
+	// Push the directory past the budget so every fill aborts immediately.
 	if err = os.WriteFile(filepath.Join(cachePath, "ballast"), make([]byte, 2<<20), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -302,9 +301,9 @@ func TestCachedGetInFlightDownloadsBypassTheCache(t *testing.T) {
 	}
 
 	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
-	pth := arch.GetBucketPathForHash(hash)
+	path := arch.GetBucketPathForHash(hash)
 
-	first, err := arch.cachedGet(pth)
+	first, err := arch.cachedGet(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,7 +311,7 @@ func TestCachedGetInFlightDownloadsBypassTheCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	second, err := arch.cachedGet(pth)
+	second, err := arch.cachedGet(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/historyarchive/archive_cache_test.go
+++ b/historyarchive/archive_cache_test.go
@@ -13,11 +13,14 @@ import (
 )
 
 // Serves a body that never ends, so the test controls when copying stops.
-func endlessServer(t *testing.T, served *atomic.Int64) *httptest.Server {
+func endlessServer(t *testing.T, requests *atomic.Int64) *httptest.Server {
 	t.Helper()
 	stop := make(chan struct{})
 	chunk := make([]byte, 256*1024)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests != nil {
+			requests.Add(1)
+		}
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("not-a-gzip-header-xx"))
 		w.(http.Flusher).Flush()
@@ -27,11 +30,7 @@ func endlessServer(t *testing.T, served *atomic.Int64) *httptest.Server {
 				return
 			default:
 			}
-			n, err := w.Write(chunk)
-			if served != nil {
-				served.Add(int64(n))
-			}
-			if err != nil {
+			if _, err := w.Write(chunk); err != nil {
 				return
 			}
 			w.(http.Flusher).Flush()
@@ -43,16 +42,16 @@ func endlessServer(t *testing.T, served *atomic.Int64) *httptest.Server {
 	return srv
 }
 
-func cacheDirSize(t *testing.T, dir string) int64 {
+func finiteServer(t *testing.T, body []byte, requests *atomic.Int64) *httptest.Server {
 	t.Helper()
-	var total int64
-	filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
-		if err == nil && !info.IsDir() {
-			total += info.Size()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests != nil {
+			requests.Add(1)
 		}
-		return nil
-	})
-	return total
+		w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 func TestGetXdrStreamStopsCachingWhenStreamIsRejected(t *testing.T) {
@@ -70,10 +69,10 @@ func TestGetXdrStreamStopsCachingWhenStreamIsRejected(t *testing.T) {
 	}
 
 	time.Sleep(500 * time.Millisecond)
-	settled := cacheDirSize(t, cachePath)
+	settled := dirSize(cachePath)
 	time.Sleep(1 * time.Second)
 
-	if grew := cacheDirSize(t, cachePath) - settled; grew > 0 {
+	if grew := dirSize(cachePath) - settled; grew > 0 {
 		t.Fatalf("cache kept growing by %d bytes after the stream was rejected", grew)
 	}
 }
@@ -92,14 +91,16 @@ func TestCachedGetStopsWritingWhenReaderIsClosed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(300 * time.Millisecond)
+	if _, err := io.CopyN(io.Discard, rdr, 512*1024); err != nil {
+		t.Fatal(err)
+	}
 	rdr.Close()
 
 	time.Sleep(300 * time.Millisecond)
-	settled := cacheDirSize(t, cachePath)
+	settled := dirSize(cachePath)
 	time.Sleep(1 * time.Second)
 
-	if grew := cacheDirSize(t, cachePath) - settled; grew > 0 {
+	if grew := dirSize(cachePath) - settled; grew > 0 {
 		t.Fatalf("cache kept growing by %d bytes after the reader was closed", grew)
 	}
 }
@@ -124,14 +125,45 @@ func TestCachedGetReaderCloseIsIdempotent(t *testing.T) {
 	rdr.Close()
 }
 
+func TestCachedGetHitReaderCloseIsIdempotent(t *testing.T) {
+	srv := finiteServer(t, bytes.Repeat([]byte("payload"), 1024), nil)
+
+	arch, err := Connect(srv.URL, ArchiveOptions{CachePath: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
+	pth := arch.GetBucketPathForHash(hash)
+
+	rdr, err := arch.cachedGet(pth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(io.Discard, rdr); err != nil {
+		t.Fatal(err)
+	}
+	rdr.Close()
+
+	hit, err := arch.cachedGet(pth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := arch.stats.GetCacheHits(); got != 1 {
+		t.Fatalf("expected the second get to be a cache hit, hits=%d", got)
+	}
+	if _, err := io.Copy(io.Discard, hit); err != nil {
+		t.Fatal(err)
+	}
+
+	hit.Close()
+	hit.Close()
+	hit.Close()
+}
+
 func TestArchivePoolCachesEachFileOnce(t *testing.T) {
 	var upstreamRequests atomic.Int64
-	body := bytes.Repeat([]byte("payload"), 1024)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upstreamRequests.Add(1)
-		w.Write(body)
-	}))
-	t.Cleanup(srv.Close)
+	srv := finiteServer(t, bytes.Repeat([]byte("payload"), 1024), &upstreamRequests)
 
 	cachePath := t.TempDir()
 	pool, err := NewArchivePool([]string{srv.URL, srv.URL, srv.URL}, ArchiveOptions{CachePath: cachePath})
@@ -159,6 +191,22 @@ func TestArchivePoolCachesEachFileOnce(t *testing.T) {
 	}
 }
 
+func TestArchivePoolFailedConnectLeavesCachePathAlone(t *testing.T) {
+	cachePath := t.TempDir()
+	sentinel := filepath.Join(cachePath, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := NewArchivePool([]string{""}, ArchiveOptions{CachePath: cachePath}); err == nil {
+		t.Fatal("expected pool construction to fail")
+	}
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("failed pool construction disturbed the cache directory: %v", err)
+	}
+}
+
 func TestCachedGetHonoursPerFileSizeLimit(t *testing.T) {
 	srv := endlessServer(t, nil)
 	cachePath := t.TempDir()
@@ -174,11 +222,12 @@ func TestCachedGetHonoursPerFileSizeLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	io.Copy(io.Discard, rdr)
+	if _, err := io.CopyN(io.Discard, rdr, limit+(4<<20)); err != nil {
+		t.Fatalf("a file too big to cache must still be served in full, got %v", err)
+	}
 	rdr.Close()
 
-	// Allow slack for the chunk in flight when the limit tripped.
-	if got := cacheDirSize(t, cachePath); got > limit+(8<<20) {
+	if got := dirSize(cachePath); got > limit {
 		t.Fatalf("wrote %d bytes past a %d byte limit", got, limit)
 	}
 }
@@ -199,11 +248,90 @@ func TestCachedGetHonoursTotalCacheSizeLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	io.Copy(io.Discard, rdr)
+	if _, err := io.CopyN(io.Discard, rdr, budget+(8<<20)); err != nil {
+		t.Fatalf("spending the cache budget must not cut the download short, got %v", err)
+	}
 	rdr.Close()
 
-	// Allow slack for the chunk in flight when the budget was reached.
-	if got := cacheDirSize(t, cachePath); got > budget+(8<<20) {
+	// Allow slack for the bytes written between two budget checks.
+	if got := dirSize(cachePath); got > budget+(8<<20) {
 		t.Fatalf("wrote %d bytes past a %d byte budget", got, budget)
+	}
+}
+
+func TestCachedGetServesFullFileWhenCacheIsFull(t *testing.T) {
+	body := bytes.Repeat([]byte("payload"), 4096)
+	srv := finiteServer(t, body, nil)
+
+	cachePath := t.TempDir()
+	arch, err := Connect(srv.URL, ArchiveOptions{CachePath: cachePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	arch.cache.maxTotalSize = 1 << 20
+
+	// Fill the directory past the budget. Retrying cannot help: until eviction
+	// runs, every download must degrade to an uncached passthrough.
+	if err := os.WriteFile(filepath.Join(cachePath, "ballast"), make([]byte, 2<<20), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
+	rdr, err := arch.cachedGet(arch.GetBucketPathForHash(hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(rdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rdr.Close()
+
+	if !bytes.Equal(got, body) {
+		t.Fatalf("got %d bytes, want %d: a full cache must not corrupt downloads", len(got), len(body))
+	}
+}
+
+func TestCachedGetInFlightDownloadsBypassTheCache(t *testing.T) {
+	var requests atomic.Int64
+	srv := endlessServer(t, &requests)
+
+	arch, err := Connect(srv.URL, ArchiveOptions{CachePath: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
+	pth := arch.GetBucketPathForHash(hash)
+
+	first, err := arch.cachedGet(pth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.CopyN(io.Discard, first, 128*1024); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := arch.cachedGet(pth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.CopyN(io.Discard, second, 128*1024); err != nil {
+		t.Fatal(err)
+	}
+
+	// Abandoning the first download (and with it the cache fill) must not
+	// disturb the second reader.
+	first.Close()
+	if _, err := io.CopyN(io.Discard, second, 1<<20); err != nil {
+		t.Fatalf("second reader broke when the cache fill was abandoned: %v", err)
+	}
+	second.Close()
+
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("expected 2 separate upstream downloads, got %d", got)
+	}
+	if hits := arch.stats.GetCacheHits(); hits != 0 {
+		t.Fatalf("an in-flight bypass must not count as a cache hit, hits=%d", hits)
 	}
 }

--- a/historyarchive/archive_cache_test.go
+++ b/historyarchive/archive_cache_test.go
@@ -140,7 +140,7 @@ func TestCachedGetHitReaderCloseIsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := io.Copy(io.Discard, rdr); err != nil {
+	if _, err = io.Copy(io.Discard, rdr); err != nil {
 		t.Fatal(err)
 	}
 	rdr.Close()
@@ -272,7 +272,7 @@ func TestCachedGetServesFullFileWhenCacheIsFull(t *testing.T) {
 
 	// Fill the directory past the budget. Retrying cannot help: until eviction
 	// runs, every download must degrade to an uncached passthrough.
-	if err := os.WriteFile(filepath.Join(cachePath, "ballast"), make([]byte, 2<<20), 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(cachePath, "ballast"), make([]byte, 2<<20), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -308,7 +308,7 @@ func TestCachedGetInFlightDownloadsBypassTheCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := io.CopyN(io.Discard, first, 128*1024); err != nil {
+	if _, err = io.CopyN(io.Discard, first, 128*1024); err != nil {
 		t.Fatal(err)
 	}
 

--- a/historyarchive/archive_pool.go
+++ b/historyarchive/archive_pool.go
@@ -52,6 +52,30 @@ func NewArchivePoolWithBackoff(archiveURLs []string, opts ArchiveOptions, strate
 	}
 	var lastErr error
 
+	// Connect to the archives before building the shared cache: building the
+	// cache wipes CachePath and starts a background eviction loop that cannot
+	// be stopped, so it must not happen on an attempt that produces no pool.
+	// Members are connected without a CachePath so that none of them builds a
+	// private cache; the one shared cache is attached below.
+	memberOpts := opts
+	memberOpts.CachePath = ""
+
+	// Try connecting to all of the listed archives, but only store valid ones.
+	archives := make([]*Archive, 0, len(archiveURLs))
+	for _, url := range archiveURLs {
+		archive, err := Connect(url, memberOpts)
+		if err != nil {
+			lastErr = errors.Wrapf(err, "Error connecting to history archive (%s)", url)
+			continue
+		}
+
+		archives = append(archives, archive)
+	}
+
+	if len(archives) == 0 {
+		return nil, lastErr
+	}
+
 	// One cache for the whole pool. If each archive built its own over the same
 	// directory, the size budget would be multiplied by the number of archives,
 	// and each archive's downloads would be invisible to the others' eviction
@@ -61,22 +85,13 @@ func NewArchivePoolWithBackoff(archiveURLs []string, opts ArchiveOptions, strate
 		if err != nil {
 			return nil, err
 		}
-		opts.sharedCache = cache
-	}
-
-	// Try connecting to all of the listed archives, but only store valid ones.
-	for _, url := range archiveURLs {
-		archive, err := Connect(url, opts)
-		if err != nil {
-			lastErr = errors.Wrapf(err, "Error connecting to history archive (%s)", url)
-			continue
+		for _, archive := range archives {
+			archive.cache = cache
 		}
-
-		ap.pool = append(ap.pool, archive)
 	}
 
-	if len(ap.pool) == 0 {
-		return nil, lastErr
+	for _, archive := range archives {
+		ap.pool = append(ap.pool, archive)
 	}
 
 	ap.curr = rand.Intn(len(ap.pool)) // don't necessarily start at zero

--- a/historyarchive/archive_pool.go
+++ b/historyarchive/archive_pool.go
@@ -52,11 +52,10 @@ func NewArchivePoolWithBackoff(archiveURLs []string, opts ArchiveOptions, strate
 	}
 	var lastErr error
 
-	// Connect to the archives before building the shared cache: building the
-	// cache wipes CachePath and starts a background eviction loop that cannot
-	// be stopped, so it must not happen on an attempt that produces no pool.
-	// Members are connected without a CachePath so that none of them builds a
-	// private cache; the one shared cache is attached below.
+	// Connect before building the shared cache: building it wipes CachePath
+	// and starts an eviction timer that cannot be stopped, so a failed pool
+	// must not get that far. Members connect without a CachePath so none
+	// builds a private cache; the one shared cache is attached below.
 	memberOpts := opts
 	memberOpts.CachePath = ""
 
@@ -76,10 +75,9 @@ func NewArchivePoolWithBackoff(archiveURLs []string, opts ArchiveOptions, strate
 		return nil, lastErr
 	}
 
-	// One cache for the whole pool. If each archive built its own over the same
-	// directory, the size budget would be multiplied by the number of archives,
-	// and each archive's downloads would be invisible to the others' eviction
-	// bookkeeping, so nothing would ever be evicted.
+	// One cache for the whole pool: per-member caches over the same directory
+	// would multiply the size budget and hide each member's files from the
+	// others' eviction.
 	if opts.CachePath != "" {
 		cache, err := newArchiveBucketCache(opts)
 		if err != nil {
@@ -262,11 +260,11 @@ func (pa *ArchivePool) GetXdrStreamForHash(hash Hash) (*xdr.Stream, error) {
 	})
 }
 
-func (pa *ArchivePool) GetXdrStream(pth string) (*xdr.Stream, error) {
+func (pa *ArchivePool) GetXdrStream(path string) (*xdr.Stream, error) {
 	var stream *xdr.Stream
 	return stream, pa.runRoundRobin(func(ai ArchiveInterface) error {
 		var err error
-		stream, err = ai.GetXdrStream(pth)
+		stream, err = ai.GetXdrStream(path)
 		return err
 	})
 }
@@ -291,6 +289,6 @@ func (pa *ArchivePool) ListAllBucketHashes() (chan Hash, chan error) {
 	return pa.getNextArchive().ListAllBucketHashes()
 }
 
-func (pa *ArchivePool) ListCategoryCheckpoints(cat string, pth string) (chan uint32, chan error) {
-	return pa.getNextArchive().ListCategoryCheckpoints(cat, pth)
+func (pa *ArchivePool) ListCategoryCheckpoints(cat string, subpath string) (chan uint32, chan error) {
+	return pa.getNextArchive().ListCategoryCheckpoints(cat, subpath)
 }

--- a/historyarchive/archive_pool.go
+++ b/historyarchive/archive_pool.go
@@ -52,6 +52,18 @@ func NewArchivePoolWithBackoff(archiveURLs []string, opts ArchiveOptions, strate
 	}
 	var lastErr error
 
+	// One cache for the whole pool. If each archive built its own over the same
+	// directory, the size budget would be multiplied by the number of archives,
+	// and each archive's downloads would be invisible to the others' eviction
+	// bookkeeping, so nothing would ever be evicted.
+	if opts.CachePath != "" {
+		cache, err := newArchiveBucketCache(opts)
+		if err != nil {
+			return nil, err
+		}
+		opts.sharedCache = cache
+	}
+
 	// Try connecting to all of the listed archives, but only store valid ones.
 	for _, url := range archiveURLs {
 		archive, err := Connect(url, opts)

--- a/historyarchive/archive_test.go
+++ b/historyarchive/archive_test.go
@@ -306,6 +306,18 @@ func TestScanSlowMissing(t *testing.T) {
 	assert.Equal(t, 5, n)
 }
 
+func TestBucketWithFailedExistenceCheckIsNotClassifiedMissing(t *testing.T) {
+	arch := MustConnect("mock://test", ArchiveOptions{CheckpointFrequency: DefaultCheckpointFrequency})
+	bucket := MustDecodeHash("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb")
+
+	assert.True(t, arch.NoteReferencedBucket(bucket))
+	arch.forgetReferencedBucket(bucket)
+
+	assert.NotContains(t, arch.CheckBucketsMissing(), bucket)
+	assert.True(t, arch.NoteReferencedBucket(bucket),
+		"a forgotten bucket must be re-checkable on its next reference")
+}
+
 func TestMirror(t *testing.T) {
 	defer cleanup()
 	opts := testOptions()

--- a/historyarchive/mirror.go
+++ b/historyarchive/mirror.go
@@ -58,7 +58,8 @@ func Mirror(src *Archive, dst *Archive, opts *CommandOptions) error {
 
 				buckets, err := has.Buckets()
 				if err != nil {
-					panic(errors.Wrap(err, "error getting buckets"))
+					atomic.AddUint32(&errs, noteError(errors.Wrap(err, "error getting buckets")))
+					continue
 				}
 
 				for _, bucket := range buckets {

--- a/historyarchive/scan.go
+++ b/historyarchive/scan.go
@@ -278,11 +278,9 @@ func (arch *Archive) ScanBuckets(opts *CommandOptions) error {
 					if !doList || opts.Verify {
 						exists, err := arch.BucketExists(bucket)
 						if err != nil {
-							// The check failed, so the bucket's status is
-							// unknown. Forget that it was referenced: leaving
-							// the reference in place would classify the bucket
-							// as missing (nothing ever marks it existing), and
-							// no later checkpoint referencing it would recheck.
+							// Status unknown — forget the reference so the
+							// bucket is not reported missing and the next
+							// checkpoint referencing it rechecks.
 							arch.forgetReferencedBucket(bucket)
 							atomic.AddUint32(&errs, noteError(err))
 							continue

--- a/historyarchive/scan.go
+++ b/historyarchive/scan.go
@@ -78,7 +78,9 @@ func (arch *Archive) ScanCheckpointsSlow(opts *CommandOptions) error {
 				}
 				exists, err := arch.CategoryCheckpointExists(r.category, r.checkpoint)
 				if err != nil {
-					panic(err)
+					atomic.AddUint32(&errs, noteError(err))
+					tick <- true
+					continue
 				}
 				tick <- true
 				arch.NoteCheckpointFile(r.category, r.checkpoint, exists)
@@ -263,7 +265,9 @@ func (arch *Archive) ScanBuckets(opts *CommandOptions) error {
 				atomic.AddUint32(&errs, noteError(e))
 				buckets, err := has.Buckets()
 				if err != nil {
-					panic(err)
+					atomic.AddUint32(&errs, noteError(err))
+					tick <- true
+					continue
 				}
 				for _, bucket := range buckets {
 					new := arch.NoteReferencedBucket(bucket)
@@ -274,7 +278,8 @@ func (arch *Archive) ScanBuckets(opts *CommandOptions) error {
 					if !doList || opts.Verify {
 						exists, err := arch.BucketExists(bucket)
 						if err != nil {
-							panic(err)
+							atomic.AddUint32(&errs, noteError(err))
+							continue
 						}
 						if exists {
 							if !doList {

--- a/historyarchive/scan.go
+++ b/historyarchive/scan.go
@@ -278,6 +278,12 @@ func (arch *Archive) ScanBuckets(opts *CommandOptions) error {
 					if !doList || opts.Verify {
 						exists, err := arch.BucketExists(bucket)
 						if err != nil {
+							// The check failed, so the bucket's status is
+							// unknown. Forget that it was referenced: leaving
+							// the reference in place would classify the bucket
+							// as missing (nothing ever marks it existing), and
+							// no later checkpoint referencing it would recheck.
+							arch.forgetReferencedBucket(bucket)
 							atomic.AddUint32(&errs, noteError(err))
 							continue
 						}
@@ -366,6 +372,12 @@ func (arch *Archive) NoteReferencedBucket(bucket Hash) bool {
 	}
 	arch.referencedBuckets[bucket] = true
 	return true
+}
+
+func (arch *Archive) forgetReferencedBucket(bucket Hash) {
+	arch.mutex.Lock()
+	defer arch.mutex.Unlock()
+	delete(arch.referencedBuckets, bucket)
 }
 
 func (arch *Archive) CheckCheckpointFilesMissing(opts *CommandOptions) map[string][]uint32 {


### PR DESCRIPTION
### TL;DR

Three fixes in `historyarchive`:

1. **The cache can no longer truncate what you're reading.** Before: the caller read a file *out of the cache* while a goroutine filled it — so when the fill stopped early (size limit, error, closed reader), the caller's file silently ended mid-way, with no error. Now the caller reads the download directly, and the cache keeps a copy on the side. That copy can be abandoned at any moment and the caller never notices.
2. **An archive pool shares one cache.** N mirrors used to build N caches over the same directory — N× the size budget, and no member could see the others' files to evict them. Now there's one cache, built only after at least one mirror actually connects.
3. **One bad request no longer panics `scan`/`mirror`**, and no longer tricks `repair` into re-uploading a bucket that was never missing.

Two rules make the cache fix hold everywhere:

- Only **whole** files are ever served from the cache. A file mid-download is invisible to everyone but its downloader.
- Size limits mean "**don't keep a copy**" — never "cut the download short".

### Follow-up: #5976

The cache stores exactly what a mirror sent — it cannot tell a good file from a bad one. So a file that streams cleanly end-to-end but then fails its content-hash check still gets cached, and every retry is served that same cached copy instead of asking a different mirror. Fixing that needs a purge hook in the interface plus caller changes here and in horizon/rpc/galexie — spec'd out in #5976 rather than grown into this PR.

---

### The cache fill no longer sits between caller and data

On `main`, a cache miss returns a reader over the cache file while a detached goroutine copies the upstream into it — forever, with no size limit, no matter what the caller does. Just bounding that copy (this PR's first iteration) made things worse: every abort committed a partial file, and its readers saw a clean EOF at the truncation point.

The redesign removes the coupling instead of managing it:

- A miss hands the caller a reader over the **upstream itself** (`cacheFillingReader`); each chunk the caller reads is also written into the cache entry. The caller's data path never depends on the cache.
- When caching must stop — file outgrows `MaxCacheFileSize`, directory hits the 10 GiB budget, a cache write fails — the entry is deleted and the reader keeps streaming.
- While a path is mid-fill, concurrent requests bypass the cache and download their own copy. (fscache cannot error-out readers of an abandoned in-flight stream — they'd see a clean EOF — so isolation is the only safe option.)
- Gzip consumers stop reading right after the gzip trailer, before the raw `io.EOF`. `Close` on a still-active fill therefore does one bounded probe read: immediate EOF → the file was fully consumed → commit; anything else → discard. A timer closes the upstream if the probe stalls, so `Close` cannot hang.
- LRU eviction now trims to 8 GiB, deliberately below the 10 GiB budget. The two limits are measured differently (eviction skips open files and metadata), so sharing one number let a full cache evict nothing, permanently disabling caching.
- Cache-hit readers tolerate a double `Close` (the fscache reader underneath panics on the second one).
- Budget bookkeeping uses atomic counters, re-measures the directory at most once a second without holding a lock across the walk, and checks the budget every 4 MiB written instead of every `Read`.

### One cache per pool, built only on success

- Every pool member used to build its own cache over the shared `CachePath`: budget × pool size, blind eviction, and each member re-downloading the same buckets. The pool now builds one cache and attaches it to every member.
- Construction order matters: building the cache **wipes `CachePath`** and starts an eviction timer that can never be stopped. The pool now connects first and builds the cache only if something succeeded — a retry loop around a failing `NewArchivePool` no longer wipes the directory or leaks a timer per attempt.

### scan/mirror workers stop panicking — and stop misclassifying

- Worker goroutines in `Scan` and `Mirror` panicked the whole process when one request failed (`has.Buckets()`, `BucketExists`, `CategoryCheckpointExists`). They now feed the error accumulator sitting next to them and move on.
- De-panicking `BucketExists` exposed a second bug: the bucket was marked *referenced* before the failed check, which left it permanently classified "missing" — and `repair` would re-upload it. The reference is now forgotten on error, so the next checkpoint referencing the bucket rechecks it.

### Behaviour changes

- Abandoning a stream mid-file discards its cache fill; the next request is a miss. (A file nobody finished reading shouldn't occupy budget.)
- Concurrent requests for a mid-fill path each download their own copy — bandwidth traded for correctness. The first completed fill serves everyone afterwards.
- A file too big for the cache, or arriving while the cache is full, is served in full and simply not cached.

### Tests

- `historyarchive/archive_cache_test.go`: readers can consume files **past** both size limits and past a full cache, untruncated; the cache stops growing when a reader closes or a stream is rejected; in-flight requests bypass the cache and survive an abandoned fill; `Close` is idempotent on hit and miss paths; a pool fetches each path once; a pool that fails to construct leaves `CachePath` untouched.
- `historyarchive/archive_test.go`: a bucket whose existence check failed is neither reported missing nor blocked from a recheck.
