### PR TITLE
changelog: cut the Pending section as 0.7.2, and record 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Official project releases may be found here: https://github.com/stellar/go-stell
 
 ### Bug Fixes
 * processors/token_transfer: trustline revocation now compares liquidity pool assets by value instead of pointer identity, fixing wrong-leg selection when burning pool shares ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974))
+* ingest: `ApplyLedgerMetadata` now closes the datastore and the ledger backend, and returns the `PrepareRange` error instead of discarding it — an early return previously stranded one goroutine per configured worker and a failed prepare went unnoticed ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974))
+
+### Updates
+* go.mod: Bumped github.com/stellar/go-xdr to dc590f1, normalizing the schema bound in `mergeInputLenAndMaxSize` so a variable-length field whose length prefix ends the input keeps both its schema and input-length bounds. Every generated type decodes through this decoder ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974))
 
 ## [0.7.1] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ This monorepo contains a number of sdk's:
 Official project releases may be found here: https://github.com/stellar/go-stellar-sdk/releases
 ## Pending
 
-### New Features
-* protocols/rpc: Add `LatestLedgerCloseTime` and `OldestLedgerCloseTime` to `GetHealthResponse`, exposing the latest and oldest ledgers' close times (unix seconds) on the `getHealth` response ([#5958](https://github.com/stellar/go-stellar-sdk/pull/5958))
+## [0.7.2] - 2026-08-14
 
 ### Breaking Changes
 * strkey: `Decode` and `DecodeAny` now validate the payload length against the version byte per [SEP-23](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md). Fixed-length keys (account ID, seed, muxed account, contract, liquidity pool, claimable balance, hashTx, hashX) must decode to their exact canonical size, and signed payloads must carry a declared payload length of 1–64 bytes matched by their zero padding. Inputs with a valid checksum but a wrong-length payload — previously accepted by `Decode`, `DecodeAny`, and every `IsValid*` helper — are now rejected. ([#5977](https://github.com/stellar/go-stellar-sdk/pull/5977))
@@ -22,10 +21,18 @@ Official project releases may be found here: https://github.com/stellar/go-stell
   * `keypair.ParseAddress` wraps every decode failure with `ErrInvalidKey`, so `errors.Is(err, ErrInvalidKey)` keeps matching wrong-length keys (and now also matches checksum/encoding failures, which previously returned the bare strkey error).
   * `DecodeSignedPayload` delegates structure validation to `Decode`; structurally invalid inputs now uniformly error with `invalid signed payload` (previously `signed payload too short: ...` or `invalid signed payload padding`).
 * xdr: `Asset.LessThan` now orders assets the way the protocol does — by the raw 32-byte issuer key — instead of by base32 strkey text, and `xdr.NewPoolId` requires strictly `a < b`, rejecting reversed and identical pairs ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974))
-* txnbuild: liquidity pool operations reject asset pairs that are not strictly ordered; see the [txnbuild changelog](./txnbuild/CHANGELOG.md) ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974))
+* txnbuild: liquidity pool operations reject asset pairs that are not strictly ordered; see the [txnbuild changelog](./txnbuild/CHANGELOG.md) ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974), [#5978](https://github.com/stellar/go-stellar-sdk/pull/5978))
 
 ### Bug Fixes
 * processors/token_transfer: trustline revocation now compares liquidity pool assets by value instead of pointer identity, fixing wrong-leg selection when burning pool shares ([#5974](https://github.com/stellar/go-stellar-sdk/pull/5974))
+
+## [0.7.1] - 2026-08-04
+
+### New Features
+* ingest: Added `ExtractLedgerTxParts` plus `EventsFromTxParts` and `FeesFromTxParts` (**experimental**), a single-walk zero-copy extraction API that supersedes the earlier extractor bundles; see the [ingest changelog](./ingest/CHANGELOG.md) ([#5966](https://github.com/stellar/go-stellar-sdk/pull/5966))
+
+### Bug Fixes
+* clients/stellartoml: `GetStellarToml` validates the domain before requesting it, for parity with its sibling client ([#5970](https://github.com/stellar/go-stellar-sdk/pull/5970))
 
 ## [0.7.0]
 
@@ -34,6 +41,7 @@ Official project releases may be found here: https://github.com/stellar/go-stell
   [stellar-xdr@9c9c1459](https://github.com/stellar/stellar-xdr/commit/9c9c145953e80990d6ff1ae3a6a973a0ce6d0694),
   the commit stellar-core 28.0.0 pins; both CAPs are ungated upstream so
   `XDR_FEATURES` is now empty.
+* protocols/rpc: Add `LatestLedgerCloseTime` and `OldestLedgerCloseTime` to `GetHealthResponse`, exposing the latest and oldest ledgers' close times (unix seconds) on the `getHealth` response ([#5958](https://github.com/stellar/go-stellar-sdk/pull/5958))
 
 ## [0.6.0] - 2026-06-09
 


### PR DESCRIPTION
Part of the Protocol 28 GA release train (#5967).

[v0.7.2](https://github.com/stellar/go-stellar-sdk/releases/tag/v0.7.2) has been tagged at
`b46a4639` so that stellar-rpc, Horizon and Galexie v28.0.0 all pin a released SDK tag —
Horizon's release branch had been pinning `v0.7.2-0.20260806235222-d2f530f4327b` to pick up
#5974. This lands the changelog for it.

* `## Pending` becomes `## [0.7.2] - 2026-08-14`. Its contents are exactly what the tag carries.
* The `protocols/rpc` `GetHealthResponse` close-time entry (#5958) moves to `[0.7.0]`:
  `git merge-base --is-ancestor fc9acb3f v0.7.0` passes, so it shipped on 2026-08-03 and was
  mis-filed under Pending.
* New `[0.7.1] - 2026-08-04` section for #5966 and #5970, which were tagged without a root
  changelog entry — without it, 0.7.2 would silently absorb them.
* The 0.7.2 txnbuild bullet also credits #5978.

Not touched: `ingest/CHANGELOG.md` and `txnbuild/CHANGELOG.md` still have `Pending` /
`Unreleased` sections mixing items from several released versions (e.g. #5944 shipped in 0.6.0).
Worth a follow-up, but it needs per-item version attribution rather than a mechanical cut.

Docs only — no code change, so the tag does not need moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)