### PR TITLE
xdr: export LedgerCloseMetaView.LedgerHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Official project releases may be found here: https://github.com/stellar/go-stell
 ## Pending
 
 ### New Features
-* xdr: Added `LedgerCloseMetaView.LedgerHeader()`, exposing the version-resolving header accessor that already backs `LedgerSequence`, `LedgerCloseTime`, `LedgerHash`, and `PreviousLedgerHash`
+* xdr: Added `LedgerCloseMetaView.LedgerHeader()`, exposing the version-resolving header accessor that already backs `LedgerSequence`, `LedgerCloseTime`, `LedgerHash`, and `PreviousLedgerHash` ([#5982](https://github.com/stellar/go-stellar-sdk/pull/5982))
 
 ## [0.7.2] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This monorepo contains a number of sdk's:
 Official project releases may be found here: https://github.com/stellar/go-stellar-sdk/releases
 ## Pending
 
+### New Features
+* xdr: Added `LedgerCloseMetaView.LedgerHeader()`, exposing the version-resolving header accessor that already backs `LedgerSequence`, `LedgerCloseTime`, `LedgerHash`, and `PreviousLedgerHash`
+
 ## [0.7.2] - 2026-08-14
 
 ### Breaking Changes

--- a/xdr/ledger_close_meta_view.go
+++ b/xdr/ledger_close_meta_view.go
@@ -9,7 +9,10 @@ package xdr
 // that need to hold the value past the source's lifetime should copy it
 // into a fixed-size type themselves.
 
-func (v LedgerCloseMetaView) ledgerHeaderHistoryEntry() (LedgerHeaderHistoryEntryView, error) {
+// LedgerHeader returns a view of this ledger's LedgerHeaderHistoryEntry,
+// resolving the LedgerCloseMeta version (V0/V1/V2) internally. It lets
+// callers read header fields without decoding the rest of the meta.
+func (v LedgerCloseMetaView) LedgerHeader() (LedgerHeaderHistoryEntryView, error) {
 	value, err := v.V()
 	if err != nil {
 		return nil, err
@@ -40,7 +43,7 @@ func (v LedgerCloseMetaView) ledgerHeaderHistoryEntry() (LedgerHeaderHistoryEntr
 
 // LedgerSequence returns the sequence number of this LedgerCloseMeta.
 func (v LedgerCloseMetaView) LedgerSequence() (uint32, error) {
-	header, err := v.ledgerHeaderHistoryEntry()
+	header, err := v.LedgerHeader()
 	if err != nil {
 		return 0, err
 	}
@@ -63,7 +66,7 @@ func (v LedgerCloseMetaView) LedgerSequence() (uint32, error) {
 // LedgerCloseMeta, mirroring LedgerCloseMeta.LedgerCloseTime on the parsed
 // type.
 func (v LedgerCloseMetaView) LedgerCloseTime() (int64, error) {
-	header, err := v.ledgerHeaderHistoryEntry()
+	header, err := v.LedgerHeader()
 	if err != nil {
 		return 0, err
 	}
@@ -79,7 +82,7 @@ func (v LedgerCloseMetaView) LedgerCloseTime() (int64, error) {
 // the source bytes. Zero copy; the slice is valid as long as the source
 // LedgerCloseMetaView's bytes are.
 func (v LedgerCloseMetaView) LedgerHash() ([]byte, error) {
-	header, err := v.ledgerHeaderHistoryEntry()
+	header, err := v.LedgerHeader()
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +99,7 @@ func (v LedgerCloseMetaView) LedgerHash() ([]byte, error) {
 // slice into the source bytes. Zero copy; the slice is valid as long as
 // the source LedgerCloseMetaView's bytes are.
 func (v LedgerCloseMetaView) PreviousLedgerHash() ([]byte, error) {
-	header, err := v.ledgerHeaderHistoryEntry()
+	header, err := v.LedgerHeader()
 	if err != nil {
 		return nil, err
 	}

--- a/xdr/view_randxdr_test.go
+++ b/xdr/view_randxdr_test.go
@@ -68,26 +68,10 @@ func TestView_RandXDR_AccessorCorrectness(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int32(lcm.V), vVal, "iter %d", i)
 
-		// Navigate to LedgerHeader via the selected arm and compare bytes
-		// against the value-side field.
-		var hdrView LedgerHeaderHistoryEntryView
-		switch lcm.V {
-		case 0:
-			v0, e := view.V0()
-			require.NoError(t, e)
-			hdrView, e = v0.LedgerHeader()
-			require.NoError(t, e)
-		case 1:
-			v1, e := view.V1()
-			require.NoError(t, e)
-			hdrView, e = v1.LedgerHeader()
-			require.NoError(t, e)
-		case 2:
-			v2, e := view.V2()
-			require.NoError(t, e)
-			hdrView, e = v2.LedgerHeader()
-			require.NoError(t, e)
-		}
+		// LedgerHeader() resolves the version arm internally; compare its
+		// bytes against the value-side field.
+		hdrView, err := view.LedgerHeader()
+		require.NoError(t, err)
 		hdrWant, err := lcm.LedgerHeaderHistoryEntry().MarshalBinary()
 		require.NoError(t, err)
 		hdrGot, err := hdrView.Raw()


### PR DESCRIPTION
### What

Exports the previously-unexported `LedgerCloseMetaView.ledgerHeaderHistoryEntry()` as `LedgerHeader() (LedgerHeaderHistoryEntryView, error)`. The version-switch body (V0/V1/V2 dispatch) is unchanged; the four internal callers in `xdr/ledger_close_meta_view.go` (`LedgerSequence`, `LedgerCloseTime`, `LedgerHash`, `PreviousLedgerHash`) now call the exported name.

`TestView_RandXDR_AccessorCorrectness` previously navigated to the header via a manual V0/V1/V2 switch that duplicated the method's body; it now calls `LedgerHeader()` directly, giving the exported method randomized byte-for-byte coverage against the value-side field across all three meta versions.

### Why

stellar-rpc's v2 `BatchGetLedgers` wants a header-only decode: today it unmarshals the entire `LedgerCloseMeta` per ledger and keeps only the header. The cross-version dispatch it needs already existed here, unexported, backing the public header-field accessors — this makes it callable:

```go
headerView, err := xdr.LedgerCloseMetaView(rawLCM).LedgerHeader()
headerRaw, err := headerView.Raw()
var header xdr.LedgerHeaderHistoryEntry
err = header.UnmarshalBinary(headerRaw)
```

No `Must*` variant is added, matching the sibling accessors in the file.