### PR TITLE
processors/token_transfer: accept a Void-encoded to_muxed_id in V4 event data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Official project releases may be found here: https://github.com/stellar/go-stell
 ### New Features
 * xdr: Added `LedgerCloseMetaView.LedgerHeader()`, exposing the version-resolving header accessor that already backs `LedgerSequence`, `LedgerCloseTime`, `LedgerHash`, and `PreviousLedgerHash` ([#5982](https://github.com/stellar/go-stellar-sdk/pull/5982))
 
+### Bug Fixes
+* processors/token_transfer: Accept a `to_muxed_id` bound to `Void` in V4 event data. CAP-0067 specifies that the key is simply absent when there is no muxed destination, and that form already parsed. `Void` is what a contract emits instead if it publishes its event data as a `#[contracttype]` struct with an `Option` field — the natural way to write it before CAP-0086's sparse maps, which omit the key. Such an event previously failed to parse and was dropped from the event stream entirely, silently ([#5983](https://github.com/stellar/go-stellar-sdk/pull/5983))
+
 ## [0.7.2] - 2026-08-14
 
 ### Breaking Changes

--- a/processors/token_transfer/contract_events.go
+++ b/processors/token_transfer/contract_events.go
@@ -334,7 +334,8 @@ func parseCustomTokenEventV4(
 
 	// V4 data format can be:
 	// 1. Direct i128 (when there's no memo)
-	// 2. ScMap with exactly 2 fields: "amount" (i128) + "to_muxed_id" (u64/bytes/string)
+	// 2. ScMap with an "amount" (i128) field and an optional "to_muxed_id"
+	//    (u64/bytes/string) field.
 	// If it's a map, at the very least "amount" should be present.
 	if mapData, ok := value.GetMap(); ok {
 		if mapData == nil {
@@ -467,6 +468,9 @@ func parseV4MapDataForTokenEvents(mapData xdr.ScMap) (xdr.Int128Parts, *MuxedInf
 						},
 					}
 				}
+			case xdr.ScValTypeScvVoid:
+				// No muxed destination. Contracts built before CAP-86 encode
+				// that as Void; later ones omit the key entirely.
 			default:
 				return amt, nil, fmt.Errorf("invalid to_muxed_id type for data: %s", entry.Val.Type)
 			}

--- a/processors/token_transfer/contract_events_test.go
+++ b/processors/token_transfer/contract_events_test.go
@@ -1094,7 +1094,14 @@ func TestValidSep41EventsWithExtraTopicsAndDataV4(t *testing.T) {
 		"some random key", "some random value",
 	)
 
+	// The two encodings of a to_muxed_id holding None: contracts built against
+	// the CAP-86 sparse map host functions omit the key, while contracts built
+	// before that store it bound to Void.
 	mapWithJustAmount := createScMap("amount", createInt128(thousand))
+	mapWithVoidMuxedInfo := createScMap(
+		"amount", createInt128(thousand),
+		"to_muxed_id", xdr.ScVal{Type: xdr.ScValTypeScvVoid},
+	)
 
 	createContract := func(contractId *xdr.ContractId, topics []xdr.ScVal, data xdr.ScVal) xdr.ContractEvent {
 		return xdr.ContractEvent{
@@ -1172,6 +1179,27 @@ func TestValidSep41EventsWithExtraTopicsAndDataV4(t *testing.T) {
 					createString("some random extra topic 2"), // extra
 				}
 				data := mapWithJustAmount
+				return createContract(&someContractId1, topics, data)
+			},
+			validateEvent: func(t *testing.T, event *TokenTransferEvent) {
+				assert.NotNil(t, event.GetTransfer())
+				assert.Equal(t, randomAccount, event.GetTransfer().From)
+				assert.Equal(t, someContract1, event.GetTransfer().To)
+				assert.Nil(t, event.GetAsset())
+				assert.Equal(t, thousandStr, event.GetTransfer().Amount)
+				assert.Nil(t, event.Meta.GetToMuxedInfo())
+			},
+		}, {
+			name: "Transfer Event with extra topics and void to_muxed_id in map data - Valid Sep-41 token",
+			setupEvent: func() xdr.ContractEvent {
+				topics := []xdr.ScVal{
+					createSymbol(TransferEvent),
+					createAddress(randomAccount),              // from
+					createAddress(someContract1),              // to
+					createString("some random extra topic 1"), // extra
+					createString("some random extra topic 2"), // extra
+				}
+				data := mapWithVoidMuxedInfo
 				return createContract(&someContractId1, topics, data)
 			},
 			validateEvent: func(t *testing.T, event *TokenTransferEvent) {


### PR DESCRIPTION
## The bug

`parseV4MapDataForTokenEvents` rejects a `to_muxed_id` bound to `Void`:

```go
default:
    return amt, nil, fmt.Errorf("invalid to_muxed_id type for data: %s", entry.Val.Type)
```

and `contractEventsFromOperation` discards an event whose parse fails rather than surfacing the error:

```go
// You dont bail on error here, since error here means that it is not a sep-41 compliant token event.
if err == nil {
    events = append(events, ev)
}
```

So the **entire transfer event vanishes from the stream**, silently, over a field that carries no information.

## Why a contract emits `Void`

A Soroban UDT struct (`#[contracttype]`) is a map with `Symbol` keys, and an `Option` field holding `None` is encoded as a key bound to `Void`. A SEP-41 token that publishes its event data as

```rust
#[contracttype]
pub struct TransferData { pub amount: i128, pub to_muxed_id: Option<u64> }
```

therefore emits `to_muxed_id -> Void` for a transfer with no muxed destination — the natural way to write it, and reachable from any SEP-41 contract, since those are built with soroban-sdk.

[CAP-0067](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md) instead specifies the key as *absent* in that case:

> Non-muxed accounts are represented as a singular `from`/`to` value in the event topics and the `to_muxed_id` key won't be present in the `data` map.

That form already parsed. [CAP-0086](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0086.md) (protocol 28) is what closes the gap going forward: it adds `sparse_map_new_from_linear_memory` / `sparse_map_unpack_to_linear_memory`, which omit a key holding `None`, so the same struct built with the v28 SDK produces the compliant encoding. Contracts built before that keep emitting `Void`, so both forms coexist in ledger history.

## The fix

Treat `Void` as "no muxed destination" — the same result as an absent key. Three lines and a test. There is no XDR change and nothing to regenerate.

## Scope

Deliberately limited to `processors/token_transfer`, which decodes event data from arbitrary SEP-41 contracts.

**The Stellar Asset Contract needs no change**, on three independent grounds:

1. It is not built with soroban-sdk. `storage_types.rs` and `public_types.rs` in rs-soroban-env `use soroban_builtin_sdk_macros::contracttype` — a builtin macro crate compiled into the host — so a soroban-sdk release does not reach it.
2. Its storage types have no `Option` fields: `BalanceValue { amount: i128, authorized: bool, clawback: bool }`, `AllowanceValue { amount: i128, live_until_ledger: u32 }`, `AlphaNum{4,12}AssetInfo { asset_code: String, issuer: BytesN<32> }`. Sparse encoding omits only `Void`, so there would be nothing to omit.
3. Its event data map is built by `get_amount_data_maybe_muxed` via `map_new` plus explicit puts, never through the linear-memory host functions CAP-0086 touches.

So `ingest/sac` is untouched here, as is Horizon's own SAC event parser.

## Testing

`processors/token_transfer` and `xdr` pass. `gofmt` clean, `go vet` clean under the flags `govet.sh` uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
