### PR TITLE
protocols/rpc: delete EventInfo.InSuccessfulContractCall

### DIFF
--- a/protocols/rpc/get_events.go
+++ b/protocols/rpc/get_events.go
@@ -32,9 +32,6 @@ type EventInfo struct {
 	TxIndex         uint32 `json:"transactionIndex"`
 	TransactionHash string `json:"txHash"`
 
-	// Deprecated: remove in v24
-	InSuccessfulContractCall bool `json:"inSuccessfulContractCall"`
-
 	// TopicXDR is a base64-encoded list of ScVals
 	TopicXDR  []string          `json:"topic,omitempty"`
 	TopicJSON []json.RawMessage `json:"topicJson,omitempty"`


### PR DESCRIPTION
Deletes `EventInfo.InSuccessfulContractCall`.

The field has carried `// Deprecated: remove in v24` since protocol 23. The full-history RPC's `getEvents` is launching without it, and because `EventInfo` is the shared response type, dropping the field here drops it from the existing service's responses in the same step rather than leaving one service serving it and the other not.

The value was derivable from the event's position anyway: `true` for every operation event, and `false` only on the fee and refund events of failed transactions.

Consumer side: stellar-rpc removes the assignment in `internal/methods/get_events.go` and its test expectations in the change that bumps the pin to this commit, so there is no window where the field marshals as a hard-coded `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
