### PR TITLE
processors/token_transfer: stop coercing a bytes to_muxed_id to 32 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Official project releases may be found here: https://github.com/stellar/go-stell
 
 ### Bug Fixes
 * processors/token_transfer: Accept a `to_muxed_id` bound to `Void` in V4 event data. CAP-0067 specifies that the key is simply absent when there is no muxed destination, and that form already parsed. `Void` is what a contract emits instead if it publishes its event data as a `#[contracttype]` struct with an `Option` field — the natural way to write it before CAP-0086's sparse maps, which omit the key. Such an event previously failed to parse and was dropped from the event stream entirely, silently ([#5983](https://github.com/stellar/go-stellar-sdk/pull/5983))
+* processors/token_transfer: Report a `to_muxed_id` of type `ScvBytes` at the length the contract emitted. It was previously copied into a fixed 32-byte buffer, so a shorter value was right-padded with zeroes and a longer one truncated, reporting a muxed id that was never emitted. Only a classic transaction memo maps to a fixed 32 bytes here; a contract may put any byte string in `to_muxed_id` ([#5984](https://github.com/stellar/go-stellar-sdk/issues/5984))
 
 ## [0.7.2] - 2026-08-14
 

--- a/processors/token_transfer/contract_events.go
+++ b/processors/token_transfer/contract_events.go
@@ -452,7 +452,12 @@ func parseV4MapDataForTokenEvents(mapData xdr.ScMap) (xdr.Int128Parts, *MuxedInf
 				}
 			case xdr.ScValTypeScvBytes:
 				if val, ok := entry.Val.GetBytes(); ok {
-					hashBytes := make([]byte, 32)
+					// Reported at whatever length the contract emitted. Only a
+					// classic memo maps to a fixed 32 bytes here; a contract may
+					// put any byte string in to_muxed_id, and padding or
+					// truncating it to 32 would report a value that was never
+					// emitted.
+					hashBytes := make([]byte, len(val))
 					copy(hashBytes, val)
 					muxedInfo = &MuxedInfo{
 						Content: &MuxedInfo_Hash{

--- a/processors/token_transfer/contract_events_test.go
+++ b/processors/token_transfer/contract_events_test.go
@@ -1,6 +1,7 @@
 package token_transfer
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -1510,6 +1511,62 @@ func TestValidContractEventsV4(t *testing.T) {
 				assert.NotNil(t, event.Meta.ToMuxedInfo)
 				expectedHash := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
 				assert.Equal(t, expectedHash, event.Meta.ToMuxedInfo.GetHash())
+			},
+		},
+		{
+			// A contract may put any byte string in to_muxed_id. A short one
+			// used to be right-padded with zeroes out to 32 bytes.
+			name:       "V4 Transfer SEP-41 Token Event - Hash Memo Shorter Than 32 Bytes",
+			eventType:  TransferEvent,
+			addr1:      someContract1, // from
+			addr2:      someContract2, // to
+			amount:     thousand,
+			isSacEvent: false,
+			hasV4Memo:  true,
+			memoType:   "hash",
+			memoValue:  []byte{1, 2, 3, 4},
+			validateEvent: func(t *testing.T, event *TokenTransferEvent) {
+				assert.NotNil(t, event.GetTransfer())
+				assert.Equal(t, thousandStr, event.GetTransfer().Amount)
+				require.NotNil(t, event.Meta.ToMuxedInfo)
+				assert.Equal(t, []byte{1, 2, 3, 4}, event.Meta.ToMuxedInfo.GetHash())
+			},
+		},
+		{
+			// The same, from the other side: a longer one used to be truncated
+			// to its first 32 bytes.
+			name:       "V4 Transfer SEP-41 Token Event - Hash Memo Longer Than 32 Bytes",
+			eventType:  TransferEvent,
+			addr1:      someContract1, // from
+			addr2:      someContract2, // to
+			amount:     thousand,
+			isSacEvent: false,
+			hasV4Memo:  true,
+			memoType:   "hash",
+			memoValue:  bytes.Repeat([]byte{7}, 40),
+			validateEvent: func(t *testing.T, event *TokenTransferEvent) {
+				assert.NotNil(t, event.GetTransfer())
+				assert.Equal(t, thousandStr, event.GetTransfer().Amount)
+				require.NotNil(t, event.Meta.ToMuxedInfo)
+				assert.Equal(t, bytes.Repeat([]byte{7}, 40), event.Meta.ToMuxedInfo.GetHash())
+			},
+		},
+		{
+			// Nothing downstream may alias the event's XDR buffer.
+			name:       "V4 Transfer SEP-41 Token Event - Empty Hash Memo",
+			eventType:  TransferEvent,
+			addr1:      someContract1, // from
+			addr2:      someContract2, // to
+			amount:     thousand,
+			isSacEvent: false,
+			hasV4Memo:  true,
+			memoType:   "hash",
+			memoValue:  []byte{},
+			validateEvent: func(t *testing.T, event *TokenTransferEvent) {
+				assert.NotNil(t, event.GetTransfer())
+				assert.Equal(t, thousandStr, event.GetTransfer().Amount)
+				require.NotNil(t, event.Meta.ToMuxedInfo)
+				assert.Empty(t, event.Meta.ToMuxedInfo.GetHash())
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #5984.

## The bug

`parseV4MapDataForTokenEvents` copied a `to_muxed_id` of type `ScvBytes` into a fixed 32-byte buffer:

```go
hashBytes := make([]byte, 32)
copy(hashBytes, val)
```

`copy` moves `min(32, len(val))` bytes, so a value shorter than 32 was right-padded with zeroes and a longer one truncated to its first 32. Either way the emitted event reported a muxed id the contract never sent, silently — and a consumer cannot distinguish a genuine 32-byte value from a 4-byte one zero-extended into the same shape.

## Where it came from

The same three lines appear in `NewMuxedInfoFromMemo` (`muxed_info.go`), where the source is `*m.Hash` — an `xdr.Hash`, i.e. `[32]byte`. There the fixed size is exact and the copy is just a safe array-to-slice conversion.

Here the source is an `xdr.ScBytes`, which is `[]byte` and unbounded, so the identical code silently coerces. The 32 was inherited from the classic path, not from the data model: `MuxedInfo_Hash.Hash` is a `[]byte`, so nothing downstream requires a fixed width.

## The fix

Allocate `len(val)` instead of `32`, keeping the defensive copy so nothing aliases the event's XDR buffer.

Per CAP-0067, only classic-derived events map `to_muxed_id` to bytes, and there it is a 32-byte `MEMO_HASH`/`MEMO_RETURN`. A custom SEP-41 contract may put any byte string in that field, so the parser now reports what was emitted and leaves any length policy to the consumer.

The issue floated ignoring such events instead. That trades silent corruption for silent loss: callers discard an event whose parse fails rather than surfacing an error (`token_transfer_processor.go`), so rejecting would drop the transfer's amount and both addresses over a field carrying no value.

## Tests

Three cases added to `TestValidContractEventsV4` — shorter than 32, longer than 32, and empty. Each was confirmed to fail against the unfixed parser:

```
--- FAIL: TestValidContractEventsV4/..._Hash_Memo_Shorter_Than_32_Bytes
--- FAIL: TestValidContractEventsV4/..._Hash_Memo_Longer_Than_32_Bytes
--- FAIL: TestValidContractEventsV4/..._Empty_Hash_Memo
        Should be empty, but was [0 0 0 0 ... 0]
```

The existing hash-memo case uses exactly 32 bytes, so neither branch was previously covered.

`processors/token_transfer` passes; `gofmt` clean, `go vet` clean under the flags `govet.sh` uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
