### PR TITLE
txnbuild: consolidate liquidity pool ordering guards; xdr and ingest cleanups

### DIFF
--- a/ingest/producer_test.go
+++ b/ingest/producer_test.go
@@ -47,7 +47,7 @@ func TestBSBProducerFn(t *testing.T) {
 	endLedger := uint32(3)
 	ctx := context.Background()
 	ledgerRange := ledgerbackend.BoundedRange(startLedger, endLedger)
-	mockDataStore := createMockdataStore(t, startLedger, endLedger, endLedger, 64000)
+	mockDataStore := createMockdataStore(t, startLedger, endLedger, 64000)
 	dsConfig := datastore.DataStoreConfig{}
 	pubConfig := PublisherConfig{
 		DataStoreConfig:       dsConfig,
@@ -206,7 +206,11 @@ func TestBSBProducerFnCallbackError(t *testing.T) {
 		DataStoreConfig:       datastore.DataStoreConfig{},
 		BufferedStorageConfig: DefaultBufferedStorageBackendConfig(1),
 	}
-	mockDataStore := createMockdataStore(t, 2, 3, 2, 64000)
+	mockDataStore := createMockdataStore(t, 2, 2, 64000)
+	// The callback fails on ledger 2, so the multi-worker buffer may or may not
+	// get far enough to prefetch ledger 3 — allow the fetch without requiring it.
+	mockDataStore.On("GetFile", mock.Anything, fmt.Sprintf("FFFFFFFF--0-63999/%08X--3.xdr.zst", math.MaxUint32-3)).
+		Return(makeSingleLCMBatch(3), int64(-1), nil).Maybe()
 
 	appCallback := func(lcm xdr.LedgerCloseMeta) error {
 		return errors.New("uhoh")
@@ -220,9 +224,8 @@ func TestBSBProducerFnCallbackError(t *testing.T) {
 		"received an error from callback invocation")
 }
 
-// Serves ledgers start..end. Fetches past requiredEnd are allowed but not
-// required, since the backend prefetches and a test may stop consuming early.
-func createMockdataStore(t *testing.T, start, end, requiredEnd, partitionSize uint32) *datastore.MockDataStore {
+// Serves ledgers start..end, requiring exactly one fetch of each.
+func createMockdataStore(t *testing.T, start, end, partitionSize uint32) *datastore.MockDataStore {
 	mockDataStore := new(datastore.MockDataStore)
 
 	var expectedManifest = datastore.DatastoreManifest{
@@ -243,13 +246,8 @@ func createMockdataStore(t *testing.T, start, end, requiredEnd, partitionSize ui
 	partition := partitionSize - 1
 	for i := start; i <= end; i++ {
 		objectName := fmt.Sprintf("FFFFFFFF--0-%d/%08X--%d.xdr.zst", partition, math.MaxUint32-i, i)
-		call := mockDataStore.On("GetFile", mock.Anything, objectName).
-			Return(makeSingleLCMBatch(i), int64(-1), nil)
-		if i <= requiredEnd {
-			call.Once()
-		} else {
-			call.Maybe()
-		}
+		mockDataStore.On("GetFile", mock.Anything, objectName).
+			Return(makeSingleLCMBatch(i), int64(-1), nil).Once()
 	}
 
 	t.Cleanup(func() {

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -11,7 +11,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 * Liquidity pool asset pairs are validated strictly ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974)):
   * `LiquidityPoolParameters.ToXDR`, `NewLiquidityPoolId`, `NewLiquidityPoolDeposit`, and `NewLiquidityPoolWithdraw` now require `AssetA < AssetB` in the protocol's order (raw issuer key, not strkey text). Reversed or identical pairs — which previously could build operations that stellar-core rejects with `CHANGE_TRUST_MALFORMED` — now error at build time, with the message changed from `AssetA must be <= AssetB` to `AssetA must be < AssetB`.
   * Asset sort order via `Assets`/`LessThan` changes accordingly, and `NativeAsset.LessThan` no longer reports a native asset as less than another native asset.
-  * `NewLiquidityPoolId`, `NewLiquidityPoolDeposit`, and `NewLiquidityPoolWithdraw` validate ordering after XDR conversion, so a malformed asset now returns the conversion error rather than an ordering error ([#5977](https://github.com/stellar/go-stellar-sdk/pull/5977)).
+  * `NewLiquidityPoolId`, `NewLiquidityPoolDeposit`, and `NewLiquidityPoolWithdraw` validate ordering after XDR conversion, so a malformed asset now returns the conversion error rather than an ordering error ([#5978](https://github.com/stellar/go-stellar-sdk/pull/5978)).
 
 ## [11.0.0](https://github.com/stellar/go-stellar-sdk/releases/tag/horizonclient-v11.0.0) - 2023-03-29
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -11,7 +11,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 * Liquidity pool asset pairs are validated strictly ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974)):
   * `LiquidityPoolParameters.ToXDR`, `NewLiquidityPoolId`, `NewLiquidityPoolDeposit`, and `NewLiquidityPoolWithdraw` now require `AssetA < AssetB` in the protocol's order (raw issuer key, not strkey text). Reversed or identical pairs — which previously could build operations that stellar-core rejects with `CHANGE_TRUST_MALFORMED` — now error at build time, with the message changed from `AssetA must be <= AssetB` to `AssetA must be < AssetB`.
   * Asset sort order via `Assets`/`LessThan` changes accordingly, and `NativeAsset.LessThan` no longer reports a native asset as less than another native asset.
-  * `NewLiquidityPoolId` validates ordering after XDR conversion, so a malformed asset now returns the conversion error rather than an ordering error.
+  * `NewLiquidityPoolId`, `NewLiquidityPoolDeposit`, and `NewLiquidityPoolWithdraw` validate ordering after XDR conversion, so a malformed asset now returns the conversion error rather than an ordering error ([#5977](https://github.com/stellar/go-stellar-sdk/pull/5977)).
 
 ## [11.0.0](https://github.com/stellar/go-stellar-sdk/releases/tag/horizonclient-v11.0.0) - 2023-03-29
 

--- a/txnbuild/liquidity_pool_deposit.go
+++ b/txnbuild/liquidity_pool_deposit.go
@@ -28,10 +28,6 @@ func NewLiquidityPoolDeposit(
 	minPrice,
 	maxPrice xdr.Price,
 ) (LiquidityPoolDeposit, error) {
-	if !a.Asset.LessThan(b.Asset) {
-		return LiquidityPoolDeposit{}, errors.New("AssetA must be < AssetB")
-	}
-
 	poolId, err := NewLiquidityPoolId(a.Asset, b.Asset)
 	if err != nil {
 		return LiquidityPoolDeposit{}, err

--- a/txnbuild/liquidity_pool_deposit_test.go
+++ b/txnbuild/liquidity_pool_deposit_test.go
@@ -48,6 +48,17 @@ func TestNewLiquidityPoolDeposit(t *testing.T) {
 		)
 		require.EqualError(t, err, "AssetA must be < AssetB")
 	})
+
+	t.Run("malformed asset", func(t *testing.T) {
+		_, err := NewLiquidityPoolDeposit(
+			"GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
+			AssetAmount{CreditAsset{Code: "EUR", Issuer: "malformed"}, "0.1000000"},
+			AssetAmount{assetB, "0.2000000"},
+			price.MustParse("0.3"),
+			price.MustParse("0.4"),
+		)
+		require.ErrorContains(t, err, "failed to build XDR AssetA ID")
+	})
 }
 
 func TestLiquidityPoolDepositRoundTrip(t *testing.T) {

--- a/txnbuild/liquidity_pool_id.go
+++ b/txnbuild/liquidity_pool_id.go
@@ -2,8 +2,6 @@
 package txnbuild
 
 import (
-	"fmt"
-
 	"github.com/stellar/go-stellar-sdk/support/errors"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
@@ -22,15 +20,12 @@ func NewLiquidityPoolId(a, b Asset) (LiquidityPoolId, error) {
 		return LiquidityPoolId{}, errors.Wrap(err, "failed to build XDR AssetB ID")
 	}
 
-	// AssetA must sort strictly before AssetB — two identical assets are not a
-	// valid pool pair, so the test is "not less than" rather than "greater than".
-	if !xdrAssetA.LessThan(xdrAssetB) {
-		return LiquidityPoolId{}, fmt.Errorf("AssetA must be < AssetB")
-	}
-
+	// xdr.NewPoolId enforces the pool ordering invariant (strictly AssetA <
+	// AssetB). Its error is returned as-is so callers see the same message the
+	// XDR layer produces.
 	id, err := xdr.NewPoolId(xdrAssetA, xdrAssetB, xdr.LiquidityPoolFeeV18)
 	if err != nil {
-		return LiquidityPoolId{}, errors.Wrap(err, "failed to build XDR liquidity pool id")
+		return LiquidityPoolId{}, err
 	}
 	return LiquidityPoolId(id), nil
 }

--- a/txnbuild/liquidity_pool_withdraw.go
+++ b/txnbuild/liquidity_pool_withdraw.go
@@ -26,10 +26,6 @@ func NewLiquidityPoolWithdraw(
 	a, b AssetAmount,
 	amount string,
 ) (LiquidityPoolWithdraw, error) {
-	if !a.Asset.LessThan(b.Asset) {
-		return LiquidityPoolWithdraw{}, errors.New("AssetA must be < AssetB")
-	}
-
 	poolId, err := NewLiquidityPoolId(a.Asset, b.Asset)
 	if err != nil {
 		return LiquidityPoolWithdraw{}, err

--- a/txnbuild/liquidity_pool_withdraw_test.go
+++ b/txnbuild/liquidity_pool_withdraw_test.go
@@ -43,6 +43,16 @@ func TestNewLiquidityPoolWithdraw(t *testing.T) {
 		)
 		require.EqualError(t, err, "AssetA must be < AssetB")
 	})
+
+	t.Run("malformed asset", func(t *testing.T) {
+		_, err := NewLiquidityPoolWithdraw(
+			"GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H",
+			AssetAmount{CreditAsset{Code: "EUR", Issuer: "malformed"}, "0.1000000"},
+			AssetAmount{assetB, "0.2000000"},
+			"52.5",
+		)
+		require.ErrorContains(t, err, "failed to build XDR AssetA ID")
+	})
 }
 
 func TestLiquidityPoolWithdrawRoundTrip(t *testing.T) {

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -454,14 +454,9 @@ func (a *Asset) LessThan(b Asset) bool {
 		return a.GetCode() < b.GetCode()
 	}
 
-	aIssuer, err := a.GetIssuerAccountId()
-	if err != nil {
-		panic(err)
-	}
-	bIssuer, err := b.GetIssuerAccountId()
-	if err != nil {
-		panic(err)
-	}
+	// GetIssuerAccountId only errors for native assets, which returned above.
+	aIssuer, _ := a.GetIssuerAccountId()
+	bIssuer, _ := b.GetIssuerAccountId()
 	aKey := aIssuer.MustEd25519()
 	bKey := bIssuer.MustEd25519()
 	return bytes.Compare(aKey[:], bKey[:]) < 0


### PR DESCRIPTION
## What changed

### txnbuild
- Building a liquidity pool deposit, withdraw, or pool id used to check "is AssetA smaller than AssetB?" in several places. That check now lives in one place (`xdr.NewPoolId`) and everything else relies on it.
- A reversed asset pair still fails with the exact same error: `AssetA must be < AssetB`.
- A broken asset (for example, a bad issuer address) now fails with an error that says what is broken, instead of the ordering error.

### xdr
- `Asset.LessThan` had two `panic(err)` branches that could never run. They are gone; behavior is unchanged.

### ingest (tests only)
- The test helper `createMockdataStore` takes three numbers (`start, end, partitionSize`) instead of four. The one test that needed the extra knob now declares that expectation inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)